### PR TITLE
feat(session): persist sessions and add /resume, /sessions slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # phi
 
-Agent harness for coding work. Interactive sessions persist under `~/.phi/session/` as JSONL; resume with `/resume <id>` (list with `/sessions`).
+Agent harness for coding work. Sessions persist under `~/.phi/session/<encoded-cwd>/` (per project directory). List with `/sessions`, resume with `/resume <id>`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # phi
+
+Agent harness for coding work. Interactive sessions persist under `~/.phi/session/` as JSONL; resume with `/resume <id>` (list with `/sessions`).

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -29,8 +29,19 @@ type Engine struct {
 	session *Session
 }
 
-// NewEngine wires an LLM client and tool executor.
-func NewEngine(cfg llm.ModelConfig) *Engine {
+// EngineOpts configures NewEngine.
+type EngineOpts struct {
+	Model       llm.ModelConfig
+	SessionOpts SessionOpts
+}
+
+// NewEngine wires an LLM client, tool executor, and session store.
+func NewEngine(opts EngineOpts) (*Engine, error) {
+	sess, err := NewSession(opts.SessionOpts)
+	if err != nil {
+		return nil, err
+	}
+	cfg := opts.Model
 	toolList := tools.DefaultTools()
 	client := llm.NewClient(cfg, tools.Definitions(toolList), Prompt(cfg.SkillPath))
 	return &Engine{
@@ -39,8 +50,61 @@ func NewEngine(cfg llm.ModelConfig) *Engine {
 		maxRounds:     defaultMaxToolRounds,
 		skillPath:     cfg.SkillPath,
 		contextWindow: cfg.ContextWindow,
-		session:       NewSession(),
+		session:       sess,
+	}, nil
+}
+
+// SetModel replaces the LLM client and model-related settings without
+// discarding the session tree.
+func (engine *Engine) SetModel(cfg llm.ModelConfig) error {
+	toolList := tools.DefaultTools()
+	engine.client = llm.NewClient(cfg, tools.Definitions(toolList), Prompt(cfg.SkillPath))
+	engine.executor = NewExecutor(tools.NewRegistry(toolList))
+	engine.skillPath = cfg.SkillPath
+	engine.contextWindow = cfg.ContextWindow
+	return nil
+}
+
+// SessionID returns the durable session id.
+func (engine *Engine) SessionID() string {
+	if engine == nil || engine.session == nil {
+		return ""
 	}
+	return engine.session.ID()
+}
+
+// SessionFile returns the JSONL path (empty in memory mode).
+func (engine *Engine) SessionFile() string {
+	if engine == nil || engine.session == nil {
+		return ""
+	}
+	return engine.session.File()
+}
+
+// SessionCwd returns the cwd recorded on the session header.
+func (engine *Engine) SessionCwd() string {
+	if engine == nil || engine.session == nil {
+		return ""
+	}
+	return engine.session.Cwd()
+}
+
+// ReplaceSession swaps the session store (used by /resume).
+func (engine *Engine) ReplaceSession(opts SessionOpts) error {
+	sess, err := NewSession(opts)
+	if err != nil {
+		return err
+	}
+	engine.session = sess
+	return nil
+}
+
+// Session returns the underlying session wrapper (for UI transcript replay).
+func (engine *Engine) Session() *Session {
+	if engine == nil {
+		return nil
+	}
+	return engine.session
 }
 
 // LoopOpts configures a single agent loop turn.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pulseaiclub/phi/internal/llm"
@@ -17,9 +18,81 @@ type Session struct {
 	contextCacheValid bool
 }
 
-// NewSession creates an in-memory session manager wrapper.
-func NewSession() *Session {
-	return &Session{manager: session.NewManager()}
+// SessionOpts configures how the engine binds a session store.
+type SessionOpts struct {
+	Cwd        string // written to SessionHeader.Cwd; usually process cwd
+	SessionDir string // ~/.phi/session; required when Persist is true
+	Persist    bool   // false → in-memory (tests default)
+	ResumePath string // open this jsonl; ignores "new session"
+	ResumeID   string // resolve under SessionDir (mutually exclusive with ResumePath)
+	ParentID   string // reserved for sub-agents; passed to WithParent
+}
+
+// NewSession creates a session wrapper according to opts.
+func NewSession(opts SessionOpts) (*Session, error) {
+	if opts.ResumePath != "" && opts.ResumeID != "" {
+		return nil, fmt.Errorf("agent: ResumePath and ResumeID are mutually exclusive")
+	}
+
+	if opts.ResumePath != "" || opts.ResumeID != "" {
+		path := opts.ResumePath
+		if path == "" {
+			if opts.SessionDir == "" {
+				return nil, fmt.Errorf("agent: SessionDir required to resume by id")
+			}
+			var err error
+			path, err = session.FindSessionFile(opts.SessionDir, opts.ResumeID)
+			if err != nil {
+				return nil, err
+			}
+		}
+		m, err := session.OpenSession(path)
+		if err != nil {
+			return nil, err
+		}
+		return &Session{manager: m, lastID: m.LeafID()}, nil
+	}
+
+	if opts.Persist {
+		if opts.SessionDir == "" {
+			return nil, fmt.Errorf("agent: SessionDir required when Persist is true")
+		}
+		m, err := session.NewSessionManager(opts.Cwd,
+			session.WithSessionDir(opts.SessionDir),
+			session.WithShouldFlush(true),
+			session.WithParent(opts.ParentID),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return &Session{manager: m}, nil
+	}
+
+	return &Session{manager: session.NewManager(opts.Cwd)}, nil
+}
+
+// ID returns the durable session id (empty only if manager missing).
+func (s *Session) ID() string {
+	if s == nil || s.manager == nil {
+		return ""
+	}
+	return s.manager.ID()
+}
+
+// File returns the JSONL path, or empty in memory mode / before first flush path assignment.
+func (s *Session) File() string {
+	if s == nil || s.manager == nil {
+		return ""
+	}
+	return s.manager.File()
+}
+
+// Cwd returns the session header cwd.
+func (s *Session) Cwd() string {
+	if s == nil || s.manager == nil {
+		return ""
+	}
+	return s.manager.Cwd()
 }
 
 func (s *Session) invalidateContextCache() {

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionPersistFlush(t *testing.T) {
+	dir := t.TempDir()
+	sess, err := NewSession(SessionOpts{
+		Cwd:        dir,
+		SessionDir: dir,
+		Persist:    true,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, sess.ID())
+	assert.NotEmpty(t, sess.File())
+
+	require.NoError(t, sess.Append(llm.Message{Role: llm.RoleUser, Content: "hi"}))
+	_, err = os.Stat(sess.File())
+	assert.True(t, os.IsNotExist(err), "should not flush before first assistant")
+
+	require.NoError(t, sess.Append(llm.Message{Role: llm.RoleAssistant, Content: "hello"}))
+	require.FileExists(t, sess.File())
+
+	b, err := os.ReadFile(sess.File())
+	require.NoError(t, err)
+	var header struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+	}
+	first := splitFirstJSONL(b)
+	require.NoError(t, json.Unmarshal(first, &header))
+	assert.Equal(t, "EntrySession", header.Type)
+	assert.Equal(t, sess.ID(), header.ID)
+}
+
+func TestSessionPersistFalseNoDisk(t *testing.T) {
+	sess, err := NewSession(SessionOpts{Persist: false, Cwd: t.TempDir()})
+	require.NoError(t, err)
+	assert.Empty(t, sess.File())
+	require.NoError(t, sess.Append(llm.Message{Role: llm.RoleUser, Content: "a"}))
+	require.NoError(t, sess.Append(llm.Message{Role: llm.RoleAssistant, Content: "b"}))
+	assert.Empty(t, sess.File())
+}
+
+func TestEngineSetModelKeepsSession(t *testing.T) {
+	dir := t.TempDir()
+	eng, err := NewEngine(EngineOpts{
+		Model: llm.ModelConfig{Name: "model-a", APIKey: "k", BaseURL: "http://example"},
+		SessionOpts: SessionOpts{
+			Cwd:        dir,
+			SessionDir: dir,
+			Persist:    true,
+		},
+	})
+	require.NoError(t, err)
+
+	id := eng.SessionID()
+	file := eng.SessionFile()
+	require.NotEmpty(t, id)
+	require.NotEmpty(t, file)
+
+	require.NoError(t, eng.session.Append(llm.Message{Role: llm.RoleUser, Content: "keep me"}))
+	require.NoError(t, eng.session.Append(llm.Message{Role: llm.RoleAssistant, Content: "ok"}))
+	n := eng.session.Len()
+
+	require.NoError(t, eng.SetModel(llm.ModelConfig{
+		Name:          "model-b",
+		APIKey:        "k",
+		BaseURL:       "http://example",
+		ContextWindow: 8192,
+		SkillPath:     dir,
+	}))
+	assert.Equal(t, id, eng.SessionID())
+	assert.Equal(t, file, eng.SessionFile())
+	assert.Equal(t, n, eng.session.Len())
+	assert.Equal(t, 8192, eng.contextWindow)
+	assert.Equal(t, dir, eng.skillPath)
+}
+
+func splitFirstJSONL(b []byte) []byte {
+	for i, c := range b {
+		if c == '\n' {
+			return b[:i]
+		}
+	}
+	return b
+}

--- a/internal/components/chat/chat_input.go
+++ b/internal/components/chat/chat_input.go
@@ -57,14 +57,23 @@ type ChatInput struct {
 	// OnMentionChange is called after Value or Cursor changes that may
 	// activate/deactivate an @-file mention. active is false when none.
 	OnMentionChange func(active bool, query string)
+	// OnSlashChange is called after Value or Cursor changes that may
+	// activate/deactivate a leading /command. active is false when none.
+	OnSlashChange func(active bool, query string)
 
 	// MentionOpen is set by the editor while the @-file picker is visible.
 	// When true, Up/Down/Tab/Enter are left unconsumed so the picker can
 	// handle navigation (focus stays on the composer for typing).
 	MentionOpen bool
+	// SlashOpen is set while the /command picker is visible (same nav deferral).
+	SlashOpen bool
 
 	// dumpNextDraw is set on paste/insert when PHI_DEBUG=1.
 	dumpNextDraw bool
+}
+
+func (c *ChatInput) completerOpen() bool {
+	return c.MentionOpen || c.SlashOpen
 }
 
 func (c *ChatInput) bodyRows(width int, method xui.WidthMethod) int {
@@ -175,8 +184,8 @@ func (c *ChatInput) Handle(ctx *components.EventContext, ev xui.Event) {
 		c.clampCursor()
 		switch e.Code {
 		case xui.KeyEnter:
-			if c.MentionOpen {
-				// Let the @-file picker accept / consume Enter.
+			if c.completerOpen() {
+				// Let the @-file / slash picker accept / consume Enter.
 				return
 			}
 			// Shift+Enter / Alt+Enter insert newline; bare Enter submits.
@@ -224,7 +233,7 @@ func (c *ChatInput) Handle(ctx *components.EventContext, ev xui.Event) {
 				_, size := utf8.DecodeLastRuneInString(c.Value[:c.Cursor])
 				c.Cursor -= size
 			}
-			c.notifyMention()
+			c.notifyCompleters()
 			ctx.ConsumeAndRedraw()
 			return
 		case xui.KeyRight:
@@ -232,37 +241,37 @@ func (c *ChatInput) Handle(ctx *components.EventContext, ev xui.Event) {
 				_, size := utf8.DecodeRuneInString(c.Value[c.Cursor:])
 				c.Cursor += size
 			}
-			c.notifyMention()
+			c.notifyCompleters()
 			ctx.ConsumeAndRedraw()
 			return
 		case xui.KeyHome:
 			c.Cursor = lineStart(c.Value, c.Cursor)
-			c.notifyMention()
+			c.notifyCompleters()
 			ctx.ConsumeAndRedraw()
 			return
 		case xui.KeyEnd:
 			c.Cursor = lineEnd(c.Value, c.Cursor)
-			c.notifyMention()
+			c.notifyCompleters()
 			ctx.ConsumeAndRedraw()
 			return
 		case xui.KeyUp:
-			if c.MentionOpen {
+			if c.completerOpen() {
 				return
 			}
 			c.moveVert(-1)
-			c.notifyMention()
+			c.notifyCompleters()
 			ctx.ConsumeAndRedraw()
 			return
 		case xui.KeyDown:
-			if c.MentionOpen {
+			if c.completerOpen() {
 				return
 			}
 			c.moveVert(1)
-			c.notifyMention()
+			c.notifyCompleters()
 			ctx.ConsumeAndRedraw()
 			return
 		case xui.KeyTab:
-			if c.MentionOpen {
+			if c.completerOpen() {
 				return
 			}
 			return
@@ -352,7 +361,12 @@ func (c *ChatInput) notifyChange() {
 	if c.OnChange != nil {
 		c.OnChange(c.Value)
 	}
+	c.notifyCompleters()
+}
+
+func (c *ChatInput) notifyCompleters() {
 	c.notifyMention()
+	c.notifySlash()
 }
 
 func (c *ChatInput) notifyMention() {
@@ -361,6 +375,14 @@ func (c *ChatInput) notifyMention() {
 	}
 	q, _, _, ok := ActiveMention(c.Value, c.Cursor)
 	c.OnMentionChange(ok, q)
+}
+
+func (c *ChatInput) notifySlash() {
+	if c.OnSlashChange == nil {
+		return
+	}
+	q, _, _, ok := ActiveSlash(c.Value, c.Cursor)
+	c.OnSlashChange(ok, q)
 }
 
 // ReplaceRange replaces value[start:end] with text and places the cursor after it.

--- a/internal/components/chat/slash.go
+++ b/internal/components/chat/slash.go
@@ -1,0 +1,33 @@
+package chat
+
+import "strings"
+
+// ActiveSlash reports whether the cursor sits in a leading `/command` token.
+// Only the first token of the composer value participates (slash commands are
+// whole-line). query is the text after '/' up to the cursor.
+// start/end are byte offsets to replace on accept (from '/' through cursor).
+func ActiveSlash(value string, cursor int) (query string, start, end int, ok bool) {
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor > len(value) {
+		cursor = len(value)
+	}
+	if !strings.HasPrefix(value, "/") {
+		return "", 0, 0, false
+	}
+	if cursor < 1 {
+		return "", 0, 0, false
+	}
+	// First whitespace ends the command token; picker only while editing it.
+	for i := 1; i < len(value); i++ {
+		c := value[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			if cursor > i {
+				return "", 0, 0, false
+			}
+			break
+		}
+	}
+	return value[1:cursor], 0, cursor, true
+}

--- a/internal/components/chat/slash_test.go
+++ b/internal/components/chat/slash_test.go
@@ -1,0 +1,47 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestActiveSlash(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		cursor int
+		ok     bool
+		query  string
+	}{
+		{"empty", "", 0, false, ""},
+		{"slash alone", "/", 1, true, ""},
+		{"prefix", "/resu", 5, true, "resu"},
+		{"mid prefix", "/resume", 4, true, "res"},
+		{"cursor at start", "/sessions", 0, false, ""},
+		{"after space arg", "/resume abc", 11, false, ""},
+		{"in cmd before space", "/resume abc", 7, true, "resume"},
+		{"not at start", "hi /sessions", 12, false, ""},
+		{"plain text", "hello", 5, false, ""},
+		{"at mention", "@file", 5, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, start, end, ok := ActiveSlash(tt.value, tt.cursor)
+			if ok != tt.ok {
+				t.Fatalf("ok=%v want %v", ok, tt.ok)
+			}
+			if !ok {
+				return
+			}
+			if q != tt.query {
+				t.Fatalf("query=%q want %q", q, tt.query)
+			}
+			if start != 0 || end != tt.cursor {
+				t.Fatalf("range=[%d,%d) want [0,%d)", start, end, tt.cursor)
+			}
+			if !strings.HasPrefix(tt.value, "/") {
+				t.Fatal("expected slash prefix")
+			}
+		})
+	}
+}

--- a/internal/components/mention/picker.go
+++ b/internal/components/mention/picker.go
@@ -7,12 +7,13 @@ import (
 	"github.com/pulseaiclub/xui"
 )
 
-// Item is one row in the mention picker.
+// Item is one row in the mention / slash picker.
 type Item struct {
-	Path string // relative workspace path (slash-separated)
+	Path        string // primary label without Prefix (file path or command name)
+	Description string // optional secondary hint shown after the label
 }
 
-// Picker is a floating file list anchored above the composer.
+// Picker is a floating list anchored above the composer.
 // Query lives in the composer; this widget only navigates and accepts.
 type Picker struct {
 	Open     bool
@@ -22,6 +23,8 @@ type Picker struct {
 	Theme    components.Theme
 	MaxItems int // visible rows; default 12
 	Width    int // panel width; 0 = fill anchor
+	// Prefix is drawn before Path (default "@"). Use "/" for slash commands.
+	Prefix   string
 	OnAccept func(Item)
 	OnCancel func()
 
@@ -82,11 +85,17 @@ func (p *Picker) clampSelected() {
 }
 
 // Accept selects the current item (if any) and closes.
+// With no items, it still closes so Enter does not leave a stuck overlay.
 func (p *Picker) Accept() bool {
-	if !p.Open || len(p.Items) == 0 {
+	if !p.Open {
+		return false
+	}
+	if len(p.Items) == 0 {
+		p.Hide()
 		return false
 	}
 	if p.Selected < 0 || p.Selected >= len(p.Items) {
+		p.Hide()
 		return false
 	}
 	item := p.Items[p.Selected]
@@ -262,14 +271,19 @@ func (p *Picker) Draw(ctx components.DrawContext) components.Surface {
 
 	padL := 1
 	listY := 1
+	prefix := p.Prefix
+	if prefix == "" {
+		prefix = "@"
+	}
 	if nItems == 0 {
 		msg := p.Status
 		if msg == "" {
-			msg = "No matching files"
+			msg = "No matches"
 		}
 		panel.Print(padL+1, listY, layout.TruncateToWidth(msg, boxW-3, ctx.Method), th.Muted, ctx.Method)
 	} else {
 		pathSt := th.ToolName
+		descSt := th.Muted
 		for row := 0; row < visible; row++ {
 			fi := row + scroll
 			if fi < 0 || fi >= nItems {
@@ -278,15 +292,32 @@ func (p *Picker) Draw(ctx components.DrawContext) components.Surface {
 			item := p.Items[fi]
 			sel := fi == p.Selected
 			y := listY + row
-			label := "@" + item.Path
+			label := prefix + item.Path
 			st := pathSt
+			dst := descSt
 			if sel {
 				for x := 1; x < boxW-1; x++ {
 					panel.SetCell(x, y, xui.Cell{Char: " ", Width: 1, Style: xui.Style{Bg: selBg}})
 				}
 				st = xui.Style{Fg: xui.RGBColor(0xe0, 0xf0, 0xff), Bg: selBg, Bold: true}
+				dst = xui.Style{Fg: xui.RGBColor(0xb0, 0xc8, 0xe0), Bg: selBg}
 			}
-			panel.Print(padL+1, y, layout.TruncateToWidth(label, boxW-3, ctx.Method), st, ctx.Method)
+			innerW := boxW - 3
+			if item.Description == "" {
+				panel.Print(padL+1, y, layout.TruncateToWidth(label, innerW, ctx.Method), st, ctx.Method)
+				continue
+			}
+			gap := "  "
+			labelW := xui.StringWidth(label, ctx.Method)
+			gapW := xui.StringWidth(gap, ctx.Method)
+			descBudget := innerW - labelW - gapW
+			if descBudget < 8 {
+				panel.Print(padL+1, y, layout.TruncateToWidth(label, innerW, ctx.Method), st, ctx.Method)
+				continue
+			}
+			panel.Print(padL+1, y, label, st, ctx.Method)
+			panel.Print(padL+1+labelW, y, gap, dst, ctx.Method)
+			panel.Print(padL+1+labelW+gapW, y, layout.TruncateToWidth(item.Description, descBudget, ctx.Method), dst, ctx.Method)
 		}
 	}
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -24,6 +24,12 @@ func (g GlobalLayout) BinDir() string      { return filepath.Join(g.root, "bin")
 func (g GlobalLayout) SkillsDir() string   { return filepath.Join(g.root, "skills") }
 func (g GlobalLayout) SessionBase() string { return filepath.Join(g.root, "session") }
 
+// SessionDir returns the per-cwd session storage directory
+// (~/.phi/session/<encoded-cwd>/), matching panda / pi layout.
+func (p *Project) SessionDir() string {
+	return ProjectSessionDir(p.global.SessionBase(), p.root)
+}
+
 // Project is the resolved phi workspace: the current working directory plus
 // the global layout and its loaded configuration.
 type Project struct {
@@ -78,9 +84,13 @@ func Discover(startDir string) (*Project, error) {
 	if err != nil {
 		return nil, err
 	}
+	absRoot, err := filepath.Abs(startDir)
+	if err != nil {
+		return nil, err
+	}
 	global := GlobalLayout{root: filepath.Join(home, ".phi")}
 	if err := ensureGlobalDirs(global); err != nil {
 		return nil, err
 	}
-	return &Project{root: startDir, global: global}, nil
+	return &Project{root: absRoot, global: global}, nil
 }

--- a/internal/project/session_dir.go
+++ b/internal/project/session_dir.go
@@ -1,0 +1,41 @@
+package project
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// ProjectDirName returns a filesystem-safe directory name derived from cwd,
+// matching panda / pi coding-agent:
+//
+//	--<cwd with leading path sep stripped and / \ : replaced by ->--
+func ProjectDirName(cwd string) string {
+	s := filepath.Clean(cwd)
+	if s == "." {
+		return "--unknown--"
+	}
+	if len(s) > 0 && (s[0] == '/' || s[0] == '\\') {
+		s = s[1:]
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+	for _, r := range s {
+		switch r {
+		case '/', '\\', ':':
+			b.WriteByte('-')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	if out == "" {
+		out = "unknown"
+	}
+	return "--" + out + "--"
+}
+
+// ProjectSessionDir is where jsonl session files for cwd live under baseDir
+// (e.g. ~/.phi/session/--Users-me-proj--/).
+func ProjectSessionDir(baseDir, cwd string) string {
+	return filepath.Join(baseDir, ProjectDirName(cwd))
+}

--- a/internal/project/session_dir_test.go
+++ b/internal/project/session_dir_test.go
@@ -1,0 +1,42 @@
+package project
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectDirName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		cwd  string
+		want string
+	}{
+		{"/Users/foo/bar", "--Users-foo-bar--"},
+		{"relative/proj", "--relative-proj--"},
+		{".", "--unknown--"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cwd, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ProjectDirName(tt.cwd))
+		})
+	}
+}
+
+func TestProjectSessionDir(t *testing.T) {
+	t.Parallel()
+	base := "/tmp/phi-sessions"
+	cwd := "/home/dev/app"
+	got := ProjectSessionDir(base, cwd)
+	assert.Equal(t, filepath.Join(base, "--home-dev-app--"), got)
+}
+
+func TestProjectSessionDirMethod(t *testing.T) {
+	p := &Project{
+		root:   "/Users/foo/Phi",
+		global: GlobalLayout{root: "/tmp/.phi"},
+	}
+	assert.Equal(t, filepath.Join("/tmp/.phi/session", "--Users-foo-Phi--"), p.SessionDir())
+}

--- a/internal/session/load.go
+++ b/internal/session/load.go
@@ -1,0 +1,321 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pulseaiclub/phi/internal/llm"
+)
+
+// SessionMeta is a lightweight listing row for persisted sessions.
+type SessionMeta struct {
+	ID        string
+	File      string
+	Timestamp string
+	Cwd       string
+	Mtime     time.Time
+	Preview   string // truncated last user text
+}
+
+// ListSessions returns session files under dir, newest mtime first.
+func ListSessions(dir string) ([]SessionMeta, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]SessionMeta, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		meta, err := readSessionMeta(path, e)
+		if err != nil {
+			continue // skip unreadable / malformed files in listings
+		}
+		out = append(out, meta)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Mtime.After(out[j].Mtime)
+	})
+	return out, nil
+}
+
+func readSessionMeta(path string, e os.DirEntry) (SessionMeta, error) {
+	info, err := e.Info()
+	if err != nil {
+		return SessionMeta{}, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return SessionMeta{}, err
+	}
+	defer f.Close()
+
+	meta := SessionMeta{
+		File:  path,
+		Mtime: info.ModTime(),
+	}
+	sc := bufio.NewScanner(f)
+	// Session files can grow; allow large lines for tool payloads.
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := sc.Bytes()
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+		entry, err := decodeEntryLine(line, lineNo)
+		if err != nil {
+			if meta.ID == "" {
+				return SessionMeta{}, err
+			}
+			break
+		}
+		switch e := entry.(type) {
+		case SessionHeader:
+			meta.ID = e.ID
+			meta.Timestamp = e.Timestamp
+			meta.Cwd = e.Cwd
+		case SessionMessageEntry:
+			if e.Message.Role == llm.RoleUser && strings.TrimSpace(e.Message.Content) != "" {
+				meta.Preview = truncatePreview(e.Message.Content, 72)
+			}
+		}
+	}
+	if meta.ID == "" {
+		// Fall back to filename id when header missing.
+		if id, ok := sessionIDFromFilename(filepath.Base(path)); ok {
+			meta.ID = id
+		} else {
+			return SessionMeta{}, fmt.Errorf("session: no header in %s", path)
+		}
+	}
+	return meta, nil
+}
+
+func truncatePreview(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// FindSessionFile resolves id to a unique jsonl path under dir.
+// id may be exact or a unique prefix of the session id.
+func FindSessionFile(dir, id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("session: empty id")
+	}
+	if filepath.IsAbs(id) || strings.HasSuffix(id, ".jsonl") {
+		if _, err := os.Stat(id); err != nil {
+			return "", fmt.Errorf("session: file %q: %w", id, err)
+		}
+		return id, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+
+	var exact, prefix []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		sid, ok := sessionIDFromFilename(e.Name())
+		if !ok {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		if sid == id {
+			exact = append(exact, path)
+		} else if strings.HasPrefix(sid, id) {
+			prefix = append(prefix, path)
+		}
+	}
+	if len(exact) == 1 {
+		return exact[0], nil
+	}
+	if len(exact) > 1 {
+		return "", fmt.Errorf("session: ambiguous id %q (%d matches)", id, len(exact))
+	}
+	if len(prefix) == 1 {
+		return prefix[0], nil
+	}
+	if len(prefix) > 1 {
+		return "", fmt.Errorf("session: ambiguous id prefix %q (%d matches)", id, len(prefix))
+	}
+	return "", fmt.Errorf("session: id %q not found in %s", id, dir)
+}
+
+func sessionIDFromFilename(name string) (string, bool) {
+	base := strings.TrimSuffix(name, ".jsonl")
+	i := strings.IndexByte(base, '_')
+	if i < 0 || i+1 >= len(base) {
+		return "", false
+	}
+	return base[i+1:], true
+}
+
+// OpenSession loads a JSONL session file and returns a Manager ready to append.
+func OpenSession(path string) (*Manager, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+
+	var (
+		entries         []MessageEntry
+		byIDs           = make(map[string]MessageEntry, 64)
+		header          *SessionHeader
+		leafID          *string
+		hasAssistantMsg bool
+		lineNo          int
+	)
+
+	for sc.Scan() {
+		lineNo++
+		raw := sc.Bytes()
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			continue
+		}
+		entry, err := decodeEntryLine(raw, lineNo)
+		if err != nil {
+			return nil, err
+		}
+		switch e := entry.(type) {
+		case SessionHeader:
+			if header != nil {
+				return nil, fmt.Errorf("session: duplicate header at %s:%d", path, lineNo)
+			}
+			h := e
+			header = &h
+			entries = append(entries, h)
+		default:
+			if header == nil {
+				return nil, fmt.Errorf("session: first entry must be session header at %s:%d", path, lineNo)
+			}
+			id := entry.GetID()
+			byIDs[id] = entry
+			entries = append(entries, entry)
+			leafID = &id
+			if msg, ok := entry.(SessionMessageEntry); ok && msg.Message.Role == llm.RoleAssistant {
+				hasAssistantMsg = true
+			}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("session: read %s: %w", path, err)
+	}
+	if header == nil {
+		return nil, fmt.Errorf("session: missing header in %s", path)
+	}
+
+	parent := header.ParentSession
+	return &Manager{
+		cwd:         header.Cwd,
+		entries:     entries,
+		byIDs:       byIDs,
+		sessionFile: path,
+		leafID:      leafID,
+		shouldFlush: true,
+		flushed:     true,
+		sessionID:   header.ID,
+		config: ManagerConfig{
+			sessionDir:  filepath.Dir(path),
+			shouldFlush: true,
+			parentID:    parent,
+		},
+		hasAssistantMsg: hasAssistantMsg,
+	}, nil
+}
+
+func decodeEntryLine(raw []byte, lineNo int) (MessageEntry, error) {
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return nil, fmt.Errorf("session: line %d: %w", lineNo, err)
+	}
+	switch probe.Type {
+	case EntrySession, "session":
+		var h SessionHeader
+		if err := json.Unmarshal(raw, &h); err != nil {
+			return nil, fmt.Errorf("session: line %d header: %w", lineNo, err)
+		}
+		h.Type = EntrySession
+		return h, nil
+	case EntryMessage:
+		var m SessionMessageEntry
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, fmt.Errorf("session: line %d message: %w", lineNo, err)
+		}
+		return m, nil
+	case EntryCompaction:
+		var c CompactionEntry
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, fmt.Errorf("session: line %d compaction: %w", lineNo, err)
+		}
+		return c, nil
+	case EntryBranchSummary, "branch_summary":
+		var b BranchSummaryEntry
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return nil, fmt.Errorf("session: line %d branch_summary: %w", lineNo, err)
+		}
+		return b, nil
+	default:
+		return nil, fmt.Errorf("session: line %d: unknown type %q", lineNo, probe.Type)
+	}
+}
+
+// ID returns the session identifier from the header.
+func (sm *Manager) ID() string {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.sessionID
+}
+
+// File returns the JSONL path, or empty when not persisting.
+func (sm *Manager) File() string {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.sessionFile
+}
+
+// Cwd returns the session working directory recorded in the header.
+func (sm *Manager) Cwd() string {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.cwd
+}
+
+// LeafID returns the current leaf entry id, or empty if none.
+func (sm *Manager) LeafID() string {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if sm.leafID == nil {
+		return ""
+	}
+	return *sm.leafID
+}

--- a/internal/session/load.go
+++ b/internal/session/load.go
@@ -24,6 +24,8 @@ type SessionMeta struct {
 }
 
 // ListSessions returns session files under dir, newest mtime first.
+// Callers should pass a per-cwd directory (e.g. project.SessionDir()), not the
+// global session base, so listings stay scoped to the current project.
 func ListSessions(dir string) ([]SessionMeta, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/internal/session/load_test.go
+++ b/internal/session/load_test.go
@@ -1,0 +1,172 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionPersistRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewSessionManager(dir, WithSessionDir(dir), WithShouldFlush(true))
+	require.NoError(t, err)
+
+	_, err = m.Append(llm.Message{Role: llm.RoleUser, Content: "read foo.go"})
+	require.NoError(t, err)
+	_, err = m.Append(llm.Message{Role: llm.RoleAssistant, Content: "done reading"})
+	require.NoError(t, err)
+
+	path := m.File()
+	require.FileExists(t, path)
+
+	loaded, err := OpenSession(path)
+	require.NoError(t, err)
+	assert.Equal(t, m.ID(), loaded.ID())
+	assert.Equal(t, path, loaded.File())
+	assert.Equal(t, dir, loaded.Cwd())
+
+	orig := messageContents(m.BuildContext())
+	got := messageContents(loaded.BuildContext())
+	assert.Equal(t, orig, got)
+
+	// Append continues on the same file.
+	_, err = loaded.Append(llm.Message{Role: llm.RoleUser, Content: "continue"})
+	require.NoError(t, err)
+	_, err = loaded.Append(llm.Message{Role: llm.RoleAssistant, Content: "ok"})
+	require.NoError(t, err)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+
+	reloaded, err := OpenSession(path)
+	require.NoError(t, err)
+	assert.Equal(t, messageContents(loaded.BuildContext()), messageContents(reloaded.BuildContext()))
+}
+
+func TestSessionPersistCompaction(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewSessionManager(dir, WithSessionDir(dir), WithShouldFlush(true))
+	require.NoError(t, err)
+
+	_, err = m.Append(llm.Message{Role: llm.RoleUser, Content: "old"})
+	require.NoError(t, err)
+	keptID, err := m.Append(llm.Message{Role: llm.RoleAssistant, Content: "kept"})
+	require.NoError(t, err)
+	_, err = m.AppendCompaction(Compaction{
+		Summary:          "conversation summary",
+		FirstKeptEntryID: keptID,
+	})
+	require.NoError(t, err)
+	_, err = m.Append(llm.Message{Role: llm.RoleUser, Content: "after"})
+	require.NoError(t, err)
+
+	loaded, err := OpenSession(m.File())
+	require.NoError(t, err)
+
+	ctx := loaded.BuildContext()
+	require.GreaterOrEqual(t, len(ctx), 2)
+	assert.Equal(t, EntryCompaction, ctx[0].GetType())
+	ce := ctx[0].(CompactionEntry)
+	assert.Equal(t, "conversation summary", ce.Compaction.Summary)
+
+	got := messageContents(ctx)
+	want := messageContents(m.BuildContext())
+	assert.Equal(t, want, got)
+}
+
+func TestFindSessionFilePrefix(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(id string) string {
+		name := "2026-01-01T00-00-00_" + id + ".jsonl"
+		path := filepath.Join(dir, name)
+		header := SessionHeader{
+			Type:      EntrySession,
+			ID:        id,
+			Timestamp: "2026-01-01T00-00-00",
+			Cwd:       dir,
+		}
+		f, err := os.Create(path)
+		require.NoError(t, err)
+		require.NoError(t, jsonEncode(f, header))
+		require.NoError(t, f.Close())
+		return path
+	}
+
+	p1 := write("abcdef1234567890")
+	_ = write("abcdef9999999999")
+	p3 := write("deadbeef00001111")
+
+	got, err := FindSessionFile(dir, "deadbeef00001111")
+	require.NoError(t, err)
+	assert.Equal(t, p3, got)
+
+	got, err = FindSessionFile(dir, "deadbeef")
+	require.NoError(t, err)
+	assert.Equal(t, p3, got)
+
+	_, err = FindSessionFile(dir, "abcdef")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+
+	got, err = FindSessionFile(dir, "abcdef1234567890")
+	require.NoError(t, err)
+	assert.Equal(t, p1, got)
+
+	_, err = FindSessionFile(dir, "nope")
+	require.Error(t, err)
+}
+
+func TestListSessions(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewSessionManager(dir, WithSessionDir(dir), WithShouldFlush(true))
+	require.NoError(t, err)
+	_, err = m.Append(llm.Message{Role: llm.RoleUser, Content: "list me please"})
+	require.NoError(t, err)
+	_, err = m.Append(llm.Message{Role: llm.RoleAssistant, Content: "ok"})
+	require.NoError(t, err)
+
+	list, err := ListSessions(dir)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, m.ID(), list[0].ID)
+	assert.Equal(t, "list me please", list[0].Preview)
+	assert.Equal(t, dir, list[0].Cwd)
+}
+
+func TestOpenSessionFailFastBadLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "2026-01-01T00-00-00_badbadbadbadbadb.jsonl")
+	content := `{"type":"EntrySession","id":"badbadbadbadbadb","timestamp":"t","cwd":"/tmp"}
+{not-json}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	_, err := OpenSession(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 2")
+}
+
+func messageContents(entries []MessageEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		switch v := e.(type) {
+		case CompactionEntry:
+			out = append(out, "compaction:"+v.Compaction.Summary)
+		case SessionMessageEntry:
+			out = append(out, string(v.Message.Role)+":"+v.Message.Content)
+		default:
+			out = append(out, e.GetType()+":"+e.GetID())
+		}
+	}
+	return out
+}
+
+func jsonEncode(f *os.File, v any) error {
+	return json.NewEncoder(f).Encode(v)
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -110,8 +110,8 @@ func NewSessionManager(sessionPath string, opt ...ManagerOption) (*Manager, erro
 }
 
 // NewManager creates an in-memory session manager (no persistence).
-func NewManager() *Manager {
-	m, err := NewSessionManager("", WithShouldFlush(false))
+func NewManager(sessionDir string) *Manager {
+	m, err := NewSessionManager(sessionDir, WithShouldFlush(false))
 	if err != nil {
 		panic(err) // cannot fail without flush
 	}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -4,22 +4,75 @@ import (
 	"strings"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/mention"
 	"github.com/pulseaiclub/phi/internal/components/palette"
 	"github.com/pulseaiclub/phi/internal/llm/skills"
 )
 
-// PaletteCommands returns sample commands for the tui demo.
-func PaletteCommands(onRun func(msg string)) []palette.PaletteCommand {
-	run := func(msg string) func() {
-		return func() {
-			if onRun != nil {
-				onRun(msg)
-			}
+// SlashCommand is one composer `/` command shown in the slash picker.
+type SlashCommand struct {
+	Name        string // without leading slash, e.g. "resume"
+	Description string
+	// Insert is written into the composer on accept (include trailing space when args follow).
+	Insert string
+}
+
+// SlashCommands is the built-in slash catalog.
+func SlashCommands() []SlashCommand {
+	return []SlashCommand{
+		{
+			Name:        "sessions",
+			Description: "List recent persisted sessions",
+			Insert:      "/sessions",
+		},
+		{
+			Name:        "resume",
+			Description: "Resume a session by id — /resume <id>",
+			Insert:      "/resume ",
+		},
+	}
+}
+
+// FilterSlashCommands returns commands whose name starts with query (case-insensitive).
+func FilterSlashCommands(query string) []mention.Item {
+	q := strings.ToLower(strings.TrimSpace(query))
+	all := SlashCommands()
+	out := make([]mention.Item, 0, len(all))
+	for _, c := range all {
+		if q != "" && !strings.HasPrefix(strings.ToLower(c.Name), q) {
+			continue
+		}
+		out = append(out, mention.Item{
+			Path:        c.Name,
+			Description: c.Description,
+		})
+	}
+	return out
+}
+
+// LookupSlashInsert returns the Insert string for a command name, or empty.
+func LookupSlashInsert(name string) string {
+	name = strings.TrimPrefix(strings.TrimSpace(name), "/")
+	for _, c := range SlashCommands() {
+		if strings.EqualFold(c.Name, name) {
+			return c.Insert
 		}
 	}
+	return ""
+}
 
+// PaletteCommands returns sample commands for the tui demo.
+func PaletteCommands(onModel func(name string)) []palette.PaletteCommand {
 	models := []palette.PaletteCommand{
-		{ID: "model-deepseek-v4-pro", Verb: "deepseek", Run: run("model: Model")},
+		{
+			ID:   "model-deepseek-v4-pro",
+			Verb: "deepseek",
+			Run: func() {
+				if onModel != nil {
+					onModel("deepseek")
+				}
+			},
+		},
 	}
 	return []palette.PaletteCommand{
 		{

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -22,12 +22,12 @@ func SlashCommands() []SlashCommand {
 	return []SlashCommand{
 		{
 			Name:        "sessions",
-			Description: "List recent persisted sessions",
+			Description: "List sessions for this directory",
 			Insert:      "/sessions",
 		},
 		{
 			Name:        "resume",
-			Description: "Resume a session by id — /resume <id>",
+			Description: "Resume a session in this directory — /resume <id>",
 			Insert:      "/resume ",
 		},
 	}

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -51,3 +51,19 @@ func TestSkillsCommand_Empty(t *testing.T) {
 	require.Len(t, cmd.Submenu, 1)
 	assert.True(t, cmd.Submenu[0].Disabled)
 }
+
+func TestFilterSlashCommands(t *testing.T) {
+	all := FilterSlashCommands("")
+	require.Len(t, all, 2)
+
+	resu := FilterSlashCommands("resu")
+	require.Len(t, resu, 1)
+	assert.Equal(t, "resume", resu[0].Path)
+	assert.Contains(t, resu[0].Description, "Resume")
+
+	none := FilterSlashCommands("zzz")
+	assert.Empty(t, none)
+
+	assert.Equal(t, "/resume ", LookupSlashInsert("resume"))
+	assert.Equal(t, "/sessions", LookupSlashInsert("sessions"))
+}

--- a/internal/tui/controller.go
+++ b/internal/tui/controller.go
@@ -36,7 +36,7 @@ func NewController(bus *Bus) *Controller {
 	proj := project.GetDefaultProject()
 	cwd, _ := os.Getwd()
 	c.cwd = cwd
-	c.sessionDir = proj.Global().SessionBase()
+	c.sessionDir = proj.SessionDir()
 
 	if err := proj.LoadConfig(); err != nil {
 		c.engineErr = err

--- a/internal/tui/controller.go
+++ b/internal/tui/controller.go
@@ -3,11 +3,13 @@ package tui
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/pulseaiclub/phi/internal/agent"
+	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/project"
 	"github.com/pulseaiclub/phi/internal/session"
 )
@@ -23,22 +25,41 @@ type Controller struct {
 	streamGen    int
 
 	bus *Bus
+
+	sessionDir string
+	cwd        string
+	modelCfg   llm.ModelConfig
 }
 
 func NewController(bus *Bus) *Controller {
 	c := &Controller{bus: bus}
 	proj := project.GetDefaultProject()
+	cwd, _ := os.Getwd()
+	c.cwd = cwd
+	c.sessionDir = proj.Global().SessionBase()
+
 	if err := proj.LoadConfig(); err != nil {
 		c.engineErr = err
-	} else {
-		c.engine = agent.NewEngine(proj.Config().Model())
+		return c
 	}
+	c.modelCfg = proj.Config().Model()
+	eng, err := agent.NewEngine(agent.EngineOpts{
+		Model: c.modelCfg,
+		SessionOpts: agent.SessionOpts{
+			Cwd:        cwd,
+			SessionDir: c.sessionDir,
+			Persist:    true,
+		},
+	})
+	if err != nil {
+		c.engineErr = err
+		return c
+	}
+	c.engine = eng
 	return c
 }
 
-// SetModel rebuilds the agent engine with the given model name, keeping the
-// rest of the loaded connection config (api key / base URL). Cancels any
-// in-flight stream first.
+// SetModel replaces the LLM client while keeping the same session tree.
 func (c *Controller) SetModel(name string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -51,9 +72,125 @@ func (c *Controller) SetModel(name string) error {
 	cfg := proj.Config().Model()
 	cfg.Name = name
 	c.Cancel()
-	c.engine = agent.NewEngine(cfg)
+	if c.engine == nil {
+		eng, err := agent.NewEngine(agent.EngineOpts{
+			Model: cfg,
+			SessionOpts: agent.SessionOpts{
+				Cwd:        c.cwd,
+				SessionDir: c.sessionDir,
+				Persist:    true,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		c.engine = eng
+		c.modelCfg = cfg
+		c.engineErr = nil
+		return nil
+	}
+	if err := c.engine.SetModel(cfg); err != nil {
+		return err
+	}
+	c.modelCfg = cfg
 	c.engineErr = nil
 	return nil
+}
+
+// SessionID returns the short-form-friendly session id.
+func (c *Controller) SessionID() string {
+	if c.engine == nil {
+		return ""
+	}
+	return c.engine.SessionID()
+}
+
+// SessionFile returns the JSONL path when persisting.
+func (c *Controller) SessionFile() string {
+	if c.engine == nil {
+		return ""
+	}
+	return c.engine.SessionFile()
+}
+
+// Resume loads a prior session by id (exact or unique prefix).
+// On success the engine session is replaced; caller should refresh the UI transcript.
+// If the resumed session cwd differs from the process cwd, cwdWarning is non-empty.
+func (c *Controller) Resume(id string) (cwdWarning string, err error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", fmt.Errorf("empty session id")
+	}
+	if c.sessionDir == "" {
+		return "", fmt.Errorf("session directory not configured")
+	}
+	c.Cancel()
+
+	cfg := c.modelCfg
+	if cfg.Name == "" {
+		proj := project.GetDefaultProject()
+		if err := proj.LoadConfig(); err != nil {
+			return "", err
+		}
+		cfg = proj.Config().Model()
+	}
+
+	eng, err := agent.NewEngine(agent.EngineOpts{
+		Model: cfg,
+		SessionOpts: agent.SessionOpts{
+			Cwd:        c.cwd,
+			SessionDir: c.sessionDir,
+			Persist:    true,
+			ResumeID:   id,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if sessCwd := eng.SessionCwd(); sessCwd != "" && c.cwd != "" && sessCwd != c.cwd {
+		cwdWarning = fmt.Sprintf("session cwd is %s (current %s); not changing directory", sessCwd, c.cwd)
+	}
+	c.engine = eng
+	c.modelCfg = cfg
+	c.engineErr = nil
+	return cwdWarning, nil
+}
+
+// ReplaySnapshot builds a UI transcript snapshot from the engine session
+// (user/assistant text; tool rows simplified away).
+func (c *Controller) ReplaySnapshot() session.Snapshot {
+	var snap session.Snapshot
+	if c.engine == nil || c.engine.Session() == nil {
+		return snap
+	}
+	for _, entry := range c.engine.Session().PathEntries() {
+		switch entry.GetType() {
+		case session.EntryCompaction:
+			snap = session.Apply(snap, session.CompactionComplete{ID: entry.GetID()})
+		case session.EntryMessage:
+			msg := entry.(session.SessionMessageEntry).Message
+			switch msg.Role {
+			case llm.RoleUser:
+				snap = session.Apply(snap, session.UserAppend{ID: entry.GetID(), Text: msg.Content})
+			case llm.RoleAssistant:
+				text := msg.Content
+				blocks := []session.ContentBlock{}
+				if strings.TrimSpace(msg.ReasoningContent) != "" {
+					blocks = append(blocks, session.ContentBlock{Type: session.BlockThinking, Text: msg.ReasoningContent})
+				}
+				if text != "" {
+					blocks = append(blocks, session.ContentBlock{Type: session.BlockText, Text: text})
+				}
+				snap = session.Apply(snap, session.AssistantMessageUpdate{Message: session.Message{
+					ID:      entry.GetID(),
+					State:   session.StateComplete,
+					Text:    text,
+					Content: blocks,
+				}})
+			}
+		}
+	}
+	return snap
 }
 
 // StartPrompt cancels any in-flight stream and starts a new agent loop.

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -36,6 +37,7 @@ type Editor struct {
 	Chat      chat.ChatInput
 	palette   palette.CommandPalette
 	mention   mention.Picker
+	slash     mention.Picker
 	toast     toast.Toast
 	spin      *status.Spinner
 	welcome   splash.Screen
@@ -103,6 +105,10 @@ func NewEditor(vx *xui.XUI, theme components.Theme, cwd string, model string, sk
 		mention: mention.Picker{
 			Theme: theme,
 		},
+		slash: mention.Picker{
+			Theme:  theme,
+			Prefix: "/",
+		},
 		toast: toast.Toast{Theme: theme},
 		list: transcript.MessageList{
 			Theme:    theme,
@@ -132,8 +138,14 @@ func NewEditor(vx *xui.XUI, theme components.Theme, cwd string, model string, sk
 	editor.Chat.OnMentionChange = func(active bool, query string) {
 		editor.handleMentionChange(active, query)
 	}
+	editor.Chat.OnSlashChange = func(active bool, query string) {
+		editor.handleSlashChange(active, query)
+	}
 	editor.mention.OnAccept = func(item mention.Item) {
 		editor.acceptMention(item)
+	}
+	editor.slash.OnAccept = func(item mention.Item) {
+		editor.acceptSlash(item)
 	}
 	addSkill := func(name string) {
 		editor.Chat.AddPendingSkill(name)
@@ -142,8 +154,16 @@ func NewEditor(vx *xui.XUI, theme components.Theme, cwd string, model string, sk
 		}
 	}
 	editor.palette.Commands = append(
-		PaletteCommands(func(msg string) {
-			editor.list.StickToBottom()
+		PaletteCommands(func(name string) {
+			if err := editor.ctrl.SetModel(name); err != nil {
+				editor.toast.Show(err.Error(), toast.ToastError, 3*time.Second)
+				return
+			}
+			editor.Chat.TopRightLabel.Text = name
+			editor.toast.Show("Model: "+name, toast.ToastSuccess, 2*time.Second)
+			if editor.vx != nil {
+				editor.vx.QueueRefresh()
+			}
 		}),
 		ThemeCommand(editor.applyTheme),
 		SkillsCommand(skillPath, addSkill),
@@ -176,6 +196,7 @@ func (editor *Editor) applyTheme(name string) {
 	editor.Chat.BottomRightLabel.Style = th.Muted
 	editor.palette.Theme = th
 	editor.mention.Theme = th
+	editor.slash.Theme = th
 	editor.toast.Theme = th
 	editor.welcome.Theme = th
 	editor.list.Theme = th
@@ -276,6 +297,14 @@ func (editor *Editor) applySessionEvent(ev session.Event) {
 
 func (editor *Editor) handleSubmit(text string) {
 	text = strings.TrimSpace(text)
+	if strings.HasPrefix(text, "/") {
+		if editor.handleSlash(text) {
+			editor.hideCompleters()
+			editor.Chat.Value = ""
+			editor.Chat.Cursor = 0
+			return
+		}
+	}
 	pending := append([]string(nil), editor.Chat.PendingSkills...)
 	if (text == "" && len(pending) == 0) || editor.isBusy() {
 		return
@@ -284,6 +313,8 @@ func (editor *Editor) handleSubmit(text string) {
 	editor.mention.Hide()
 	editor.Chat.MentionOpen = false
 	editor.mentionGen++
+	editor.slash.Hide()
+	editor.Chat.SlashOpen = false
 
 	editor.activity.Apply(ActivitySubmitting)
 	display := text
@@ -301,6 +332,100 @@ func (editor *Editor) handleSubmit(text string) {
 	editor.Chat.ClearPendingSkills()
 
 	editor.ctrl.StartPrompt(text, pending)
+}
+
+// handleSlash runs /sessions and /resume. Returns true when the input was consumed.
+func (editor *Editor) handleSlash(text string) bool {
+	fields := strings.Fields(text)
+	if len(fields) == 0 {
+		return false
+	}
+	switch fields[0] {
+	case "/sessions":
+		editor.showSessions()
+		return true
+	case "/resume":
+		if len(fields) < 2 {
+			editor.toast.Show("Usage: /resume <session-id>", toast.ToastWarning, 3*time.Second)
+			return true
+		}
+		editor.resumeSession(fields[1])
+		return true
+	default:
+		return false
+	}
+}
+
+func (editor *Editor) showSessions() {
+	dir := ""
+	if editor.ctrl != nil {
+		dir = editor.ctrl.sessionDir
+	}
+	list, err := session.ListSessions(dir)
+	if err != nil {
+		editor.toast.Show(err.Error(), toast.ToastError, 3*time.Second)
+		return
+	}
+	const maxN = 12
+	var b strings.Builder
+	if len(list) == 0 {
+		b.WriteString("No sessions in " + dir)
+	} else {
+		fmt.Fprintf(&b, "Recent sessions (%d):\n", len(list))
+		n := len(list)
+		if n > maxN {
+			n = maxN
+		}
+		for i := 0; i < n; i++ {
+			m := list[i]
+			short := m.ID
+			if len(short) > 8 {
+				short = short[:8]
+			}
+			preview := m.Preview
+			if preview == "" {
+				preview = "(no preview)"
+			}
+			fmt.Fprintf(&b, "  %s  %s  %s\n", short, m.Mtime.Format("01-02 15:04"), preview)
+		}
+		b.WriteString("Resume with /resume <id>")
+	}
+	editor.applySessionEvent(session.AssistantMessageUpdate{Message: session.Message{
+		ID:    fmt.Sprintf("sessions-%d", time.Now().UnixNano()),
+		State: session.StateComplete,
+		Text:  b.String(),
+		Content: []session.ContentBlock{
+			{Type: session.BlockText, Text: b.String()},
+		},
+	}})
+	editor.list.Entries, editor.listIDs = editor.mapper.Sync(editor.list.Entries, editor.listIDs, editor.snap)
+	editor.list.InvalidateHeights()
+	editor.list.StickToBottom()
+}
+
+func (editor *Editor) resumeSession(id string) {
+	warn, err := editor.ctrl.Resume(id)
+	if err != nil {
+		editor.toast.Show(err.Error(), toast.ToastError, 4*time.Second)
+		return
+	}
+	editor.snap = editor.ctrl.ReplaySnapshot()
+	editor.list.Entries, editor.listIDs = editor.mapper.Sync(nil, nil, editor.snap)
+	editor.list.InvalidateHeights()
+	editor.list.StickToBottom()
+	msg := "Resumed " + shortSessionID(editor.ctrl.SessionID())
+	if warn != "" {
+		editor.toast.Show(msg+": "+warn, toast.ToastWarning, 5*time.Second)
+	} else {
+		editor.toast.Show(msg, toast.ToastSuccess, 3*time.Second)
+	}
+}
+
+func shortSessionID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
 }
 
 func (editor *Editor) handleCancel() {
@@ -331,6 +456,12 @@ func (editor *Editor) Handle(ctx *components.EventContext, ev xui.Event) {
 			return
 		}
 		if e.Press && e.Code == xui.KeyEscape {
+			if editor.slash.Open {
+				editor.slash.Cancel()
+				editor.Chat.SlashOpen = false
+				ctx.ConsumeAndRedraw()
+				return
+			}
 			if editor.mention.Open {
 				editor.mention.Cancel()
 				editor.Chat.MentionOpen = false
@@ -356,9 +487,7 @@ func (editor *Editor) Handle(ctx *components.EventContext, ev xui.Event) {
 				editor.palette.Hide()
 				ctx.RequestFocus(&editor.Chat)
 			} else {
-				editor.mention.Hide()
-				editor.Chat.MentionOpen = false
-				editor.mentionGen++
+				editor.hideCompleters()
 				editor.palette.Show()
 				ctx.RequestFocus(&editor.palette)
 			}
@@ -372,8 +501,18 @@ func (editor *Editor) Handle(ctx *components.EventContext, ev xui.Event) {
 			}
 			return
 		}
+		if editor.slash.Open && editor.mentionNavKey(e) {
+			editor.slash.Handle(ctx, e)
+			if !editor.slash.Open {
+				editor.Chat.SlashOpen = false
+			}
+			return
+		}
 		if editor.mention.Open && editor.mentionNavKey(e) {
 			editor.mention.Handle(ctx, e)
+			if !editor.mention.Open {
+				editor.Chat.MentionOpen = false
+			}
 			return
 		}
 		if e.Code == xui.KeyPageUp || e.Code == xui.KeyPageDown {
@@ -413,6 +552,14 @@ func (editor *Editor) mentionNavKey(e xui.KeyEvent) bool {
 	return false
 }
 
+func (editor *Editor) hideCompleters() {
+	editor.mention.Hide()
+	editor.Chat.MentionOpen = false
+	editor.mentionGen++
+	editor.slash.Hide()
+	editor.Chat.SlashOpen = false
+}
+
 func (editor *Editor) handleMentionChange(active bool, query string) {
 	if !active {
 		editor.mention.Hide()
@@ -420,12 +567,37 @@ func (editor *Editor) handleMentionChange(active bool, query string) {
 		editor.mentionGen++
 		return
 	}
+	// Prefer slash when both could match (leading /).
+	if editor.slash.Open || editor.Chat.SlashOpen {
+		return
+	}
+	editor.slash.Hide()
+	editor.Chat.SlashOpen = false
 	editor.mention.Show()
 	editor.Chat.MentionOpen = true
 	if len(editor.mention.Items) == 0 {
 		editor.mention.Status = "Searching…"
 	}
 	editor.scheduleMentionSearch(query)
+}
+
+func (editor *Editor) handleSlashChange(active bool, query string) {
+	if !active {
+		editor.slash.Hide()
+		editor.Chat.SlashOpen = false
+		return
+	}
+	editor.mention.Hide()
+	editor.Chat.MentionOpen = false
+	editor.mentionGen++
+	items := FilterSlashCommands(query)
+	s := ""
+	if len(items) == 0 {
+		s = "No matching commands"
+	}
+	editor.slash.SetResults(items, s)
+	editor.slash.Show()
+	editor.Chat.SlashOpen = true
 }
 
 func (editor *Editor) scheduleMentionSearch(query string) {
@@ -474,6 +646,27 @@ func (editor *Editor) acceptMention(item mention.Item) {
 	editor.Chat.MentionOpen = false
 	// Trailing space ends the mention token so the picker stays closed.
 	editor.Chat.ReplaceRange(start, end, "@"+item.Path+" ")
+}
+
+func (editor *Editor) acceptSlash(item mention.Item) {
+	_, start, end, ok := chat.ActiveSlash(editor.Chat.Value, editor.Chat.Cursor)
+	if !ok {
+		start, end = 0, editor.Chat.Cursor
+	}
+	insert := LookupSlashInsert(item.Path)
+	if insert == "" {
+		insert = "/" + item.Path
+	}
+	editor.Chat.ReplaceRange(start, end, insert)
+	// ReplaceRange notifies slash completer and may reopen for no-arg inserts
+	// (e.g. "/sessions"); force-close after the text update.
+	editor.slash.Hide()
+	editor.Chat.SlashOpen = false
+	// No-arg commands (no trailing space): run immediately.
+	if !strings.HasSuffix(insert, " ") {
+		editor.Publish(SubmitMsg{Text: strings.TrimSpace(insert)})
+		editor.drainBus()
+	}
 }
 
 func (editor *Editor) Draw(ctx components.DrawContext) components.Surface {
@@ -538,6 +731,17 @@ func (editor *Editor) Draw(ctx components.DrawContext) components.Surface {
 		{Origin: components.Point{X: 0, Y: 0}, Surface: listSurf},
 		{Origin: components.Point{X: 0, Y: listH}, Surface: chatSurf, Z: 1},
 		{Origin: components.Point{X: 0, Y: maxSize.Height - footerH}, Surface: footer, Z: 2},
+	}
+	if editor.slash.Open {
+		editor.slash.AnchorBottomY = listH
+		editor.slash.AnchorX = 0
+		editor.slash.AnchorWidth = maxSize.Width
+		panel := editor.slash.Draw(ctx)
+		root.Children = append(root.Children, components.SubSurface{
+			Origin:  components.Point{X: 0, Y: 0},
+			Surface: panel,
+			Z:       15,
+		})
 	}
 	if editor.mention.Open {
 		editor.mention.AnchorBottomY = listH

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -369,9 +369,9 @@ func (editor *Editor) showSessions() {
 	const maxN = 12
 	var b strings.Builder
 	if len(list) == 0 {
-		b.WriteString("No sessions in " + dir)
+		b.WriteString("No sessions for this directory")
 	} else {
-		fmt.Fprintf(&b, "Recent sessions (%d):\n", len(list))
+		fmt.Fprintf(&b, "Sessions in this directory (%d):\n", len(list))
 		n := len(list)
 		if n > maxN {
 			n = maxN

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -23,18 +23,6 @@ func (editor *Editor) drawFooter(ctx components.DrawContext, width int) componen
 		x += xui.StringWidth(msg, ctx.Method)
 	}
 
-	if editor.ctrl != nil {
-		if sid := shortSessionID(editor.ctrl.SessionID()); sid != "" {
-			label := sid
-			if msg != "" {
-				label = " · " + sid
-			}
-			footer.Print(x, 0, label, dim, ctx.Method)
-			x += xui.StringWidth(label, ctx.Method)
-		}
-	}
-
-	// Panda-style token breakdown on the right: ↑prompt ↓completion Σtotal
 	stats := editor.usageStats
 	if stats != "" {
 		sw := xui.StringWidth(stats, ctx.Method)

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -23,6 +23,17 @@ func (editor *Editor) drawFooter(ctx components.DrawContext, width int) componen
 		x += xui.StringWidth(msg, ctx.Method)
 	}
 
+	if editor.ctrl != nil {
+		if sid := shortSessionID(editor.ctrl.SessionID()); sid != "" {
+			label := sid
+			if msg != "" {
+				label = " · " + sid
+			}
+			footer.Print(x, 0, label, dim, ctx.Method)
+			x += xui.StringWidth(label, ctx.Method)
+		}
+	}
+
 	// Panda-style token breakdown on the right: ↑prompt ↓completion Σtotal
 	stats := editor.usageStats
 	if stats != "" {


### PR DESCRIPTION
- Persist agent sessions to JSONL under the session dir; add session.ListSessions / OpenSession / FindSessionFile for listing, replaying, and resuming by id or unique prefix
- Rework Engine/Session to take EngineOpts+SessionOpts with Persist/Resume options; SetModel now swaps the LLM client without discarding the session tree
- Add slash command support to the composer: /sessions lists recent sessions, /resume <id> reloads one; slash picker reuses the mention picker with a prefix and description column
- Controller gains Resume/ReplaySnapshot for UI transcript replay; footer shows the short session id; palette model command now actually switches models
- Add tests for session persist/flush, resume-by-prefix, engine model switch, and slash filtering