### PR TITLE
feat(permission): gate tool execution behind permission checks

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/llm/skills"
+	"github.com/pulseaiclub/phi/internal/permission"
 	"github.com/pulseaiclub/phi/internal/session"
 	"github.com/pulseaiclub/phi/internal/session/compaction"
 	"github.com/pulseaiclub/phi/internal/tools"
@@ -25,6 +26,8 @@ type Engine struct {
 	maxRounds     int
 	skillPath     string
 	contextWindow int
+	gate          permission.Gate
+	ask           permission.AskFunc
 
 	session *Session
 }
@@ -33,6 +36,8 @@ type Engine struct {
 type EngineOpts struct {
 	Model       llm.ModelConfig
 	SessionOpts SessionOpts
+	Gate        permission.Gate     // nil = allow all
+	Ask         permission.AskFunc  // nil = deny on Ask
 }
 
 // NewEngine wires an LLM client, tool executor, and session store.
@@ -46,11 +51,13 @@ func NewEngine(opts EngineOpts) (*Engine, error) {
 	client := llm.NewClient(cfg, tools.Definitions(toolList), Prompt(cfg.SkillPath))
 	return &Engine{
 		client:        client,
-		executor:      NewExecutor(tools.NewRegistry(toolList)),
+		executor:      NewExecutor(tools.NewRegistry(toolList), opts.Gate, opts.Ask),
 		maxRounds:     defaultMaxToolRounds,
 		skillPath:     cfg.SkillPath,
 		contextWindow: cfg.ContextWindow,
 		session:       sess,
+		gate:          opts.Gate,
+		ask:           opts.Ask,
 	}, nil
 }
 
@@ -59,10 +66,23 @@ func NewEngine(opts EngineOpts) (*Engine, error) {
 func (engine *Engine) SetModel(cfg llm.ModelConfig) error {
 	toolList := tools.DefaultTools()
 	engine.client = llm.NewClient(cfg, tools.Definitions(toolList), Prompt(cfg.SkillPath))
-	engine.executor = NewExecutor(tools.NewRegistry(toolList))
+	engine.executor = NewExecutor(tools.NewRegistry(toolList), engine.gate, engine.ask)
 	engine.skillPath = cfg.SkillPath
 	engine.contextWindow = cfg.ContextWindow
 	return nil
+}
+
+// SetPermission updates the gate and ask handler used by the tool executor.
+func (engine *Engine) SetPermission(gate permission.Gate, ask permission.AskFunc) {
+	if engine == nil {
+		return
+	}
+	engine.gate = gate
+	engine.ask = ask
+	if engine.executor != nil {
+		engine.executor.gate = gate
+		engine.executor.ask = ask
+	}
 }
 
 // SessionID returns the durable session id.

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/pulseaiclub/phi/internal/permission"
 	"github.com/pulseaiclub/phi/internal/session"
 	"github.com/pulseaiclub/phi/internal/tools"
 )
@@ -15,10 +16,15 @@ const ToolCanceledResult = "User cancelled the tool call."
 // Executor runs model tool_calls against a tool registry and emits ToolData for the UI.
 type Executor struct {
 	registry tools.Registry
+	gate     permission.Gate
+	ask      permission.AskFunc
 }
 
-func NewExecutor(registry tools.Registry) *Executor {
-	return &Executor{registry: registry}
+func NewExecutor(registry tools.Registry, gate permission.Gate, ask permission.AskFunc) *Executor {
+	if gate == nil {
+		gate = permission.AllowAll{}
+	}
+	return &Executor{registry: registry, gate: gate, ask: ask}
 }
 
 // Run executes tool calls in order, yielding ToolData updates via emit.
@@ -68,6 +74,10 @@ func (e *Executor) runOne(ctx context.Context, call llm.ToolCall, emit func(sess
 		return e.toolMessage(call.ID, errText)
 	}
 
+	if msg, rejected := e.checkPermission(ctx, call, args, detail, emit); rejected {
+		return msg
+	}
+
 	result, err := tool.Run(ctx, args)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -98,6 +108,64 @@ func (e *Executor) runOne(ctx context.Context, call llm.ToolCall, emit func(sess
 		Output:    out,
 	}})
 	return e.toolMessage(call.ID, result.Content)
+}
+
+func (e *Executor) checkPermission(
+	ctx context.Context,
+	call llm.ToolCall,
+	args json.RawMessage,
+	detail string,
+	emit func(session.ToolData) bool,
+) (llm.Message, bool) {
+	req, err := permission.Extract(call.Function.Name, args)
+	if err != nil {
+		reason := fmt.Sprintf("permission check failed: %v", err)
+		return e.rejectResult(call, detail, reason, emit), true
+	}
+
+	dec, reason := e.gate.Check(ctx, req)
+	switch dec {
+	case permission.Allow:
+		return llm.Message{}, false
+	case permission.Deny:
+		if reason == "" {
+			reason = "tool execution denied by permissions"
+		}
+		return e.rejectResult(call, detail, reason, emit), true
+	case permission.Ask:
+		if e.ask == nil {
+			if reason == "" {
+				reason = "tool requires approval but no ask handler is configured"
+			}
+			return e.rejectResult(call, detail, reason, emit), true
+		}
+		res, askErr := e.ask(ctx, req, reason)
+		if askErr != nil {
+			msg := fmt.Sprintf("approval failed: %v", askErr)
+			return e.rejectResult(call, detail, msg, emit), true
+		}
+		if !res.Approved {
+			msg := "tool execution rejected by user"
+			if res.Feedback != "" {
+				msg = "This tool call was rejected by the user with feedback: " + res.Feedback
+			}
+			return e.rejectResult(call, detail, msg, emit), true
+		}
+		return llm.Message{}, false
+	default:
+		return e.rejectResult(call, detail, "unknown permission decision", emit), true
+	}
+}
+
+func (e *Executor) rejectResult(call llm.ToolCall, detail, reason string, emit func(session.ToolData) bool) llm.Message {
+	_ = emit(session.ToolData{Run: session.ToolRun{
+		ToolUseID: call.ID,
+		Status:    session.ToolRejected,
+		Detail:    detail,
+		Error:     reason,
+		Output:    reason,
+	}})
+	return e.toolMessage(call.ID, reason)
 }
 
 func (e *Executor) cancelResult(call llm.ToolCall, emit func(session.ToolData) bool) llm.Message {

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/pulseaiclub/phi/internal/permission"
+	"github.com/pulseaiclub/phi/internal/session"
+	"github.com/pulseaiclub/phi/internal/tools"
+)
+
+type fixedGate struct {
+	dec    permission.Decision
+	reason string
+}
+
+func (g fixedGate) Check(context.Context, permission.Request) (permission.Decision, string) {
+	return g.dec, g.reason
+}
+
+func TestExecutorDenyDoesNotRunHandler(t *testing.T) {
+	var ran atomic.Int32
+	reg := tools.Registry{
+		"bash": {
+			Definition: llm.ToolDefinition{Name: "bash"},
+			Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+				ran.Add(1)
+				return tools.Result{Content: "ok"}, nil
+			},
+		},
+	}
+	ex := NewExecutor(reg, fixedGate{dec: permission.Deny, reason: "denied by test"}, nil)
+	var statuses []session.ToolStatus
+	msgs := ex.Run(context.Background(), []llm.ToolCall{{
+		ID:       "c1",
+		Function: llm.Function{Name: "bash", Arguments: `{"command":"echo hi"}`},
+	}}, func(td session.ToolData) bool {
+		statuses = append(statuses, td.Run.Status)
+		return true
+	})
+	if ran.Load() != 0 {
+		t.Fatal("handler should not run on deny")
+	}
+	if len(msgs) != 1 || msgs[0].Content != "denied by test" {
+		t.Fatalf("tool message: %+v", msgs)
+	}
+	found := false
+	for _, s := range statuses {
+		if s == session.ToolRejected {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected ToolRejected in %v", statuses)
+	}
+}
+
+func TestExecutorAskFalseRejects(t *testing.T) {
+	var ran atomic.Int32
+	reg := tools.Registry{
+		"bash": {
+			Definition: llm.ToolDefinition{Name: "bash"},
+			Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+				ran.Add(1)
+				return tools.Result{Content: "ok"}, nil
+			},
+		},
+	}
+	ask := func(context.Context, permission.Request, string) (permission.AskResult, error) {
+		return permission.AskResult{Approved: false}, nil
+	}
+	ex := NewExecutor(reg, fixedGate{dec: permission.Ask, reason: "needs approval"}, ask)
+	msgs := ex.Run(context.Background(), []llm.ToolCall{{
+		ID:       "c1",
+		Function: llm.Function{Name: "bash", Arguments: `{"command":"curl x"}`},
+	}}, func(session.ToolData) bool { return true })
+	if ran.Load() != 0 {
+		t.Fatal("handler should not run when ask denied")
+	}
+	if len(msgs) != 1 || msgs[0].Content == "" {
+		t.Fatalf("expected rejection message, got %+v", msgs)
+	}
+}
+
+func TestExecutorAskTrueRuns(t *testing.T) {
+	var ran atomic.Int32
+	reg := tools.Registry{
+		"bash": {
+			Definition: llm.ToolDefinition{Name: "bash"},
+			Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+				ran.Add(1)
+				return tools.Result{Content: "ran"}, nil
+			},
+		},
+	}
+	ask := func(context.Context, permission.Request, string) (permission.AskResult, error) {
+		return permission.AskResult{Approved: true}, nil
+	}
+	ex := NewExecutor(reg, fixedGate{dec: permission.Ask, reason: "needs approval"}, ask)
+	msgs := ex.Run(context.Background(), []llm.ToolCall{{
+		ID:       "c1",
+		Function: llm.Function{Name: "bash", Arguments: `{"command":"curl x"}`},
+	}}, func(session.ToolData) bool { return true })
+	if ran.Load() != 1 {
+		t.Fatal("handler should run when ask approved")
+	}
+	if len(msgs) != 1 || msgs[0].Content != "ran" {
+		t.Fatalf("got %+v", msgs)
+	}
+}
+
+func TestExecutorAskFeedbackMessage(t *testing.T) {
+	reg := tools.Registry{
+		"bash": {
+			Definition: llm.ToolDefinition{Name: "bash"},
+			Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+				return tools.Result{Content: "ok"}, nil
+			},
+		},
+	}
+	ask := func(context.Context, permission.Request, string) (permission.AskResult, error) {
+		return permission.AskResult{Approved: false, Feedback: "use go test instead"}, nil
+	}
+	ex := NewExecutor(reg, fixedGate{dec: permission.Ask, reason: "ask me"}, ask)
+	msgs := ex.Run(context.Background(), []llm.ToolCall{{
+		ID:       "c1",
+		Function: llm.Function{Name: "bash", Arguments: `{"command":"curl x"}`},
+	}}, func(session.ToolData) bool { return true })
+	if len(msgs) != 1 || !strings.Contains(msgs[0].Content, "use go test instead") {
+		t.Fatalf("expected feedback in message, got %+v", msgs)
+	}
+}
+
+func TestExecutorNilAskOnAskDenies(t *testing.T) {
+	reg := tools.Registry{
+		"bash": {
+			Definition: llm.ToolDefinition{Name: "bash"},
+			Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+				return tools.Result{Content: "ok"}, nil
+			},
+		},
+	}
+	ex := NewExecutor(reg, fixedGate{dec: permission.Ask, reason: "ask me"}, nil)
+	msgs := ex.Run(context.Background(), []llm.ToolCall{{
+		ID:       "c1",
+		Function: llm.Function{Name: "bash", Arguments: `{"command":"curl x"}`},
+	}}, func(session.ToolData) bool { return true })
+	if len(msgs) != 1 || msgs[0].Content == "" {
+		t.Fatalf("expected deny message, got %+v", msgs)
+	}
+}

--- a/internal/components/app/app.go
+++ b/internal/components/app/app.go
@@ -154,6 +154,18 @@ func (a *App) dispatch(ctx *components.EventContext, ev xui.Event) {
 	}
 }
 
+// RequestFocus moves keyboard focus to w (nil = root). Safe from the UI goroutine.
+func (a *App) RequestFocus(w components.Widget) {
+	if a == nil {
+		return
+	}
+	if w == nil {
+		w = a.root
+	}
+	a.focused = w
+	a.redraw = true
+}
+
 // acceptsKeyboardFocus reports whether a mouse-press target should become the
 // keyboard focus. Message-list rows handle clicks (expand/select) but typing
 // must stay on the composer / palette / text fields.

--- a/internal/components/block/bash_block.go
+++ b/internal/components/block/bash_block.go
@@ -20,6 +20,7 @@ const (
 	BashRunning
 	BashError
 	BashCancelled
+	BashRejected
 )
 
 // BashBlock renders bash tool output:
@@ -158,18 +159,24 @@ func (bashBlock *BashBlock) titleSpans(th components.Theme) []components.Span {
 		prefixStyle = th.Destructive
 	case BashRunning:
 		prefixStyle = th.ToolName
-	case BashCancelled:
+	case BashCancelled, BashRejected:
 		prefixStyle = th.Muted
 	}
 
 	cmdStyle := th.Foreground
-	if bashBlock.Status == BashCancelled {
+	if bashBlock.Status == BashCancelled || bashBlock.Status == BashRejected {
 		cmdStyle.Strikethrough = true
 	}
 
 	title := []components.Span{
 		{Text: "$ ", Style: prefixStyle},
 		{Text: bashBlock.Command, Style: cmdStyle},
+	}
+	switch bashBlock.Status {
+	case BashCancelled:
+		title = append(title, components.Span{Text: " (cancelled)", Style: th.Muted})
+	case BashRejected:
+		title = append(title, components.Span{Text: " (rejected)", Style: th.Muted})
 	}
 	if bashBlock.Status == BashDone && bashBlock.ExitCode != 0 {
 		it := xui.Style{Italic: true}

--- a/internal/components/block/tool_block.go
+++ b/internal/components/block/tool_block.go
@@ -101,6 +101,9 @@ func (toolBlock *ToolBlock) Draw(ctx components.DrawContext) components.Surface 
 	case status.ToolCancelled:
 		icon = "⊘"
 		iconSt = th.Muted
+	case status.ToolRejected:
+		icon = "⊘"
+		iconSt = th.Destructive
 	}
 
 	spans := []components.Span{
@@ -110,8 +113,11 @@ func (toolBlock *ToolBlock) Draw(ctx components.DrawContext) components.Surface 
 	if toolBlock.Detail != "" {
 		spans = append(spans, components.Span{Text: " " + toolBlock.Detail, Style: th.Muted})
 	}
-	if toolBlock.Status == status.ToolCancelled {
+	switch toolBlock.Status {
+	case status.ToolCancelled:
 		spans = append(spans, components.Span{Text: " (cancelled)", Style: th.Muted})
+	case status.ToolRejected:
+		spans = append(spans, components.Span{Text: " (rejected)", Style: th.Muted})
 	}
 	if toolBlock.hasBody() {
 		arrow := " ▶"

--- a/internal/components/status/status.go
+++ b/internal/components/status/status.go
@@ -390,6 +390,7 @@ const (
 	ToolError
 	ToolCancelled
 	ToolQueued
+	ToolRejected
 )
 
 func (t *ToolHeader) theme() components.Theme {
@@ -419,7 +420,7 @@ func (t *ToolHeader) Draw(ctx components.DrawContext) components.Surface {
 	case ToolError:
 		icon = "✗"
 		iconSt = th.Destructive
-	case ToolCancelled:
+	case ToolCancelled, ToolRejected:
 		icon = "⊘"
 		iconSt = th.Muted
 	}

--- a/internal/permission/ask.go
+++ b/internal/permission/ask.go
@@ -1,0 +1,13 @@
+package permission
+
+import "context"
+
+// AskResult is the user's response to an Ask decision.
+type AskResult struct {
+	Approved bool
+	Feedback string // non-empty when user denied with guidance for the model
+}
+
+// AskFunc is invoked when Gate.Check returns Ask (after mode folding).
+// Approved=false means deny; Feedback is forwarded to the model as the tool result.
+type AskFunc func(ctx context.Context, req Request, reason string) (AskResult, error)

--- a/internal/permission/bypass.go
+++ b/internal/permission/bypass.go
@@ -1,0 +1,23 @@
+package permission
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// BypassGate wraps an inner Gate and allows everything when Enabled is true
+// (Amp's dangerouslyAllowAll / "Allow All for This Session").
+type BypassGate struct {
+	Inner   Gate
+	Enabled *atomic.Bool
+}
+
+func (g *BypassGate) Check(ctx context.Context, req Request) (Decision, string) {
+	if g != nil && g.Enabled != nil && g.Enabled.Load() {
+		return Allow, ""
+	}
+	if g == nil || g.Inner == nil {
+		return Allow, ""
+	}
+	return g.Inner.Check(ctx, req)
+}

--- a/internal/permission/defaults.go
+++ b/internal/permission/defaults.go
@@ -1,0 +1,32 @@
+package permission
+
+var defaultBashAllow = []string{
+	`^git (status|diff|log|show|branch|rev-parse|describe)\b`,
+	`^go (test|build|vet|fmt|mod|list|env|version)\b`,
+	`^ls\b`,
+	`^pwd\b`,
+	`^echo\b`,
+	`^cat\b`,
+	`^head\b`,
+	`^tail\b`,
+	`^wc\b`,
+	`^which\b`,
+	`^type\b`,
+	`^true\b`,
+	`^false\b`,
+}
+
+var defaultBashDeny = []string{
+	`\bsudo\b`,
+	`\bsu\b`,
+	// Any recursive/force rm (not only rm -rf /).
+	`\brm\s+-[a-zA-Z]*[rf][a-zA-Z]*\b`,
+	`\brm\s+--recursive\b`,
+	`\brm\s+--force\b`,
+	`>\s*/etc/`,
+	`curl\s+.*\|\s*(ba)?sh`,
+	`wget\s+.*\|\s*(ba)?sh`,
+	`mkfs\b`,
+	`dd\s+if=`,
+	`:(){ :\|:& };:`,
+}

--- a/internal/permission/extract.go
+++ b/internal/permission/extract.go
@@ -1,0 +1,136 @@
+package permission
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Extract builds a permission Request from a tool name and raw JSON args.
+// Paths are absolute and cleaned. Unknown tools return Ask with a generic reason via Action "".
+func Extract(toolName string, args json.RawMessage) (Request, error) {
+	req := Request{Tool: toolName}
+	switch toolName {
+	case "bash":
+		var in struct {
+			Command string `json:"command"`
+		}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return req, fmt.Errorf("bash args: %w", err)
+		}
+		req.Action = ActionBash
+		req.Command = strings.TrimSpace(in.Command)
+		return req, nil
+
+	case "read":
+		var in struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return req, fmt.Errorf("read args: %w", err)
+		}
+		req.Action = ActionRead
+		return withPath(req, in.Path)
+
+	case "write":
+		var in struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return req, fmt.Errorf("write args: %w", err)
+		}
+		req.Action = ActionWrite
+		return withPath(req, in.Path)
+
+	case "edit":
+		var in struct {
+			Path     string `json:"path"`
+			FilePath string `json:"file_path"`
+		}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return req, fmt.Errorf("edit args: %w", err)
+		}
+		path := in.Path
+		if path == "" {
+			path = in.FilePath
+		}
+		req.Action = ActionEdit
+		return withPath(req, path)
+
+	case "grep":
+		var in struct {
+			Path string `json:"path"`
+		}
+		_ = json.Unmarshal(args, &in)
+		if in.Path == "" {
+			in.Path = "."
+		}
+		req.Action = ActionGrep
+		return withPath(req, in.Path)
+
+	case "glob":
+		var in struct {
+			Path string `json:"path"`
+		}
+		_ = json.Unmarshal(args, &in)
+		if in.Path == "" {
+			in.Path = "."
+		}
+		req.Action = ActionGlob
+		return withPath(req, in.Path)
+
+	case "list":
+		// Accept object or plain string path.
+		var asString string
+		if err := json.Unmarshal(args, &asString); err == nil && asString != "" {
+			req.Action = ActionList
+			return withPath(req, asString)
+		}
+		var in struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return req, fmt.Errorf("list args: %w", err)
+		}
+		req.Action = ActionList
+		return withPath(req, in.Path)
+
+	case "fetch":
+		var in struct {
+			URL string `json:"url"`
+		}
+		if err := json.Unmarshal(args, &in); err != nil {
+			return req, fmt.Errorf("fetch args: %w", err)
+		}
+		req.Action = ActionFetch
+		req.URL = strings.TrimSpace(in.URL)
+		return req, nil
+
+	default:
+		req.Action = Action(toolName)
+		return req, nil
+	}
+}
+
+func withPath(req Request, path string) (Request, error) {
+	abs, err := AbsClean(strings.TrimSpace(path))
+	if err != nil {
+		return req, err
+	}
+	req.Paths = []string{abs}
+	return req, nil
+}
+
+// Summarize returns a short human-readable summary of the request for UI.
+func Summarize(req Request) string {
+	switch {
+	case req.Command != "":
+		return truncate(req.Command, 200)
+	case req.URL != "":
+		return truncate(req.URL, 200)
+	case len(req.Paths) > 0:
+		return strings.Join(req.Paths, ", ")
+	default:
+		return string(req.Action)
+	}
+}

--- a/internal/permission/extract_test.go
+++ b/internal/permission/extract_test.go
@@ -1,0 +1,50 @@
+package permission
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractBash(t *testing.T) {
+	req, err := Extract("bash", json.RawMessage(`{"command":"git status"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Action != ActionBash || req.Command != "git status" {
+		t.Fatalf("got %+v", req)
+	}
+}
+
+func TestExtractWritePath(t *testing.T) {
+	req, err := Extract("write", json.RawMessage(`{"path":"out.txt","content":"x"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Action != ActionWrite || len(req.Paths) != 1 {
+		t.Fatalf("got %+v", req)
+	}
+	if !filepath.IsAbs(req.Paths[0]) {
+		t.Fatalf("path not abs: %s", req.Paths[0])
+	}
+}
+
+func TestExtractFetch(t *testing.T) {
+	req, err := Extract("fetch", json.RawMessage(`{"url":"https://example.com"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Action != ActionFetch || req.URL != "https://example.com" {
+		t.Fatalf("got %+v", req)
+	}
+}
+
+func TestExtractEditFilePath(t *testing.T) {
+	req, err := Extract("edit", json.RawMessage(`{"file_path":"a.go","edits":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Action != ActionEdit || len(req.Paths) != 1 {
+		t.Fatalf("got %+v", req)
+	}
+}

--- a/internal/permission/gate.go
+++ b/internal/permission/gate.go
@@ -1,0 +1,231 @@
+package permission
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Gate evaluates permission requests. It has no side effects; Ask is handled by the caller.
+type Gate interface {
+	Check(ctx context.Context, req Request) (Decision, string)
+}
+
+// StaticGate evaluates against a fixed Policy and workspace root.
+type StaticGate struct {
+	Policy    Policy
+	Workspace string
+
+	bashAllow []*regexp.Regexp
+	bashDeny  []*regexp.Regexp
+}
+
+// NewGate compiles policy regexes and returns a Gate.
+// Empty workspace uses WorkspaceRoot().
+func NewGate(policy Policy, workspace string) (*StaticGate, error) {
+	if workspace == "" {
+		workspace = WorkspaceRoot()
+	}
+	g := &StaticGate{Policy: policy, Workspace: workspace}
+	var err error
+	g.bashAllow, err = compilePatterns(policy.BashAllow)
+	if err != nil {
+		return nil, fmt.Errorf("bash allow: %w", err)
+	}
+	g.bashDeny, err = compilePatterns(policy.BashDeny)
+	if err != nil {
+		return nil, fmt.Errorf("bash deny: %w", err)
+	}
+	return g, nil
+}
+
+func compilePatterns(patterns []string) ([]*regexp.Regexp, error) {
+	out := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pattern %q: %w", p, err)
+		}
+		out = append(out, re)
+	}
+	return out, nil
+}
+
+// Check evaluates req and applies mode folding (Ask→Deny for headless-strict / autopilot).
+func (g *StaticGate) Check(ctx context.Context, req Request) (Decision, string) {
+	_ = ctx
+	dec, reason := g.evaluate(req)
+	return g.foldMode(dec, reason, req)
+}
+
+func (g *StaticGate) evaluate(req Request) (Decision, string) {
+	switch req.Action {
+	case ActionBash:
+		return g.checkBash(req)
+	case ActionWrite, ActionEdit:
+		return g.checkWrite(req)
+	case ActionRead, ActionGrep, ActionGlob, ActionList:
+		return g.checkRead(req)
+	case ActionFetch:
+		return g.checkFetch(req)
+	default:
+		return Ask, fmt.Sprintf("unknown action %q requires approval", req.Action)
+	}
+}
+
+func (g *StaticGate) checkBash(req Request) (Decision, string) {
+	cmd := strings.TrimSpace(req.Command)
+	if cmd == "" {
+		return Deny, "empty bash command denied"
+	}
+	for _, re := range g.bashDeny {
+		if re.MatchString(cmd) {
+			return Deny, fmt.Sprintf("bash denied by policy: matches %s", re.String())
+		}
+	}
+	// Allowlist only applies to a single simple command. Prefix matches like
+	// ^ls\b must not green-light "ls && rm -rf …".
+	if bashEligibleForAllowlist(cmd) {
+		for _, re := range g.bashAllow {
+			if re.MatchString(cmd) {
+				return Allow, ""
+			}
+		}
+	}
+	def := g.Policy.BashDefault
+	if def == Allow {
+		return Allow, ""
+	}
+	if def == Deny {
+		return Deny, "bash denied by default policy"
+	}
+	return Ask, fmt.Sprintf("bash requires approval: %s", truncate(cmd, 120))
+}
+
+func (g *StaticGate) checkWrite(req Request) (Decision, string) {
+	if len(req.Paths) == 0 {
+		return Deny, "write/edit without path denied"
+	}
+	for _, p := range req.Paths {
+		if IsSensitivePath(p, g.Policy.SensitivePathDeny) {
+			return Deny, fmt.Sprintf("write to sensitive path denied: %s", p)
+		}
+		if g.Policy.WorkspaceOnlyWrites && !InWorkspace(p, g.Workspace) {
+			return Deny, fmt.Sprintf("write outside workspace denied: %s", p)
+		}
+	}
+	return Allow, ""
+}
+
+func (g *StaticGate) checkRead(req Request) (Decision, string) {
+	if len(req.Paths) == 0 {
+		// grep/glob with default "." is normalized by extract; empty = allow cwd
+		return Allow, ""
+	}
+	for _, p := range req.Paths {
+		if IsSensitivePath(p, g.Policy.SensitivePathDeny) {
+			return Deny, fmt.Sprintf("read of sensitive path denied: %s", p)
+		}
+		if g.Policy.WorkspaceOnlyReads && !InWorkspace(p, g.Workspace) {
+			return Deny, fmt.Sprintf("read outside workspace denied: %s", p)
+		}
+	}
+	return Allow, ""
+}
+
+func (g *StaticGate) checkFetch(req Request) (Decision, string) {
+	host := HostOfURL(req.URL)
+	if host == "" {
+		if u, err := url.Parse(req.URL); err == nil {
+			host = strings.ToLower(u.Hostname())
+		}
+	}
+	for _, allowed := range g.Policy.FetchAllowedHosts {
+		if strings.EqualFold(host, allowed) {
+			return Allow, ""
+		}
+	}
+	def := g.Policy.FetchDefault
+	if def == Allow {
+		return Allow, ""
+	}
+	if def == Deny {
+		return Deny, fmt.Sprintf("fetch denied by default policy: %s", req.URL)
+	}
+	return Ask, fmt.Sprintf("fetch requires approval: %s", truncate(req.URL, 120))
+}
+
+func (g *StaticGate) foldMode(dec Decision, reason string, req Request) (Decision, string) {
+	mode := g.Policy.Mode
+	if mode == "" {
+		mode = ModeInteractive
+	}
+
+	switch mode {
+	case ModeInteractive:
+		return dec, reason
+
+	case ModeReadonly:
+		if isMutating(req.Action) {
+			// Allow bash only if it already matched allowlist (dec==Allow for bash).
+			if req.Action == ActionBash && dec == Allow {
+				return Allow, reason
+			}
+			if dec == Allow || dec == Ask {
+				return Deny, readonlyReason(req, reason)
+			}
+		}
+		if dec == Ask {
+			return Deny, askFoldReason(reason, mode)
+		}
+		return dec, reason
+
+	case ModeAutopilot, ModeHeadlessStrict:
+		if dec == Ask {
+			return Deny, askFoldReason(reason, mode)
+		}
+		return dec, reason
+
+	default:
+		return dec, reason
+	}
+}
+
+func isMutating(a Action) bool {
+	switch a {
+	case ActionWrite, ActionEdit, ActionBash, ActionFetch:
+		return true
+	default:
+		return false
+	}
+}
+
+func readonlyReason(req Request, fallback string) string {
+	if fallback != "" && !strings.Contains(fallback, "requires approval") {
+		return fallback
+	}
+	return fmt.Sprintf("readonly mode denies %s", req.Action)
+}
+
+func askFoldReason(reason string, mode Mode) string {
+	if reason == "" {
+		return fmt.Sprintf("%s mode denies operations that would require approval", mode)
+	}
+	return fmt.Sprintf("%s mode: %s", mode, reason)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// AllowAll is a Gate that always allows (tests / nil-policy fallback).
+type AllowAll struct{}
+
+func (AllowAll) Check(context.Context, Request) (Decision, string) {
+	return Allow, ""
+}

--- a/internal/permission/gate_test.go
+++ b/internal/permission/gate_test.go
@@ -1,0 +1,249 @@
+package permission
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInWorkspace(t *testing.T) {
+	ws := "/Users/me/proj"
+	if !InWorkspace("/Users/me/proj", ws) {
+		t.Fatal("workspace root should be inside itself")
+	}
+	if !InWorkspace("/Users/me/proj/src/a.go", ws) {
+		t.Fatal("child should be inside")
+	}
+	if InWorkspace("/Users/me/other", ws) {
+		t.Fatal("sibling should be outside")
+	}
+	if InWorkspace("/Users/me/proj-evil/x", ws) {
+		t.Fatal("prefix-sibling should be outside")
+	}
+	if InWorkspace("/Users/me", ws) {
+		t.Fatal("parent should be outside")
+	}
+}
+
+func TestCheckWriteOutsideWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	g, err := NewGate(DefaultPolicy(), ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(os.TempDir(), "phi-perm-test-outside")
+	dec, reason := g.Check(context.Background(), Request{
+		Action: ActionWrite,
+		Tool:   "write",
+		Paths:  []string{outside},
+	})
+	if dec != Deny {
+		t.Fatalf("want Deny, got %v (%s)", dec, reason)
+	}
+}
+
+func TestCheckWriteInsideWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	g, err := NewGate(DefaultPolicy(), ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inside := filepath.Join(ws, "out.txt")
+	dec, reason := g.Check(context.Background(), Request{
+		Action: ActionWrite,
+		Tool:   "write",
+		Paths:  []string{inside},
+	})
+	if dec != Allow {
+		t.Fatalf("want Allow, got %v (%s)", dec, reason)
+	}
+}
+
+func TestCheckWriteSensitiveConfig(t *testing.T) {
+	ws := t.TempDir()
+	g, err := NewGate(DefaultPolicy(), ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	home, _ := os.UserHomeDir()
+	cfgPath := filepath.Join(home, ".phi", "config.yaml")
+	dec, reason := g.Check(context.Background(), Request{
+		Action: ActionWrite,
+		Tool:   "write",
+		Paths:  []string{cfgPath},
+	})
+	if dec != Deny {
+		t.Fatalf("want Deny for config.yaml, got %v (%s)", dec, reason)
+	}
+}
+
+func TestCheckBashAllowDenyAsk(t *testing.T) {
+	g, err := NewGate(DefaultPolicy(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	dec, _ := g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "git status"})
+	if dec != Allow {
+		t.Fatalf("git status: want Allow, got %v", dec)
+	}
+	dec, _ = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "go test ./..."})
+	if dec != Allow {
+		t.Fatalf("go test: want Allow, got %v", dec)
+	}
+	dec, reason := g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "sudo true"})
+	if dec != Deny {
+		t.Fatalf("sudo: want Deny, got %v (%s)", dec, reason)
+	}
+	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "curl https://example.com"})
+	if dec != Ask {
+		t.Fatalf("curl: want Ask, got %v (%s)", dec, reason)
+	}
+}
+
+func TestCheckBashCompoundNotAllowlisted(t *testing.T) {
+	g, err := NewGate(DefaultPolicy(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// Prefix ^ls\b must NOT allow chained rm.
+	cmd := `ls -la todo.list 2>/dev/null && rm -rf todo.list && echo "removed"`
+	dec, reason := g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: cmd})
+	if dec != Deny {
+		t.Fatalf("ls && rm -rf: want Deny, got %v (%s)", dec, reason)
+	}
+
+	// Plain ls still allowed.
+	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "ls -la todo.list"})
+	if dec != Allow {
+		t.Fatalf("ls alone: want Allow, got %v (%s)", dec, reason)
+	}
+
+	// rm -rf without trailing / must still deny.
+	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "rm -rf todo.list"})
+	if dec != Deny {
+		t.Fatalf("rm -rf file: want Deny, got %v (%s)", dec, reason)
+	}
+
+	// Pipe / redirect out of allowlist.
+	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "cat foo | sh"})
+	if dec == Allow {
+		t.Fatalf("pipe: must not Allow (%s)", reason)
+	}
+	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "cat secret > /tmp/out"})
+	if dec == Allow {
+		t.Fatalf("redirect: must not Allow (%s)", reason)
+	}
+}
+
+func TestCheckFetchHostAllowlist(t *testing.T) {
+	p := DefaultPolicy()
+	p.FetchAllowedHosts = []string{"docs.github.com"}
+	g, err := NewGate(p, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	dec, _ := g.Check(ctx, Request{Action: ActionFetch, Tool: "fetch", URL: "https://docs.github.com/en"})
+	if dec != Allow {
+		t.Fatalf("allowed host: want Allow, got %v", dec)
+	}
+	dec, _ = g.Check(ctx, Request{Action: ActionFetch, Tool: "fetch", URL: "https://evil.example"})
+	if dec != Ask {
+		t.Fatalf("other host: want Ask, got %v", dec)
+	}
+}
+
+func TestModeHeadlessStrictFoldsAsk(t *testing.T) {
+	p := DefaultPolicy()
+	p.Mode = ModeHeadlessStrict
+	g, err := NewGate(p, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, reason := g.Check(context.Background(), Request{
+		Action:  ActionBash,
+		Tool:    "bash",
+		Command: "curl https://example.com",
+	})
+	if dec != Deny {
+		t.Fatalf("want Deny, got %v (%s)", dec, reason)
+	}
+}
+
+func TestModeReadonlyDeniesWrite(t *testing.T) {
+	ws := t.TempDir()
+	p := DefaultPolicy()
+	p.Mode = ModeReadonly
+	g, err := NewGate(p, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, reason := g.Check(context.Background(), Request{
+		Action: ActionWrite,
+		Tool:   "write",
+		Paths:  []string{filepath.Join(ws, "a.txt")},
+	})
+	if dec != Deny {
+		t.Fatalf("want Deny, got %v (%s)", dec, reason)
+	}
+	// allowlisted bash still ok
+	dec, reason = g.Check(context.Background(), Request{
+		Action:  ActionBash,
+		Tool:    "bash",
+		Command: "git status",
+	})
+	if dec != Allow {
+		t.Fatalf("git status in readonly: want Allow, got %v (%s)", dec, reason)
+	}
+}
+
+func TestModeAutopilotFoldsAsk(t *testing.T) {
+	p := DefaultPolicy()
+	p.Mode = ModeAutopilot
+	g, err := NewGate(p, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, _ := g.Check(context.Background(), Request{
+		Action: ActionFetch,
+		Tool:   "fetch",
+		URL:    "https://example.com",
+	})
+	if dec != Deny {
+		t.Fatalf("want Deny, got %v", dec)
+	}
+}
+
+func TestReadSensitiveDeny(t *testing.T) {
+	g, err := NewGate(DefaultPolicy(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	home, _ := os.UserHomeDir()
+	dec, reason := g.Check(context.Background(), Request{
+		Action: ActionRead,
+		Tool:   "read",
+		Paths:  []string{filepath.Join(home, ".ssh", "id_rsa")},
+	})
+	if dec != Deny {
+		t.Fatalf("want Deny, got %v (%s)", dec, reason)
+	}
+}
+
+func TestHostOfURL(t *testing.T) {
+	cases := map[string]string{
+		"https://docs.github.com/en": "docs.github.com",
+		"http://USER:pw@Ex.com:8080/x": "ex.com",
+		"docs.github.com/path":         "docs.github.com",
+	}
+	for in, want := range cases {
+		if got := HostOfURL(in); got != want {
+			t.Errorf("HostOfURL(%q)=%q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/permission/policy.go
+++ b/internal/permission/policy.go
@@ -1,0 +1,87 @@
+package permission
+
+// Mode controls how Ask decisions are folded.
+type Mode string
+
+const (
+	ModeInteractive    Mode = "interactive"
+	ModeReadonly       Mode = "readonly"
+	ModeAutopilot      Mode = "autopilot"
+	ModeHeadlessStrict Mode = "headless-strict"
+)
+
+// Decision is the gate outcome before optional Ask folding.
+type Decision int
+
+const (
+	Allow Decision = iota
+	Deny
+	Ask
+)
+
+func (d Decision) String() string {
+	switch d {
+	case Allow:
+		return "allow"
+	case Deny:
+		return "deny"
+	case Ask:
+		return "ask"
+	default:
+		return "unknown"
+	}
+}
+
+// Action names the kind of tool operation being gated.
+type Action string
+
+const (
+	ActionBash  Action = "bash"
+	ActionRead  Action = "read"
+	ActionWrite Action = "write"
+	ActionEdit  Action = "edit"
+	ActionFetch Action = "fetch"
+	ActionGrep  Action = "grep"
+	ActionGlob  Action = "glob"
+	ActionList  Action = "list"
+)
+
+// Request describes a tool invocation for permission evaluation.
+type Request struct {
+	Action  Action
+	Tool    string
+	Paths   []string // absolute, cleaned
+	Command string
+	URL     string
+}
+
+// Policy is the configurable permission ruleset.
+type Policy struct {
+	Mode                 Mode
+	WorkspaceOnlyWrites  bool
+	AskTimeoutSec        int
+	BashDefault          Decision // typically Ask
+	BashAllow            []string // regex
+	BashDeny             []string // regex
+	FetchDefault         Decision // typically Ask
+	FetchAllowedHosts    []string
+	SensitivePathDeny    []string // path prefixes
+	WorkspaceOnlyReads   bool     // if true, out-of-workspace reads deny
+	DangerouslyAllowAll  bool     // Amp-compatible: skip all permission checks
+}
+
+// DefaultPolicy returns the interactive defaults from task-002.
+func DefaultPolicy() Policy {
+	return Policy{
+		Mode:                ModeInteractive,
+		WorkspaceOnlyWrites: true,
+		AskTimeoutSec:       120,
+		BashDefault:         Ask,
+		BashAllow:           defaultBashAllow,
+		BashDeny:            defaultBashDeny,
+		FetchDefault:        Ask,
+		FetchAllowedHosts:   nil,
+		SensitivePathDeny:   defaultSensitivePaths(),
+		WorkspaceOnlyReads:  false,
+	}
+}

--- a/internal/permission/rules.go
+++ b/internal/permission/rules.go
@@ -1,0 +1,187 @@
+package permission
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func defaultSensitivePaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return []string{
+			"/.ssh",
+			"/.phi/config.yaml",
+			"/etc/shadow",
+			"/etc/passwd",
+		}
+	}
+	return []string{
+		filepath.Join(home, ".ssh"),
+		filepath.Join(home, ".phi", "config.yaml"),
+		filepath.Join(home, ".aws", "credentials"),
+		filepath.Join(home, ".gnupg"),
+		"/etc/shadow",
+	}
+}
+
+// WorkspaceRoot returns the git-root workspace, or cwd if no .git is found.
+func WorkspaceRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	start := dir
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return start
+}
+
+// AbsClean resolves path to an absolute cleaned path (no symlink resolve).
+func AbsClean(path string) (string, error) {
+	if path == "" {
+		path = "."
+	}
+	if !filepath.IsAbs(path) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(cwd, path)
+	}
+	return filepath.Clean(path), nil
+}
+
+// InWorkspace reports whether absPath is inside workspace (or equal to it).
+func InWorkspace(absPath, workspace string) bool {
+	if workspace == "" || absPath == "" {
+		return false
+	}
+	absPath = filepath.Clean(absPath)
+	workspace = filepath.Clean(workspace)
+	if absPath == workspace {
+		return true
+	}
+	rel, err := filepath.Rel(workspace, absPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// IsSensitivePath reports whether absPath matches a sensitive prefix.
+func IsSensitivePath(absPath string, prefixes []string) bool {
+	absPath = filepath.Clean(absPath)
+	for _, p := range prefixes {
+		p = filepath.Clean(p)
+		if absPath == p {
+			return true
+		}
+		if strings.HasPrefix(absPath, p+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// HostOfURL extracts hostname from a URL string (best-effort, no full parse required).
+func HostOfURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// Strip scheme
+	if i := strings.Index(raw, "://"); i >= 0 {
+		raw = raw[i+3:]
+	}
+	// Strip path/query
+	if i := strings.IndexAny(raw, "/?#"); i >= 0 {
+		raw = raw[:i]
+	}
+	// Strip userinfo
+	if i := strings.LastIndex(raw, "@"); i >= 0 {
+		raw = raw[i+1:]
+	}
+	// Strip port
+	if i := strings.LastIndex(raw, ":"); i >= 0 {
+		// IPv6 in brackets
+		if !strings.Contains(raw, "]") {
+			raw = raw[:i]
+		}
+	}
+	return strings.ToLower(raw)
+}
+
+// bashEligibleForAllowlist reports whether cmd is a single simple command that
+// may be auto-allowed. Chaining, pipes, substitutions, and overwrite redirects
+// force Ask/Deny evaluation instead of prefix allowlist matches.
+func bashEligibleForAllowlist(cmd string) bool {
+	return !hasBashControlSyntax(cmd)
+}
+
+func hasBashControlSyntax(cmd string) bool {
+	inSingle, inDouble, escaped := false, false, false
+	for i := 0; i < len(cmd); i++ {
+		c := cmd[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' && !inSingle {
+			escaped = true
+			continue
+		}
+		if c == '\'' && !inDouble {
+			inSingle = !inSingle
+			continue
+		}
+		if c == '"' && !inSingle {
+			inDouble = !inDouble
+			continue
+		}
+		if inSingle || inDouble {
+			continue
+		}
+		switch c {
+		case '\n', '\r', ';', '|', '`':
+			return true
+		case '&':
+			if i+1 < len(cmd) && cmd[i+1] == '&' {
+				return true
+			}
+			// background `&` also chains intent; treat as control
+			return true
+		case '>':
+			// Allow only >/dev/null and N>/dev/null (stderr noise); other
+			// redirects can overwrite files and must not use the allowlist.
+			if isDevNullRedirect(cmd, i) {
+				continue
+			}
+			return true
+		case '$':
+			if i+1 < len(cmd) && (cmd[i+1] == '(' || cmd[i+1] == '{') {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isDevNullRedirect reports whether cmd[i] is the '>' of a >/dev/null redirect
+// (optionally preceded by a FD digit, optionally >>).
+func isDevNullRedirect(cmd string, gt int) bool {
+	j := gt
+	if j+1 < len(cmd) && cmd[j+1] == '>' {
+		j++
+	}
+	rest := strings.TrimSpace(cmd[j+1:])
+	return strings.HasPrefix(rest, "/dev/null")
+}

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/pulseaiclub/phi/internal/permission"
 )
 
 // Config is the project-level configuration loaded from ~/.phi/config.yaml.
@@ -16,6 +17,7 @@ import (
 type Config struct {
 	PrimaryModel llm.ModelConfig
 	SkillPath    string
+	Permissions  permission.Policy
 }
 
 // Model returns the primary model config with the skill path applied, ready
@@ -49,18 +51,27 @@ func loadConfig(global GlobalLayout) (*Config, error) {
 	return cfg, nil
 }
 
-// parseConfigFile reads primary_model.{name,api_key,base_url,context_window}
-// and the top-level skill_path with a tiny line scanner so we don't need a
-// YAML dependency. A missing or unreadable file returns a zero Config.
+// parseConfigFile reads primary_model, skill_path, and permissions with a tiny
+// line scanner so we don't need a YAML dependency. Missing file → zero Config
+// with DefaultPolicy for permissions.
 func parseConfigFile(path string) *Config {
-	cfg := &Config{}
+	cfg := &Config{Permissions: permission.DefaultPolicy()}
 	f, err := os.Open(path)
 	if err != nil {
 		return cfg
 	}
 	defer f.Close()
 
-	var inBlock bool
+	const (
+		blockNone = iota
+		blockPrimary
+		blockPerm
+	)
+	block := blockNone
+	// Within permissions: "" | "bash" | "fetch" | "bash.allow" | "bash.deny" | "fetch.allowed_hosts"
+	permSub := ""
+	permHad := false
+
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		line := sc.Text()
@@ -68,38 +79,201 @@ func parseConfigFile(path string) *Config {
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
-		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
-			// Top-level key
+
+		indent := countIndent(line)
+
+		if indent == 0 {
+			block = blockNone
+			permSub = ""
 			if strings.HasPrefix(trimmed, "skill_path:") {
 				_, val, ok := splitYAMLKV(trimmed)
 				if ok {
 					cfg.SkillPath = val
 				}
+				continue
 			}
-			inBlock = strings.HasPrefix(trimmed, "primary_model:")
-			continue
-		}
-		if !inBlock {
-			continue
-		}
-		key, val, ok := splitYAMLKV(trimmed)
-		if !ok {
-			continue
-		}
-		switch key {
-		case "name":
-			cfg.PrimaryModel.Name = val
-		case "api_key":
-			cfg.PrimaryModel.APIKey = val
-		case "base_url":
-			cfg.PrimaryModel.BaseURL = val
-		case "context_window":
-			if n, err := strconv.Atoi(val); err == nil && n > 0 {
-				cfg.PrimaryModel.ContextWindow = n
+			if strings.HasPrefix(trimmed, "primary_model:") {
+				block = blockPrimary
+				continue
 			}
+			if strings.HasPrefix(trimmed, "permissions:") {
+				block = blockPerm
+				if !permHad {
+					cfg.Permissions = permission.DefaultPolicy()
+					permHad = true
+				}
+				continue
+			}
+			continue
+		}
+
+		switch block {
+		case blockPrimary:
+			if indent < 1 {
+				continue
+			}
+			key, val, ok := splitYAMLKV(trimmed)
+			if !ok {
+				continue
+			}
+			switch key {
+			case "name":
+				cfg.PrimaryModel.Name = val
+			case "api_key":
+				cfg.PrimaryModel.APIKey = val
+			case "base_url":
+				cfg.PrimaryModel.BaseURL = val
+			case "context_window":
+				if n, err := strconv.Atoi(val); err == nil && n > 0 {
+					cfg.PrimaryModel.ContextWindow = n
+				}
+			}
+
+		case blockPerm:
+			parsePermissionsLine(cfg, &permSub, indent, trimmed)
 		}
 	}
 	return cfg
+}
+
+func parsePermissionsLine(cfg *Config, permSub *string, indent int, trimmed string) {
+	// List item
+	if strings.HasPrefix(trimmed, "- ") {
+		item := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+		item = strings.Trim(item, `"'`)
+		switch *permSub {
+		case "bash.allow":
+			cfg.Permissions.BashAllow = append(cfg.Permissions.BashAllow, item)
+		case "bash.deny":
+			cfg.Permissions.BashDeny = append(cfg.Permissions.BashDeny, item)
+		case "fetch.allowed_hosts":
+			cfg.Permissions.FetchAllowedHosts = append(cfg.Permissions.FetchAllowedHosts, item)
+		}
+		return
+	}
+
+	key, val, ok := splitYAMLKV(trimmed)
+	if !ok {
+		return
+	}
+
+	// Section headers / keys under permissions
+	switch {
+	case indent == 1 && key == "bash":
+		*permSub = "bash"
+		return
+	case indent == 1 && key == "fetch":
+		*permSub = "fetch"
+		return
+	case indent == 1:
+		*permSub = ""
+		switch key {
+		case "mode":
+			cfg.Permissions.Mode = permission.Mode(val)
+		case "workspace_only_writes":
+			cfg.Permissions.WorkspaceOnlyWrites = parseBool(val, true)
+		case "ask_timeout_sec":
+			if n, err := strconv.Atoi(val); err == nil && n > 0 {
+				cfg.Permissions.AskTimeoutSec = n
+			}
+		case "dangerously_allow_all":
+			cfg.Permissions.DangerouslyAllowAll = parseBool(val, false)
+		}
+		return
+	case *permSub == "bash" && indent >= 2:
+		switch key {
+		case "default":
+			cfg.Permissions.BashDefault = parseDecision(val, permission.Ask)
+		case "allow":
+			*permSub = "bash.allow"
+			cfg.Permissions.BashAllow = nil // replace defaults when explicitly set
+			if val != "" && val != "[]" {
+				cfg.Permissions.BashAllow = append(cfg.Permissions.BashAllow, strings.Trim(val, `"'`))
+			}
+		case "deny":
+			*permSub = "bash.deny"
+			cfg.Permissions.BashDeny = nil
+			if val != "" && val != "[]" {
+				cfg.Permissions.BashDeny = append(cfg.Permissions.BashDeny, strings.Trim(val, `"'`))
+			}
+		}
+		return
+	case *permSub == "fetch" && indent >= 2:
+		switch key {
+		case "default":
+			cfg.Permissions.FetchDefault = parseDecision(val, permission.Ask)
+		case "allowed_hosts":
+			*permSub = "fetch.allowed_hosts"
+			cfg.Permissions.FetchAllowedHosts = nil
+			if val != "" && val != "[]" {
+				cfg.Permissions.FetchAllowedHosts = append(cfg.Permissions.FetchAllowedHosts, strings.Trim(val, `"'`))
+			}
+		}
+		return
+	case strings.HasPrefix(*permSub, "bash.") && indent == 2:
+		// Leaving a list for another bash key
+		switch key {
+		case "default":
+			*permSub = "bash"
+			cfg.Permissions.BashDefault = parseDecision(val, permission.Ask)
+		case "allow":
+			*permSub = "bash.allow"
+			cfg.Permissions.BashAllow = nil
+		case "deny":
+			*permSub = "bash.deny"
+			cfg.Permissions.BashDeny = nil
+		}
+		return
+	case strings.HasPrefix(*permSub, "fetch.") && indent == 2:
+		switch key {
+		case "default":
+			*permSub = "fetch"
+			cfg.Permissions.FetchDefault = parseDecision(val, permission.Ask)
+		case "allowed_hosts":
+			*permSub = "fetch.allowed_hosts"
+			cfg.Permissions.FetchAllowedHosts = nil
+		}
+		return
+	}
+}
+
+func countIndent(line string) int {
+	n := 0
+	for _, r := range line {
+		if r == ' ' {
+			n++
+		} else if r == '\t' {
+			n += 2
+		} else {
+			break
+		}
+	}
+	// Treat 2 spaces as one indent level for our hand-rolled parser.
+	return n / 2
+}
+
+func parseBool(val string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(val)) {
+	case "true", "yes", "1":
+		return true
+	case "false", "no", "0":
+		return false
+	default:
+		return def
+	}
+}
+
+func parseDecision(val string, def permission.Decision) permission.Decision {
+	switch strings.ToLower(strings.TrimSpace(val)) {
+	case "allow":
+		return permission.Allow
+	case "deny", "reject":
+		return permission.Deny
+	case "ask":
+		return permission.Ask
+	default:
+		return def
+	}
 }
 
 func applyEnvOverrides(c *Config) {
@@ -135,4 +309,58 @@ func firstEnv(keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// SetDangerouslyAllowAll persists permissions.dangerously_allow_all in config.yaml
+// (Amp-compatible "Allow All for Every Session"). Best-effort rewrite of that key.
+func SetDangerouslyAllowAll(global GlobalLayout, enabled bool) error {
+	path := global.ConfigFile()
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	lines := []string{}
+	if len(data) > 0 {
+		lines = strings.Split(string(data), "\n")
+	}
+	val := "false"
+	if enabled {
+		val = "true"
+	}
+	inPerm := false
+	found := false
+	out := make([]string, 0, len(lines)+2)
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		indent := countIndent(line)
+		if indent == 0 && strings.HasPrefix(trimmed, "permissions:") {
+			inPerm = true
+			out = append(out, line)
+			continue
+		}
+		if indent == 0 && trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			if inPerm && !found {
+				out = append(out, "  dangerously_allow_all: "+val)
+				found = true
+			}
+			inPerm = false
+		}
+		if inPerm && indent == 1 && strings.HasPrefix(trimmed, "dangerously_allow_all:") {
+			out = append(out, "  dangerously_allow_all: "+val)
+			found = true
+			continue
+		}
+		out = append(out, line)
+	}
+	if inPerm && !found {
+		out = append(out, "  dangerously_allow_all: "+val)
+		found = true
+	}
+	if !found {
+		if len(out) > 0 && out[len(out)-1] != "" {
+			out = append(out, "")
+		}
+		out = append(out, "permissions:", "  dangerously_allow_all: "+val)
+	}
+	return os.WriteFile(path, []byte(strings.Join(out, "\n")+"\n"), 0o644)
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -94,4 +94,36 @@ func TestLoadConfigConfigFileMissing(t *testing.T) {
 
 	require.NoError(t, p.LoadConfig())
 	assert.Equal(t, "env-model", p.Config().PrimaryModel.Name)
+	assert.Equal(t, "interactive", string(p.Config().Permissions.Mode))
+}
+
+func TestLoadConfigPermissions(t *testing.T) {
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
+primary_model:
+  name: m
+  api_key: k
+permissions:
+  mode: headless-strict
+  ask_timeout_sec: 30
+  workspace_only_writes: true
+  bash:
+    default: ask
+    allow:
+      - "^echo\b"
+    deny:
+      - "\bsudo\b"
+  fetch:
+    default: ask
+    allowed_hosts:
+      - "docs.github.com"
+`), 0o644))
+
+	require.NoError(t, p.LoadConfig())
+	perm := p.Config().Permissions
+	assert.Equal(t, "headless-strict", string(perm.Mode))
+	assert.Equal(t, 30, perm.AskTimeoutSec)
+	assert.Equal(t, []string{`^echo\b`}, perm.BashAllow)
+	assert.Equal(t, []string{`\bsudo\b`}, perm.BashDeny)
+	assert.Equal(t, []string{"docs.github.com"}, perm.FetchAllowedHosts)
 }

--- a/internal/tui/activity.go
+++ b/internal/tui/activity.go
@@ -20,6 +20,7 @@ const (
 	ActivityRetrying
 	ActivityCancelled
 	ActivityCompacting
+	ActivityAwaitingApproval
 )
 
 // ActivityHandler owns footer/stream activity state.
@@ -49,6 +50,10 @@ func (h *ActivityHandler) Apply(a Activity) {
 // SyncFromSnap derives activity from the session snapshot after model updates.
 func (h *ActivityHandler) SyncFromSnap(snap session.Snapshot) {
 	if h == nil {
+		return
+	}
+	// Don't clobber the approval footer while the confirmation UI is up.
+	if h.Current == ActivityAwaitingApproval {
 		return
 	}
 	if snap.Compacting {
@@ -112,6 +117,8 @@ func activityMessage(a Activity) string {
 		return "Retrying after disconnect…"
 	case ActivityCancelled:
 		return "Stopped"
+	case ActivityAwaitingApproval:
+		return "Waiting for approval..."
 	default:
 		return ""
 	}

--- a/internal/tui/controller.go
+++ b/internal/tui/controller.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pulseaiclub/phi/internal/agent"
 	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/pulseaiclub/phi/internal/permission"
 	"github.com/pulseaiclub/phi/internal/project"
 	"github.com/pulseaiclub/phi/internal/session"
 )
@@ -29,10 +31,14 @@ type Controller struct {
 	sessionDir string
 	cwd        string
 	modelCfg   llm.ModelConfig
+
+	gate          permission.Gate
+	askTimeoutSec int
+	allowAll      atomic.Bool // Amp dangerouslyAllowAll for this process
 }
 
 func NewController(bus *Bus) *Controller {
-	c := &Controller{bus: bus}
+	c := &Controller{bus: bus, askTimeoutSec: 120}
 	proj := project.GetDefaultProject()
 	cwd, _ := os.Getwd()
 	c.cwd = cwd
@@ -43,6 +49,8 @@ func NewController(bus *Bus) *Controller {
 		return c
 	}
 	c.modelCfg = proj.Config().Model()
+	c.initGate(proj.Config().Permissions)
+
 	eng, err := agent.NewEngine(agent.EngineOpts{
 		Model: c.modelCfg,
 		SessionOpts: agent.SessionOpts{
@@ -50,6 +58,8 @@ func NewController(bus *Bus) *Controller {
 			SessionDir: c.sessionDir,
 			Persist:    true,
 		},
+		Gate: c.gate,
+		Ask:  c.askPermission,
 	})
 	if err != nil {
 		c.engineErr = err
@@ -57,6 +67,60 @@ func NewController(bus *Bus) *Controller {
 	}
 	c.engine = eng
 	return c
+}
+
+func (c *Controller) initGate(policy permission.Policy) {
+	if policy.AskTimeoutSec > 0 {
+		c.askTimeoutSec = policy.AskTimeoutSec
+	}
+	if policy.Mode == "" {
+		policy.Mode = permission.ModeInteractive
+	}
+	if policy.DangerouslyAllowAll {
+		c.allowAll.Store(true)
+	}
+	inner, err := permission.NewGate(policy, permission.WorkspaceRoot())
+	if err != nil {
+		inner, err = permission.NewGate(permission.DefaultPolicy(), permission.WorkspaceRoot())
+		if err != nil {
+			c.gate = &permission.BypassGate{Inner: permission.AllowAll{}, Enabled: &c.allowAll}
+			return
+		}
+	}
+	c.gate = &permission.BypassGate{Inner: inner, Enabled: &c.allowAll}
+}
+
+// askPermission blocks until the Amp-style confirmation UI answers.
+func (c *Controller) askPermission(ctx context.Context, req permission.Request, reason string) (permission.AskResult, error) {
+	if c.allowAll.Load() {
+		return permission.AskResult{Approved: true}, nil
+	}
+	reply := make(chan AskReply, 1)
+	c.publish(PermissionAskMsg{Request: req, Reason: reason, Reply: reply})
+
+	timeout := time.Duration(c.askTimeoutSec) * time.Second
+	if timeout <= 0 {
+		timeout = 120 * time.Second
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case r := <-reply:
+		if r.AllowSession || r.AllowPersistent {
+			c.allowAll.Store(true)
+		}
+		if r.AllowPersistent {
+			_ = project.SetDangerouslyAllowAll(project.GetDefaultProject().Global(), true)
+		}
+		return permission.AskResult{Approved: r.Approved, Feedback: r.Feedback}, nil
+	case <-ctx.Done():
+		c.publish(PermissionDismissMsg{})
+		return permission.AskResult{}, ctx.Err()
+	case <-timer.C:
+		c.publish(PermissionDismissMsg{})
+		return permission.AskResult{}, nil
+	}
 }
 
 // SetModel replaces the LLM client while keeping the same session tree.
@@ -72,6 +136,7 @@ func (c *Controller) SetModel(name string) error {
 	cfg := proj.Config().Model()
 	cfg.Name = name
 	c.Cancel()
+	c.initGate(proj.Config().Permissions)
 	if c.engine == nil {
 		eng, err := agent.NewEngine(agent.EngineOpts{
 			Model: cfg,
@@ -80,6 +145,8 @@ func (c *Controller) SetModel(name string) error {
 				SessionDir: c.sessionDir,
 				Persist:    true,
 			},
+			Gate: c.gate,
+			Ask:  c.askPermission,
 		})
 		if err != nil {
 			return err
@@ -89,6 +156,7 @@ func (c *Controller) SetModel(name string) error {
 		c.engineErr = nil
 		return nil
 	}
+	c.engine.SetPermission(c.gate, c.askPermission)
 	if err := c.engine.SetModel(cfg); err != nil {
 		return err
 	}
@@ -143,6 +211,8 @@ func (c *Controller) Resume(id string) (cwdWarning string, err error) {
 			Persist:    true,
 			ResumeID:   id,
 		},
+		Gate: c.gate,
+		Ask:  c.askPermission,
 	})
 	if err != nil {
 		return "", err

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -61,6 +61,8 @@ type Editor struct {
 	contextWindow int
 	lastUsage     session.TokenUsage
 	usageStats    string // panda-style ↑↓Σ for footer
+
+	permAsk *permAskState
 }
 
 func newChatInput(theme components.Theme, model string, cwd string) chat.ChatInput {
@@ -260,6 +262,20 @@ func (editor *Editor) Update(m Msg) {
 		}
 	case MentionResultsMsg:
 		editor.applyMentionResults(msg)
+	case PermissionAskMsg:
+		editor.beginPermissionAsk(msg)
+	case PermissionDismissMsg:
+		// Agent already timed out / cancelled; only clear the overlay.
+		wasAsk := editor.permAsk != nil
+		editor.permAsk = nil
+		if wasAsk {
+			if editor.activity.Current == ActivityAwaitingApproval {
+				editor.activity.Apply(ActivityTools)
+			}
+			if editor.App != nil {
+				editor.App.RequestFocus(&editor.Chat)
+			}
+		}
 	case RedrawMsg:
 		// no state change; drain already requested redraw
 	}
@@ -429,6 +445,9 @@ func shortSessionID(id string) string {
 }
 
 func (editor *Editor) handleCancel() {
+	if editor.permAsk != nil {
+		editor.resolvePermission(AskReply{})
+	}
 	editor.ctrl.Cancel()
 	editor.applySessionEvent(session.CancelStreaming{})
 	editor.list.Entries, editor.listIDs = editor.mapper.Sync(editor.list.Entries, editor.listIDs, editor.snap)
@@ -442,7 +461,9 @@ func (editor *Editor) handleCancel() {
 func (editor *Editor) Handle(ctx *components.EventContext, ev xui.Event) {
 	switch e := ev.(type) {
 	case xui.FocusEvent:
-		if editor.palette.Open {
+		if editor.permAsk != nil {
+			ctx.RequestFocus(editor)
+		} else if editor.palette.Open {
 			ctx.RequestFocus(&editor.palette)
 		} else {
 			ctx.RequestFocus(&editor.Chat)
@@ -450,6 +471,9 @@ func (editor *Editor) Handle(ctx *components.EventContext, ev xui.Event) {
 	case xui.KeyEvent:
 		if e.CtrlC() {
 			ctx.Quit = true
+			return
+		}
+		if editor.handlePermissionKey(ctx, e) {
 			return
 		}
 		if editor.handleCopyKey(ctx, e) {
@@ -685,27 +709,39 @@ func (editor *Editor) Draw(ctx components.DrawContext) components.Surface {
 	root := components.Surface{Size: maxSize, Widget: editor}
 
 	footerH := 1
-	chatH := editor.Chat.PreferredHeight(maxSize.Width, ctx.Method)
-	minChatH := 5
-	if len(editor.Chat.PendingSkills) > 0 {
-		minChatH++
-	}
-	if chatH < minChatH {
-		chatH = minChatH
-	}
-	maxChatH := maxSize.Height - footerH - 3
-	if maxChatH < minChatH {
-		maxChatH = minChatH
-	}
-	if chatH > maxChatH {
-		chatH = maxChatH
+	var chatH int
+	if editor.permAsk != nil {
+		chatH = editor.permAsk.preferredAskHeight(maxSize.Width, ctx.Method)
+		maxChatH := maxSize.Height - footerH - 3
+		if chatH > maxChatH {
+			chatH = maxChatH
+		}
+		if chatH < 8 {
+			chatH = 8
+		}
+	} else {
+		chatH = editor.Chat.PreferredHeight(maxSize.Width, ctx.Method)
+		minChatH := 5
+		if len(editor.Chat.PendingSkills) > 0 {
+			minChatH++
+		}
+		if chatH < minChatH {
+			chatH = minChatH
+		}
+		maxChatH := maxSize.Height - footerH - 3
+		if maxChatH < minChatH {
+			maxChatH = minChatH
+		}
+		if chatH > maxChatH {
+			chatH = maxChatH
+		}
 	}
 	listH := maxSize.Height - chatH - footerH
 	if listH < 3 {
 		listH = 3
 		chatH = maxSize.Height - listH - footerH
-		if chatH < minChatH {
-			chatH = minChatH
+		if chatH < 5 {
+			chatH = 5
 		}
 	}
 	editor.listH = listH
@@ -724,7 +760,13 @@ func (editor *Editor) Draw(ctx components.DrawContext) components.Surface {
 	}
 	editor.lastListSurf = listSurf
 
-	chatSurf := editor.Chat.Draw(ctx.WithConstraints(components.Size{}, components.Size{Width: maxSize.Width, Height: chatH}))
+	var chatSurf components.Surface
+	if editor.permAsk != nil {
+		// Amp: confirmation replaces the chat composer (buildBottomWidget).
+		chatSurf = editor.drawPermissionAsk(ctx, maxSize.Width, chatH)
+	} else {
+		chatSurf = editor.Chat.Draw(ctx.WithConstraints(components.Size{}, components.Size{Width: maxSize.Width, Height: chatH}))
+	}
 	footer := editor.drawFooter(ctx, maxSize.Width)
 
 	root.Children = []components.SubSurface{
@@ -732,27 +774,29 @@ func (editor *Editor) Draw(ctx components.DrawContext) components.Surface {
 		{Origin: components.Point{X: 0, Y: listH}, Surface: chatSurf, Z: 1},
 		{Origin: components.Point{X: 0, Y: maxSize.Height - footerH}, Surface: footer, Z: 2},
 	}
-	if editor.slash.Open {
-		editor.slash.AnchorBottomY = listH
-		editor.slash.AnchorX = 0
-		editor.slash.AnchorWidth = maxSize.Width
-		panel := editor.slash.Draw(ctx)
-		root.Children = append(root.Children, components.SubSurface{
-			Origin:  components.Point{X: 0, Y: 0},
-			Surface: panel,
-			Z:       15,
-		})
-	}
-	if editor.mention.Open {
-		editor.mention.AnchorBottomY = listH
-		editor.mention.AnchorX = 0
-		editor.mention.AnchorWidth = maxSize.Width
-		men := editor.mention.Draw(ctx)
-		root.Children = append(root.Children, components.SubSurface{
-			Origin:  components.Point{X: 0, Y: 0},
-			Surface: men,
-			Z:       15,
-		})
+	if editor.permAsk == nil {
+		if editor.slash.Open {
+			editor.slash.AnchorBottomY = listH
+			editor.slash.AnchorX = 0
+			editor.slash.AnchorWidth = maxSize.Width
+			panel := editor.slash.Draw(ctx)
+			root.Children = append(root.Children, components.SubSurface{
+				Origin:  components.Point{X: 0, Y: 0},
+				Surface: panel,
+				Z:       15,
+			})
+		}
+		if editor.mention.Open {
+			editor.mention.AnchorBottomY = listH
+			editor.mention.AnchorX = 0
+			editor.mention.AnchorWidth = maxSize.Width
+			men := editor.mention.Draw(ctx)
+			root.Children = append(root.Children, components.SubSurface{
+				Origin:  components.Point{X: 0, Y: 0},
+				Surface: men,
+				Z:       15,
+			})
+		}
 	}
 	if editor.palette.Open {
 		pal := editor.palette.Draw(ctx)

--- a/internal/tui/mapper.go
+++ b/internal/tui/mapper.go
@@ -238,8 +238,10 @@ func bashStatus(s session.ToolStatus) block.BashStatus {
 		return block.BashDone
 	case session.ToolError:
 		return block.BashError
-	case session.ToolCancelled, session.ToolRejected:
+	case session.ToolCancelled:
 		return block.BashCancelled
+	case session.ToolRejected:
+		return block.BashRejected
 	default:
 		return block.BashRunning
 	}
@@ -251,8 +253,10 @@ func uiToolStatus(s session.ToolStatus) status.ToolStatus {
 		return status.ToolDone
 	case session.ToolError:
 		return status.ToolError
-	case session.ToolCancelled, session.ToolRejected:
+	case session.ToolCancelled:
 		return status.ToolCancelled
+	case session.ToolRejected:
+		return status.ToolRejected
 	case session.ToolQueued:
 		return status.ToolQueued
 	default:

--- a/internal/tui/msg.go
+++ b/internal/tui/msg.go
@@ -1,6 +1,9 @@
 package tui
 
-import "github.com/pulseaiclub/phi/internal/session"
+import (
+	"github.com/pulseaiclub/phi/internal/permission"
+	"github.com/pulseaiclub/phi/internal/session"
+)
 
 // Msg is a UI-thread message. Producers send; Editor.Update applies.
 // Share memory by communicating — not the other way around.
@@ -48,3 +51,18 @@ type MentionResultsMsg struct {
 }
 
 func (MentionResultsMsg) isMsg() {}
+
+// PermissionAskMsg asks the UI to confirm a gated tool call (Amp ConfirmationWidget).
+// Reply must be buffered(1); the UI sends AskReply once.
+type PermissionAskMsg struct {
+	Request permission.Request
+	Reason  string
+	Reply   chan AskReply
+}
+
+func (PermissionAskMsg) isMsg() {}
+
+// PermissionDismissMsg clears a pending permission overlay (timeout/cancel).
+type PermissionDismissMsg struct{}
+
+func (PermissionDismissMsg) isMsg() {}

--- a/internal/tui/permission_ask.go
+++ b/internal/tui/permission_ask.go
@@ -1,0 +1,405 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/layout"
+	"github.com/pulseaiclub/phi/internal/permission"
+	"github.com/pulseaiclub/xui"
+)
+
+// AskReply mirrors Amp's confirmation response for a gated tool.
+type AskReply struct {
+	Approved        bool
+	Feedback        string
+	AllowSession    bool // Allow All for This Session
+	AllowPersistent bool // Allow All for Every Session
+}
+
+type askOption int
+
+const (
+	askOptApprove askOption = iota
+	askOptAllowSession
+	askOptAllowPersistent
+	askOptDenyFeedback
+)
+
+var askOptionLabels = []string{
+	"Approve",
+	"Allow All for This Session",
+	"Allow All for Every Session",
+	"Deny with feedback",
+}
+
+// permAskState is Amp-style ConfirmationSelect: replaces the chat composer.
+type permAskState struct {
+	req    permission.Request
+	reason string
+	reply  chan AskReply
+
+	header       string
+	detail       string // command / path / url
+	selected     int
+	feedbackMode bool
+	feedback     string
+	feedbackCur  int
+}
+
+func formatAskHeader(req permission.Request) (header, detail string) {
+	switch req.Action {
+	case permission.ActionBash:
+		cmd := req.Command
+		lines := strings.Split(cmd, "\n")
+		if len(lines) > 3 {
+			cmd = strings.Join(lines[:3], "\n") + "\n..."
+		}
+		return "Run this command?", cmd
+	case permission.ActionEdit:
+		path := ""
+		if len(req.Paths) > 0 {
+			path = req.Paths[0]
+		}
+		return "Allow editing file:", path
+	case permission.ActionWrite:
+		path := ""
+		if len(req.Paths) > 0 {
+			path = req.Paths[0]
+		}
+		return "Allow creating file:", path
+	case permission.ActionFetch:
+		return "Allow fetching URL?", req.URL
+	default:
+		return fmt.Sprintf("Invoke tool %s?", req.Tool), permission.Summarize(req)
+	}
+}
+
+func newPermAskState(req permission.Request, reason string, reply chan AskReply) *permAskState {
+	h, d := formatAskHeader(req)
+	return &permAskState{
+		req:      req,
+		reason:   reason,
+		reply:    reply,
+		header:   h,
+		detail:   d,
+		selected: 0,
+	}
+}
+
+func (editor *Editor) beginPermissionAsk(msg PermissionAskMsg) {
+	if editor.permAsk != nil {
+		editor.resolvePermission(AskReply{})
+	}
+	editor.hideCompleters()
+	if editor.palette.Open {
+		editor.palette.Hide()
+	}
+	editor.permAsk = newPermAskState(msg.Request, msg.Reason, msg.Reply)
+	editor.activity.Apply(ActivityAwaitingApproval)
+	// Steal focus from Chat so ↑↓ reach handlePermissionKey (Chat would Consume them).
+	if editor.App != nil {
+		editor.App.RequestFocus(editor)
+	}
+}
+
+func (editor *Editor) resolvePermission(r AskReply) {
+	st := editor.permAsk
+	if st == nil {
+		return
+	}
+	editor.permAsk = nil
+	if editor.activity.Current == ActivityAwaitingApproval {
+		editor.activity.Apply(ActivityTools)
+	}
+	if editor.App != nil {
+		editor.App.RequestFocus(&editor.Chat)
+	}
+	if st.reply != nil {
+		select {
+		case st.reply <- r:
+		default:
+		}
+	}
+}
+
+func (editor *Editor) handlePermissionKey(ctx *components.EventContext, e xui.KeyEvent) bool {
+	st := editor.permAsk
+	if st == nil || !e.Press {
+		return false
+	}
+
+	if st.feedbackMode {
+		return editor.handlePermissionFeedbackKey(ctx, e)
+	}
+
+	// Amp: Alt+1..Alt+4 select option directly.
+	if e.Mods.Has(xui.ModAlt) && e.Code == xui.KeyRune && e.Rune >= '1' && e.Rune <= '9' {
+		idx := int(e.Rune - '1')
+		if idx < len(askOptionLabels) {
+			editor.acceptPermissionOption(askOption(idx))
+			ctx.ConsumeAndRedraw()
+			return true
+		}
+	}
+
+	switch e.Code {
+	case xui.KeyEscape:
+		editor.resolvePermission(AskReply{})
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyUp:
+		if st.selected > 0 {
+			st.selected--
+		} else {
+			st.selected = len(askOptionLabels) - 1
+		}
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyDown, xui.KeyTab:
+		st.selected = (st.selected + 1) % len(askOptionLabels)
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyEnter:
+		editor.acceptPermissionOption(askOption(st.selected))
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyRune:
+		if e.Mods.Has(xui.ModCtrl) || e.Mods.Has(xui.ModAlt) {
+			ctx.ConsumeAndRedraw()
+			return true
+		}
+		switch e.Rune {
+		case 'k', 'K':
+			if st.selected > 0 {
+				st.selected--
+			}
+			ctx.ConsumeAndRedraw()
+			return true
+		case 'j', 'J':
+			st.selected = (st.selected + 1) % len(askOptionLabels)
+			ctx.ConsumeAndRedraw()
+			return true
+		}
+	}
+	ctx.ConsumeAndRedraw()
+	return true
+}
+
+func (editor *Editor) acceptPermissionOption(opt askOption) {
+	st := editor.permAsk
+	if st == nil {
+		return
+	}
+	switch opt {
+	case askOptApprove:
+		editor.resolvePermission(AskReply{Approved: true})
+	case askOptAllowSession:
+		editor.resolvePermission(AskReply{Approved: true, AllowSession: true})
+	case askOptAllowPersistent:
+		editor.resolvePermission(AskReply{Approved: true, AllowPersistent: true})
+	case askOptDenyFeedback:
+		st.feedbackMode = true
+		st.feedback = ""
+		st.feedbackCur = 0
+	}
+}
+
+func (editor *Editor) handlePermissionFeedbackKey(ctx *components.EventContext, e xui.KeyEvent) bool {
+	st := editor.permAsk
+	if st == nil {
+		return false
+	}
+	switch e.Code {
+	case xui.KeyEscape:
+		st.feedbackMode = false
+		st.feedback = ""
+		st.feedbackCur = 0
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyEnter:
+		fb := strings.TrimSpace(st.feedback)
+		editor.resolvePermission(AskReply{Feedback: fb})
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyBackspace:
+		runes := []rune(st.feedback)
+		if st.feedbackCur > 0 && st.feedbackCur <= len(runes) {
+			st.feedback = string(append(runes[:st.feedbackCur-1], runes[st.feedbackCur:]...))
+			st.feedbackCur--
+		}
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyLeft:
+		if st.feedbackCur > 0 {
+			st.feedbackCur--
+		}
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyRight:
+		if st.feedbackCur < len([]rune(st.feedback)) {
+			st.feedbackCur++
+		}
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyRune:
+		if e.Mods.Has(xui.ModCtrl) || e.Mods.Has(xui.ModAlt) {
+			ctx.ConsumeAndRedraw()
+			return true
+		}
+		runes := []rune(st.feedback)
+		ch := string(e.Rune)
+		st.feedback = string(append(runes[:st.feedbackCur], append([]rune(ch), runes[st.feedbackCur:]...)...))
+		st.feedbackCur++
+		ctx.ConsumeAndRedraw()
+		return true
+	}
+	ctx.ConsumeAndRedraw()
+	return true
+}
+
+// preferredAskHeight estimates rows needed for the bottom confirmation panel.
+func (st *permAskState) preferredAskHeight(width int, method xui.WidthMethod) int {
+	if st == nil {
+		return 8
+	}
+	innerW := width - 4
+	if innerW < 20 {
+		innerW = 20
+	}
+	h := 2 // top/bottom border
+	h++    // header
+	if st.detail != "" {
+		h += strings.Count(st.detail, "\n") + 1
+	}
+	if st.reason != "" {
+		h++
+	}
+	h++ // blank
+	if st.feedbackMode {
+		h += 3 // denied line + input + hint
+	} else {
+		h += len(askOptionLabels)
+		h++ // navigate hint
+	}
+	h++ // padding
+	if h < 8 {
+		h = 8
+	}
+	_ = method
+	_ = innerW
+	return h
+}
+
+// drawPermissionAsk draws Amp-style confirmation in the composer slot (full width).
+func (editor *Editor) drawPermissionAsk(ctx components.DrawContext, width, height int) components.Surface {
+	st := editor.permAsk
+	if st == nil {
+		return components.NewSurface(width, height, nil)
+	}
+	th := editor.theme
+	if width <= 0 {
+		width = 80
+	}
+	if height <= 0 {
+		height = st.preferredAskHeight(width, ctx.Method)
+	}
+	innerW := width - 4
+	if innerW < 10 {
+		innerW = width
+	}
+
+	warn := th.Warning
+	primary := th.Success // Amp uses primary for selection; Phi Success is the accent green/cyan
+	if th.ToolName.Fg.Kind != 0 {
+		primary = th.ToolName
+	}
+
+	var body []components.RichLine
+	body = append(body, components.WrapSpans([]components.Span{
+		{Text: st.header, Style: th.Foreground},
+	}, innerW, ctx.Method)...)
+
+	if st.detail != "" {
+		detailLines := strings.Split(st.detail, "\n")
+		for i, line := range detailLines {
+			var spans []components.Span
+			if i == 0 && st.req.Action == permission.ActionBash {
+				spans = []components.Span{
+					{Text: "$ ", Style: xui.Style{Bold: true, Fg: th.Success.Fg}},
+					{Text: line, Style: th.Foreground},
+				}
+			} else if st.req.Action == permission.ActionBash {
+				spans = []components.Span{{Text: "  " + line, Style: th.Foreground}}
+			} else {
+				spans = []components.Span{{Text: line, Style: xui.Style{Bold: true, Fg: th.Foreground.Fg}}}
+			}
+			body = append(body, components.WrapSpans(spans, innerW, ctx.Method)...)
+		}
+	}
+	if st.reason != "" {
+		body = append(body, components.WrapSpans([]components.Span{
+			{Text: "(" + st.reason + ")", Style: th.Muted},
+		}, innerW, ctx.Method)...)
+	}
+
+	body = append(body, components.RichLine{})
+
+	if st.feedbackMode {
+		body = append(body, components.WrapSpans([]components.Span{
+			{Text: "✗ ", Style: th.Destructive},
+			{Text: "Denied", Style: xui.Style{Bold: true, Fg: th.Destructive.Fg}},
+			{Text: " — tell Phi what to do instead", Style: th.Muted},
+		}, innerW, ctx.Method)...)
+		runes := []rune(st.feedback)
+		if st.feedbackCur > len(runes) {
+			st.feedbackCur = len(runes)
+		}
+		shown := string(runes[:st.feedbackCur]) + "▎" + string(runes[st.feedbackCur:])
+		body = append(body, components.WrapSpans([]components.Span{
+			{Text: "› ", Style: xui.Style{Bold: true, Fg: primary.Fg}},
+			{Text: shown, Style: th.Foreground},
+		}, innerW, ctx.Method)...)
+		body = append(body, components.WrapSpans([]components.Span{
+			{Text: "Enter send  •  Esc cancel", Style: th.Muted},
+		}, innerW, ctx.Method)...)
+	} else {
+		for i, label := range askOptionLabels {
+			sel := i == st.selected
+			arrow := " "
+			dot := "○"
+			labelSt := th.Foreground
+			dotSt := th.Muted
+			if sel {
+				arrow = "▸"
+				dot = "●"
+				labelSt = xui.Style{Bold: true, Fg: primary.Fg}
+				dotSt = primary
+			}
+			shortcut := fmt.Sprintf(" [Alt+%d]", i+1)
+			body = append(body, components.WrapSpans([]components.Span{
+				{Text: arrow, Style: primary},
+				{Text: dot, Style: dotSt},
+				{Text: " " + label, Style: labelSt},
+				{Text: shortcut, Style: th.Muted},
+			}, innerW, ctx.Method)...)
+		}
+		body = append(body, components.WrapSpans([]components.Span{
+			{Text: "↑↓ navigate • Enter select • Esc cancel", Style: th.Muted},
+		}, innerW, ctx.Method)...)
+	}
+
+	panel := components.NewSurface(width, height, nil)
+	border := warn
+	layout.DrawRoundedBorder(&panel, layout.BorderRounded, border, nil, nil, nil, nil, ctx.Method)
+	y := 1
+	for _, line := range body {
+		if y >= height-1 {
+			break
+		}
+		components.PaintSpans(&panel, 2, y, line, ctx.Method)
+		y++
+	}
+	return panel
+}

--- a/internal/tui/permission_ask_test.go
+++ b/internal/tui/permission_ask_test.go
@@ -1,0 +1,100 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/permission"
+)
+
+func TestResolvePermissionSendsReply(t *testing.T) {
+	editor := &Editor{theme: components.DefaultTheme(), activity: NewActivityHandler(nil)}
+	reply := make(chan AskReply, 1)
+	editor.beginPermissionAsk(PermissionAskMsg{
+		Request: permission.Request{Action: permission.ActionBash, Tool: "bash", Command: "curl x"},
+		Reason:  "needs approval",
+		Reply:   reply,
+	})
+	if editor.permAsk == nil {
+		t.Fatal("expected permAsk")
+	}
+	if editor.permAsk.header != "Run this command?" {
+		t.Fatalf("header=%q", editor.permAsk.header)
+	}
+	if editor.activity.Current != ActivityAwaitingApproval {
+		t.Fatalf("activity=%v", editor.activity.Current)
+	}
+	editor.resolvePermission(AskReply{Approved: true})
+	if editor.permAsk != nil {
+		t.Fatal("expected cleared")
+	}
+	select {
+	case r := <-reply:
+		if !r.Approved {
+			t.Fatal("want approved")
+		}
+	default:
+		t.Fatal("expected reply")
+	}
+}
+
+func TestPermissionDenyWithFeedback(t *testing.T) {
+	editor := &Editor{theme: components.DefaultTheme(), activity: NewActivityHandler(nil)}
+	reply := make(chan AskReply, 1)
+	editor.beginPermissionAsk(PermissionAskMsg{
+		Request: permission.Request{Tool: "fetch", Action: permission.ActionFetch, URL: "https://x"},
+		Reply:   reply,
+	})
+	editor.acceptPermissionOption(askOptDenyFeedback)
+	if editor.permAsk == nil || !editor.permAsk.feedbackMode {
+		t.Fatal("expected feedback mode")
+	}
+	editor.permAsk.feedback = "use docs instead"
+	editor.resolvePermission(AskReply{Feedback: editor.permAsk.feedback})
+	r := <-reply
+	if r.Approved || r.Feedback != "use docs instead" {
+		t.Fatalf("got %+v", r)
+	}
+}
+
+func TestPermissionDismissClearsOverlay(t *testing.T) {
+	editor := &Editor{theme: components.DefaultTheme(), activity: NewActivityHandler(nil)}
+	reply := make(chan AskReply, 1)
+	editor.beginPermissionAsk(PermissionAskMsg{
+		Request: permission.Request{Tool: "fetch", Action: permission.ActionFetch, URL: "https://x"},
+		Reply:   reply,
+	})
+	editor.Update(PermissionDismissMsg{})
+	if editor.permAsk != nil {
+		t.Fatal("overlay should clear without consuming reply")
+	}
+	select {
+	case <-reply:
+		t.Fatal("dismiss must not send on reply")
+	default:
+	}
+}
+
+func TestDrawPermissionAskReplacesComposerSlot(t *testing.T) {
+	editor := &Editor{theme: components.DefaultTheme(), activity: NewActivityHandler(nil)}
+	reply := make(chan AskReply, 1)
+	editor.beginPermissionAsk(PermissionAskMsg{
+		Request: permission.Request{Action: permission.ActionBash, Tool: "bash", Command: "rm -f todo.list"},
+		Reason:  "Matches built-in permissions rule",
+		Reply:   reply,
+	})
+	surf := editor.drawPermissionAsk(components.DrawContext{
+		Max:    components.Size{Width: 60, Height: 12},
+		Method: 0,
+	}, 60, 12)
+	if surf.Size.Width != 60 || surf.Size.Height != 12 {
+		t.Fatalf("size=%v", surf.Size)
+	}
+}
+
+func TestFormatAskHeader(t *testing.T) {
+	h, d := formatAskHeader(permission.Request{Action: permission.ActionWrite, Paths: []string{"/tmp/a"}})
+	if h != "Allow creating file:" || d != "/tmp/a" {
+		t.Fatalf("%q %q", h, d)
+	}
+}


### PR DESCRIPTION
fix #3 

Add a permission layer that intercepts tool calls before they run:

- New internal/permission package: policy parsing, rule matching, request extraction, and a configurable Gate returning Allow/Deny/Ask
- Default policy: safe bash allowlist (git status, go test, ls, cat...) plus denylist for dangerous commands (sudo, recursive/forced rm, shell-piped curl/wget, mkfs, dd, fork bombs)
- Executor checks each tool call before execution; denied/rejected calls return the reason as the tool result so the model can self-correct
- Amp-style TUI confirmation dialog with user feedback, session-wide "allow all", and persistent dangerously-allow-all stored in config
- Config parser gains a permissions: block (mode, bash allow/deny, fetch allowed hosts, ask timeout); controller wires gate + asker into engine, including on model switch and session resume

Tests cover rule matching, gate decisions, and the ask UI.