### PR TITLE
feat(config): add multi-model support and `phi config` HTML editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,22 @@ fulfill your requests.
 
 ## Configuration
 
-phi reads `~/.phi/config.yaml` (a small, line-based YAML subset — no external
-YAML dependency). Environment variables override it for one-off runs.
+phi reads `~/.phi/config.yaml` (standard YAML). Environment variables
+override it for one-off runs. `phi config` opens an HTML editor for the same
+file in your browser.
 
 ```yaml
 # ~/.phi/config.yaml
-primary_model:
-  name: gpt-4o            # model name; "claude-*" routes to the Anthropic API
-  api_key: sk-...         # or set PHI_API_KEY
-  base_url: https://api.openai.com/v1   # default; PHI_BASE_URL overrides
-  context_window: 128000  # optional
+models:
+  - name: gpt-4o            # model name; "claude-*" routes to the Anthropic API
+    api_key: sk-...         # or set PHI_API_KEY
+    base_url: https://api.openai.com/v1   # default; PHI_BASE_URL overrides
+    context_window: 128000  # optional
+    default: true           # the model used at startup; first entry wins if absent
+  - name: claude-sonnet-4-20250514   # extra models; switchable at runtime
+    api_key: sk-ant-...
+    base_url: https://api.anthropic.com
+    context_window: 200000
 
 skill_path: ~/.phi/skills # where SKILL.md files are loaded from
 
@@ -72,9 +78,9 @@ Environment overrides:
 
 | Variable         | Overrides          |
 | ---------------- | ------------------ |
-| `PHI_API_KEY`    | `primary_model.api_key` |
-| `PHI_MODEL`      | `primary_model.name` |
-| `PHI_BASE_URL`   | `primary_model.base_url` |
+| `PHI_API_KEY`    | `models[].api_key` (default model) |
+| `PHI_MODEL`      | `models[].name` (default model) |
+| `PHI_BASE_URL`   | `models[].base_url` (default model) |
 | `PHI_SKILL_PATH` | `skill_path`       |
 
 Provider routing: a base URL containing `anthropic` or a model name starting

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulseaiclub/phi/internal/project"
+)
+
+//go:embed config.html
+var configHTML []byte
+
+// configDoc is the document served to / accepted from the config editor.
+// The yaml tags mirror internal/project's fileConfig so the page round-trips
+// config.yaml losslessly for every key the parser understands; the json tags
+// drive the editor API. Pointer fields preserve "key absent" across saves so
+// untouched sections are never rewritten.
+type configDoc struct {
+	Path        string     `yaml:"-" json:"path,omitempty"`
+	Models      []modelDoc `yaml:"models" json:"models"`
+	SkillPath   *string    `yaml:"skill_path,omitempty" json:"skillPath,omitempty"`
+	Permissions *permDoc   `yaml:"permissions,omitempty" json:"permissions,omitempty"`
+}
+
+type modelDoc struct {
+	Name          string `yaml:"name" json:"name"`
+	APIKey        string `yaml:"api_key" json:"apiKey"`
+	BaseURL       string `yaml:"base_url" json:"baseUrl"`
+	ContextWindow *int   `yaml:"context_window,omitempty" json:"contextWindow,omitempty"`
+	Default       bool   `yaml:"default,omitempty" json:"default"`
+}
+
+type permDoc struct {
+	Mode                *string   `yaml:"mode,omitempty" json:"mode,omitempty"`
+	WorkspaceOnlyWrites *bool     `yaml:"workspace_only_writes,omitempty" json:"workspaceOnlyWrites,omitempty"`
+	AskTimeoutSec       *int      `yaml:"ask_timeout_sec,omitempty" json:"askTimeoutSec,omitempty"`
+	DangerouslyAllowAll *bool     `yaml:"dangerously_allow_all,omitempty" json:"dangerouslyAllowAll,omitempty"`
+	Bash                *bashDoc  `yaml:"bash,omitempty" json:"bash,omitempty"`
+	Fetch               *fetchDoc `yaml:"fetch,omitempty" json:"fetch,omitempty"`
+}
+
+type bashDoc struct {
+	Default *string  `yaml:"default,omitempty" json:"default,omitempty"`
+	Allow   []string `yaml:"allow" json:"allow,omitempty"`
+	Deny    []string `yaml:"deny" json:"deny,omitempty"`
+}
+
+type fetchDoc struct {
+	Default      *string  `yaml:"default,omitempty" json:"default,omitempty"`
+	AllowedHosts []string `yaml:"allowed_hosts" json:"allowedHosts,omitempty"`
+}
+
+// configCmd starts a local web server (loopback only) that edits config.yaml
+// in the browser.
+func configCmd(args []string) int {
+	for _, a := range args {
+		if a == "-h" || a == "--help" {
+			fmt.Fprintln(os.Stdout, "usage: phi config\n\nOpen the HTML config editor (starts a local web server on 127.0.0.1).")
+			return ExitOK
+		}
+	}
+	proj := project.GetDefaultProject()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "phi config:", err)
+		return ExitError
+	}
+	addr := ln.Addr().(*net.TCPAddr)
+	url := fmt.Sprintf("http://127.0.0.1:%d/", addr.Port)
+	fmt.Fprintf(os.Stderr, "phi config: %s\n  config: %s\n  Ctrl-C to stop\n", url, proj.Global().ConfigFile())
+	openBrowser(url)
+
+	srv := &http.Server{Handler: &configHandler{configPath: proj.Global().ConfigFile()}}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	errc := make(chan error, 1)
+	go func() { errc <- srv.Serve(ln) }()
+	select {
+	case err := <-errc:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			fmt.Fprintln(os.Stderr, "phi config:", err)
+			return ExitError
+		}
+	case <-ctx.Done():
+		srv.Close()
+	}
+	return ExitOK
+}
+
+// configHandler serves the embedded editor page and its /api/config endpoints.
+type configHandler struct {
+	configPath string
+}
+
+func (h *configHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/":
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(configHTML)
+	case "/api/config":
+		h.handleConfig(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *configHandler) handleConfig(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		doc, err := readConfigDoc(h.configPath)
+		if err != nil {
+			writeConfigErr(w, http.StatusInternalServerError, err)
+			return
+		}
+		doc.Path = h.configPath
+		writeConfigJSON(w, doc)
+	case http.MethodPost:
+		var doc configDoc
+		if err := json.NewDecoder(r.Body).Decode(&doc); err != nil {
+			writeConfigErr(w, http.StatusBadRequest, fmt.Errorf("bad request: %w", err))
+			return
+		}
+		if err := validateConfigDoc(&doc); err != nil {
+			writeConfigErr(w, http.StatusBadRequest, err)
+			return
+		}
+		if err := writeConfigDoc(h.configPath, &doc); err != nil {
+			writeConfigErr(w, http.StatusInternalServerError, err)
+			return
+		}
+		writeConfigJSON(w, map[string]string{"status": "saved"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// readConfigDoc loads the current config file into the editor document. A
+// missing file yields an empty document so the page can bootstrap a config.
+func readConfigDoc(path string) (*configDoc, error) {
+	doc := &configDoc{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return doc, nil
+		}
+		return nil, err
+	}
+	if err := yaml.Unmarshal(data, doc); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+func validateConfigDoc(doc *configDoc) error {
+	if len(doc.Models) == 0 {
+		return fmt.Errorf("at least one model is required")
+	}
+	hasDefault := false
+	for i := range doc.Models {
+		m := &doc.Models[i]
+		if m.Name == "" {
+			return fmt.Errorf("model %d has no name", i+1)
+		}
+		if !m.Default {
+			continue
+		}
+		if hasDefault {
+			return fmt.Errorf("only one model may be marked default")
+		}
+		hasDefault = true
+		if m.APIKey == "" {
+			return fmt.Errorf("default model %q is missing api_key", m.Name)
+		}
+	}
+	if !hasDefault {
+		doc.Models[0].Default = true
+		if doc.Models[0].APIKey == "" {
+			return fmt.Errorf("default model %q is missing api_key", doc.Models[0].Name)
+		}
+	}
+	return nil
+}
+
+// writeConfigDoc backs up the current file and writes the document as YAML.
+func writeConfigDoc(path string, doc *configDoc) error {
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	if cur, err := os.ReadFile(path); err == nil {
+		if err := os.WriteFile(path+".bak", cur, 0o644); err != nil {
+			return fmt.Errorf("backup config: %w", err)
+		}
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func writeConfigJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func writeConfigErr(w http.ResponseWriter, status int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+}
+
+// openBrowser best-effort opens the editor URL in the default browser.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	default:
+		return
+	}
+	_ = cmd.Start()
+}

--- a/cmd/config.html
+++ b/cmd/config.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>phi config</title>
+<style>
+  :root { color-scheme: dark; }
+  body { font-family: system-ui, -apple-system, sans-serif; background: #14161a; color: #e6e6e6; margin: 0; padding: 24px; max-width: 980px; }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .08em; color: #9aa4b2; margin: 24px 0 8px; }
+  .path { color: #9aa4b2; font-size: 12px; margin-bottom: 4px; }
+  .card { background: #1d2128; border: 1px solid #2a2f3a; border-radius: 8px; padding: 12px; margin-top: 8px; }
+  .row { display: flex; gap: 8px; align-items: flex-end; flex-wrap: wrap; padding: 10px 0; border-bottom: 1px solid #262b34; }
+  .row:last-child { border-bottom: none; }
+  .f { display: flex; flex-direction: column; gap: 4px; }
+  .f label { font-size: 11px; color: #9aa4b2; }
+  .grow { flex: 1; min-width: 140px; }
+  input, select, textarea { background: #14161a; color: #e6e6e6; border: 1px solid #333a46; border-radius: 4px; padding: 6px 8px; font-size: 13px; }
+  input:focus, select:focus, textarea:focus { outline: 1px solid #4a9eff; }
+  textarea { font-family: ui-monospace, Menlo, monospace; width: 100%; min-height: 64px; resize: vertical; box-sizing: border-box; }
+  label.check { font-size: 13px; color: #e6e6e6; display: inline-flex; align-items: center; gap: 6px; margin-right: 16px; }
+  button { background: #2a2f3a; color: #e6e6e6; border: 1px solid #3a4250; border-radius: 4px; padding: 6px 12px; font-size: 13px; cursor: pointer; }
+  button:hover { background: #333a46; }
+  button.primary { background: #2f6fed; border-color: #2f6fed; padding: 8px 20px; font-size: 14px; }
+  button.danger { background: transparent; border-color: #6b3b3b; color: #e08a8a; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 16px; }
+  #status { margin-top: 12px; font-size: 13px; }
+  #status.ok { color: #7bc47f; }
+  #status.err { color: #e08a8a; white-space: pre-wrap; }
+  .block { margin-top: 12px; padding-top: 12px; border-top: 1px dashed #2a2f3a; }
+</style>
+</head>
+<body>
+<h1>phi config</h1>
+<div class="path" id="path"></div>
+
+<section>
+  <h2>Models</h2>
+  <div class="card" id="models"></div>
+  <button id="add" style="margin-top:8px">+ Add model</button>
+</section>
+
+<section>
+  <h2>General</h2>
+  <div class="card">
+    <div class="f" style="max-width:480px">
+      <label>skill_path (directory of SKILL.md files to load; leave empty for default)</label>
+      <input id="skillPath" placeholder="~/.phi/skills">
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2>Permissions</h2>
+  <div class="card">
+    <div class="grid2">
+      <div class="f">
+        <label>mode</label>
+        <select id="mode">
+          <option value="interactive">interactive</option>
+          <option value="readonly">readonly</option>
+          <option value="autopilot">autopilot</option>
+          <option value="headless-strict">headless-strict</option>
+        </select>
+      </div>
+      <div class="f">
+        <label>ask_timeout_sec (seconds)</label>
+        <input id="askTimeout" type="number" min="1">
+      </div>
+    </div>
+    <div style="margin-top:10px">
+      <label class="check"><input id="wow" type="checkbox"> workspace_only_writes</label>
+      <label class="check"><input id="daa" type="checkbox"> dangerously_allow_all</label>
+    </div>
+  </div>
+
+  <div class="card">
+    <label class="check"><input id="bashOn" type="checkbox"> Custom bash rules</label>
+    <div id="bashBody" class="block" style="display:none">
+      <div class="grid2">
+        <div class="f">
+          <label>bash.default</label>
+          <select id="bashDefault">
+            <option value="ask">ask</option>
+            <option value="allow">allow</option>
+            <option value="deny">deny</option>
+          </select>
+        </div>
+        <div></div>
+        <div class="f"><label>bash.allow (one regex per line)</label><textarea id="bashAllow" placeholder="go test ./..."></textarea></div>
+        <div class="f"><label>bash.deny (one regex per line)</label><textarea id="bashDeny" placeholder="rm -rf *"></textarea></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <label class="check"><input id="fetchOn" type="checkbox"> Custom fetch rules</label>
+    <div id="fetchBody" class="block" style="display:none">
+      <div class="grid2">
+        <div class="f">
+          <label>fetch.default</label>
+          <select id="fetchDefault">
+            <option value="ask">ask</option>
+            <option value="allow">allow</option>
+            <option value="deny">deny</option>
+          </select>
+        </div>
+        <div class="f"><label>fetch.allowed_hosts (one host per line)</label><textarea id="fetchHosts" placeholder="github.com"></textarea></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<button class="primary" id="save" style="margin-top:16px">Save config</button>
+<div id="status">Note: saving rewrites config.yaml (auto-backup to config.yaml.bak)</div>
+
+<script>
+"use strict";
+const $ = id => document.getElementById(id);
+
+let orig = null;
+const modelRows = [];
+const dirty = { mode: false, askTimeout: false, wow: false, daa: false, skillPath: false, bash: false, fetch: false };
+
+function el(tag, attrs, ...kids) {
+  const e = document.createElement(tag);
+  for (const k in attrs || {}) e.setAttribute(k, attrs[k]);
+  for (const k of kids) { if (typeof k === "string") e.appendChild(document.createTextNode(k)); else if (k) e.appendChild(k); }
+  return e;
+}
+function cell(label, inputEl, grow) {
+  const c = el("div", { class: "f" + (grow ? " grow" : "") }, el("label", null, label), inputEl);
+  return c;
+}
+function splitLines(s) { return (s || "").split("\n").map(x => x.trim()).filter(Boolean); }
+
+function addModelRow(m) {
+  const name = el("input", { placeholder: "model name, e.g. deepseek-chat" });
+  const key = el("input", { placeholder: "api_key" });
+  const base = el("input", { placeholder: "base_url, e.g. https://api.deepseek.com" });
+  const ctx = el("input", { type: "number", min: "1", placeholder: "optional" });
+  const def = el("input", { type: "radio", name: "def" });
+  if (m) {
+    if (m.name) name.value = m.name;
+    if (m.apiKey) key.value = m.apiKey;
+    if (m.baseUrl) base.value = m.baseUrl;
+    if (m.contextWindow) ctx.value = m.contextWindow;
+    if (m.default) def.checked = true;
+  }
+  const rm = el("button", { class: "danger" }, "Remove");
+  const row = { name, key, base, ctx, def, dom: null };
+  row.dom = el("div", { class: "row" },
+    el("label", { class: "check", title: "Default model" }, def, "default"),
+    cell("name", name, true),
+    cell("api_key", key, true),
+    cell("base_url", base, true),
+    cell("context_window", ctx),
+    rm,
+  );
+  rm.onclick = () => {
+    row.dom.remove();
+    const i = modelRows.indexOf(row);
+    if (i >= 0) modelRows.splice(i, 1);
+  };
+  modelRows.push(row);
+  $("models").appendChild(row.dom);
+}
+
+function setStatus(text, ok) {
+  const s = $("status");
+  s.className = ok ? "ok" : "err";
+  s.textContent = text;
+}
+
+async function load() {
+  const res = await fetch("/api/config");
+  const doc = await res.json();
+  if (!res.ok) { setStatus(doc.error || "Failed to load", false); return; }
+  orig = doc;
+  $("path").textContent = "config: " + (doc.path || "");
+
+  $("models").innerHTML = "";
+  modelRows.length = 0;
+  if (doc.models && doc.models.length) doc.models.forEach(addModelRow);
+  else addModelRow(null);
+
+  const p = doc.permissions || {};
+  $("skillPath").value = doc.skillPath || "";
+  $("mode").value = p.mode || "interactive";
+  $("askTimeout").value = p.askTimeoutSec != null ? p.askTimeoutSec : 120;
+  $("wow").checked = p.workspaceOnlyWrites != null ? p.workspaceOnlyWrites : true;
+  $("daa").checked = p.dangerouslyAllowAll != null ? p.dangerouslyAllowAll : false;
+
+  const b = p.bash || {};
+  $("bashOn").checked = !!p.bash;
+  $("bashDefault").value = b.default || "ask";
+  $("bashAllow").value = (b.allow || []).join("\n");
+  $("bashDeny").value = (b.deny || []).join("\n");
+  $("bashBody").style.display = $("bashOn").checked ? "" : "none";
+
+  const f = p.fetch || {};
+  $("fetchOn").checked = !!p.fetch;
+  $("fetchDefault").value = f.default || "ask";
+  $("fetchHosts").value = (f.allowedHosts || []).join("\n");
+  $("fetchBody").style.display = $("fetchOn").checked ? "" : "none";
+
+  for (const k in dirty) dirty[k] = false;
+  setStatus("Loaded. Saving rewrites config.yaml (auto-backup to config.yaml.bak)", true);
+}
+
+function buildPayload() {
+  const p = orig && orig.permissions || {};
+  const payload = {
+    models: modelRows.map(r => ({
+      name: r.name.value.trim(),
+      apiKey: r.key.value.trim(),
+      baseUrl: r.base.value.trim(),
+      contextWindow: r.ctx.value ? parseInt(r.ctx.value, 10) : null,
+      default: r.def.checked,
+    })),
+    skillPath: dirty.skillPath ? ($("skillPath").value.trim() || null) : (p.skillPath ?? null),
+    permissions: {
+      mode: dirty.mode ? $("mode").value : (p.mode ?? null),
+      workspaceOnlyWrites: dirty.wow ? $("wow").checked : (p.workspaceOnlyWrites ?? null),
+      askTimeoutSec: dirty.askTimeout ? (parseInt($("askTimeout").value, 10) || null) : (p.askTimeoutSec ?? null),
+      dangerouslyAllowAll: dirty.daa ? $("daa").checked : (p.dangerouslyAllowAll ?? null),
+    },
+  };
+  if (orig && orig.permissions && orig.permissions.bash && !dirty.bash) {
+    payload.permissions.bash = orig.permissions.bash;
+  } else if ($("bashOn").checked) {
+    payload.permissions.bash = {
+      default: $("bashDefault").value || null,
+      allow: splitLines($("bashAllow").value),
+      deny: splitLines($("bashDeny").value),
+    };
+  }
+  if (orig && orig.permissions && orig.permissions.fetch && !dirty.fetch) {
+    payload.permissions.fetch = orig.permissions.fetch;
+  } else if ($("fetchOn").checked) {
+    payload.permissions.fetch = {
+      default: $("fetchDefault").value || null,
+      allowedHosts: splitLines($("fetchHosts").value),
+    };
+  }
+  return payload;
+}
+
+async function save() {
+  setStatus("Saving…", true);
+  const res = await fetch("/api/config", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(buildPayload()),
+  });
+  const body = await res.json();
+  if (!res.ok) { setStatus("Save failed:\n" + (body.error || ""), false); return; }
+  setStatus("Saved ✓", true);
+  await load();
+}
+
+// --- wiring ---
+$("add").onclick = () => addModelRow(null);
+$("save").onclick = save;
+
+const wire = (id, key, evt) => $(id).addEventListener(evt || "input", () => { dirty[key] = true; });
+wire("mode", "mode", "change");
+wire("askTimeout", "askTimeout");
+wire("wow", "wow", "change");
+wire("daa", "daa", "change");
+wire("skillPath", "skillPath");
+
+function wireBlock(onId, bodyId, key, ...fieldIds) {
+  const on = $(onId);
+  const body = $(bodyId);
+  const show = () => { body.style.display = on.checked ? "" : "none"; dirty[key] = true; };
+  on.addEventListener("change", () => { dirty[key] = true; show(); });
+  for (const id of fieldIds) $(id).addEventListener("input", () => { if (!on.checked) { on.checked = true; } dirty[key] = true; show(); });
+  // keep the block visible even when untouched so the user sees it exists
+}
+wireBlock("bashOn", "bashBody", "bash", "bashDefault", "bashAllow", "bashDeny");
+wireBlock("fetchOn", "fetchBody", "fetch", "fetchDefault", "fetchHosts");
+
+load();
+</script>
+</body>
+</html>

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pulseaiclub/phi/internal/project"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const configUIFixture = `models:
+  - name: model-a
+    api_key: key-a
+    base_url: https://a.example/v1
+    context_window: 1000
+    default: true
+  - name: model-b
+    api_key: key-b
+    base_url: https://b.example/v1
+permissions:
+  mode: readonly
+  dangerously_allow_all: true
+  bash:
+    default: ask
+    allow:
+      - "^git "
+`
+
+func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	phiDir := filepath.Join(home, ".phi")
+	require.NoError(t, os.MkdirAll(phiDir, 0o755))
+	path := filepath.Join(phiDir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(configUIFixture), 0o644))
+
+	h := &configHandler{configPath: path}
+
+	// GET serves the current document.
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/config", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var got configDoc
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	require.Len(t, got.Models, 2)
+	assert.Equal(t, "model-a", got.Models[0].Name)
+	assert.True(t, got.Models[0].Default)
+	require.NotNil(t, got.Permissions)
+	require.NotNil(t, got.Permissions.Bash)
+	assert.Equal(t, []string{"^git "}, got.Permissions.Bash.Allow)
+	assert.Equal(t, path, got.Path)
+
+	// Edit: drop model-b and change the api_key, keep permissions untouched.
+	got.Models = got.Models[:1]
+	got.Models[0].APIKey = "new-key"
+	body, err := json.Marshal(got)
+	require.NoError(t, err)
+
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The app must be able to load the written file with the same results.
+	t.Setenv("HOME", home)
+	p, err := project.Discover("")
+	require.NoError(t, err)
+	require.NoError(t, p.LoadConfig())
+	cfg := p.Config()
+	require.Len(t, cfg.Models, 1)
+	assert.Equal(t, "model-a", cfg.Model().Name)
+	assert.Equal(t, "new-key", cfg.Model().APIKey)
+	assert.Equal(t, "readonly", string(cfg.Permissions.Mode))
+	assert.True(t, cfg.Permissions.DangerouslyAllowAll)
+	assert.Equal(t, []string{"^git "}, cfg.Permissions.BashAllow)
+
+	// The previous file content is kept as a backup.
+	bak, err := os.ReadFile(path + ".bak")
+	require.NoError(t, err)
+	assert.Contains(t, string(bak), "model-b")
+}
+
+func TestConfigHandlerMissingFile(t *testing.T) {
+	h := &configHandler{configPath: filepath.Join(t.TempDir(), "nope.yaml")}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/config", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var doc configDoc
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &doc))
+	assert.Empty(t, doc.Models)
+}
+
+func TestConfigHandlerValidation(t *testing.T) {
+	h := &configHandler{configPath: filepath.Join(t.TempDir(), "config.yaml")}
+
+	cases := []struct {
+		name string
+		doc  configDoc
+	}{
+		{"no models", configDoc{}},
+		{"default missing api_key", configDoc{Models: []modelDoc{{Name: "m"}}}},
+		{"two defaults", configDoc{Models: []modelDoc{{Name: "a", APIKey: "k", Default: true}, {Name: "b", APIKey: "k", Default: true}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(tc.doc)
+			require.NoError(t, err)
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+	}
+
+	// A minimal valid document saves and marks the first model default.
+	doc := configDoc{Models: []modelDoc{{Name: "m", APIKey: "k"}}}
+	body, err := json.Marshal(doc)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	data, err := os.ReadFile(h.configPath)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "default: true")
+	require.Contains(t, string(data), "name: m")
+}
+
+func TestConfigHandlerServesPage(t *testing.T) {
+	h := &configHandler{configPath: filepath.Join(t.TempDir(), "config.yaml")}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "phi 配置")
+	assert.Contains(t, rr.Body.String(), "/api/config")
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,8 @@ func main() {
 			os.Exit(runCmd(os.Args[2:]))
 		case "sessions":
 			os.Exit(sessionsCmd(os.Args[2:]))
+		case "config":
+			os.Exit(configCmd(os.Args[2:]))
 		case "tui":
 			runTUI()
 			return
@@ -74,6 +76,7 @@ func printMainUsage(w *os.File) {
 
   phi                start the interactive TUI
   phi tui            start the interactive TUI
+  phi config         open the HTML config editor (local web server)
   phi run -p "..."   run one agent loop headlessly (see 'phi run --help')
   phi sessions list  list persisted sessions for this directory
 `)

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/pulseaiclub/xui v0.1.0
 	github.com/stretchr/testify v1.11.1
 	github.com/yuin/goldmark v1.8.5
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2/v2 v2.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pulseaiclub/phi/internal/tools"
 )
 
-// Engine drives the agent loop: stream → tools → stream…
+// ErrMaxRounds Engine drives the agent loop: stream → tools → stream…
 // and yields session.Event for the TUI reducer. Context compaction is owned
 // here so Session stays a thin message store.
 // ErrMaxRounds is returned (wrapped) by Loop when the model exceeds the
@@ -42,8 +42,8 @@ type Engine struct {
 type EngineOpts struct {
 	Model       llm.ModelConfig
 	SessionOpts SessionOpts
-	Gate        permission.Gate     // nil = allow all
-	Ask         permission.AskFunc  // nil = deny on Ask
+	Gate        permission.Gate    // nil = allow all
+	Ask         permission.AskFunc // nil = deny on Ask
 }
 
 // NewEngine wires an LLM client, tool executor, and session store.

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -1,49 +1,101 @@
 package project
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/permission"
 )
 
 // Config is the project-level configuration loaded from ~/.phi/config.yaml.
-// It keeps the primary model separate from agent-wide settings such as the
-// skill directory (mirroring panda's project.Config).
+// All models live in one flat list under the models key; DefaultModel names
+// the entry used to start sessions (empty → the first entry).
 type Config struct {
-	PrimaryModel llm.ModelConfig
+	Models       []llm.ModelConfig
+	DefaultModel string // name of the default model; "" → first entry
 	SkillPath    string
 	Permissions  permission.Policy
 }
 
-// Model returns the primary model config with the skill path applied, ready
+// Model returns the default model config with the skill path applied, ready
 // for agent.NewEngine.
 func (c *Config) Model() llm.ModelConfig {
-	m := c.PrimaryModel
+	m := *c.defaultEntry()
 	if m.SkillPath == "" {
 		m.SkillPath = c.SkillPath
 	}
 	return m
 }
 
+// AllModels returns every configured model with the skill path applied — the
+// complete set of switchable models.
+func (c *Config) AllModels() []llm.ModelConfig {
+	all := make([]llm.ModelConfig, len(c.Models))
+	copy(all, c.Models)
+	for i := range all {
+		if all[i].SkillPath == "" {
+			all[i].SkillPath = c.SkillPath
+		}
+	}
+	return all
+}
+
+// FindModel returns the configured model whose name matches, so callers can
+// switch to it with its own api_key/base_url/context_window.
+func (c *Config) FindModel(name string) (llm.ModelConfig, bool) {
+	for _, m := range c.AllModels() {
+		if m.Name == name {
+			return m, true
+		}
+	}
+	return llm.ModelConfig{}, false
+}
+
+// defaultEntry returns the default model entry (DefaultModel by name, else
+// the first entry), creating one if the config has no models yet so env-only
+// setups can still apply PHI_* overrides.
+func (c *Config) defaultEntry() *llm.ModelConfig {
+	if c.DefaultModel != "" {
+		for i := range c.Models {
+			if c.Models[i].Name == c.DefaultModel {
+				return &c.Models[i]
+			}
+		}
+	}
+	if len(c.Models) > 0 {
+		return &c.Models[0]
+	}
+	c.Models = append(c.Models, llm.ModelConfig{})
+	return &c.Models[0]
+}
+
 // loadConfig reads the config file, applies environment overrides, and fills
 // in defaults. A missing file yields a zero Config so env-only setups work.
 func loadConfig(global GlobalLayout) (*Config, error) {
-	cfg := parseConfigFile(global.ConfigFile())
+	cfg, err := parseConfigFile(global.ConfigFile())
+	if err != nil {
+		return nil, err
+	}
 	applyEnvOverrides(cfg)
 
-	if cfg.PrimaryModel.APIKey == "" {
-		return nil, fmt.Errorf("missing api_key (set PHI_API_KEY or primary_model.api_key in %s)", global.ConfigFile())
+	if len(cfg.Models) == 0 {
+		return nil, fmt.Errorf("missing models (add at least one model in %s)", global.ConfigFile())
 	}
-	if cfg.PrimaryModel.Name == "" {
-		return nil, fmt.Errorf("missing model name (set PHI_MODEL or primary_model.name in %s)", global.ConfigFile())
+	def := cfg.defaultEntry()
+	if def.Name == "" {
+		return nil, fmt.Errorf("missing model name (set PHI_MODEL or models[].name in %s)", global.ConfigFile())
 	}
-	if cfg.PrimaryModel.BaseURL == "" {
-		cfg.PrimaryModel.BaseURL = "https://api.openai.com/v1"
+	if def.APIKey == "" {
+		return nil, fmt.Errorf("missing api_key (set PHI_API_KEY or models[].api_key in %s)", global.ConfigFile())
+	}
+	for i := range cfg.Models {
+		if cfg.Models[i].BaseURL == "" {
+			cfg.Models[i].BaseURL = "https://api.openai.com/v1"
+		}
 	}
 	if cfg.SkillPath == "" {
 		cfg.SkillPath = global.SkillsDir()
@@ -51,190 +103,139 @@ func loadConfig(global GlobalLayout) (*Config, error) {
 	return cfg, nil
 }
 
-// parseConfigFile reads primary_model, skill_path, and permissions with a tiny
-// line scanner so we don't need a YAML dependency. Missing file → zero Config
-// with DefaultPolicy for permissions.
-func parseConfigFile(path string) *Config {
+// parseConfigFile reads models, skill_path, and permissions from the YAML
+// config file. A missing file yields a zero Config with DefaultPolicy for
+// permissions; a malformed file is an error so bad config never silently
+// degrades to defaults.
+func parseConfigFile(path string) (*Config, error) {
 	cfg := &Config{Permissions: permission.DefaultPolicy()}
-	f, err := os.Open(path)
+
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return cfg
+		return cfg, nil
 	}
-	defer f.Close()
 
-	const (
-		blockNone = iota
-		blockPrimary
-		blockPerm
-	)
-	block := blockNone
-	// Within permissions: "" | "bash" | "fetch" | "bash.allow" | "bash.deny" | "fetch.allowed_hosts"
-	permSub := ""
-	permHad := false
+	// Pointer fields distinguish "key absent" from "zero value", so per-key
+	// defaults (and permission.DefaultPolicy) survive decoding and are only
+	// overridden by keys that are actually present.
+	var raw fileConfig
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
 
-	sc := bufio.NewScanner(f)
-	for sc.Scan() {
-		line := sc.Text()
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			continue
+	for _, m := range raw.Models {
+		mc := modelEntryToConfig(m)
+		if m.Default && cfg.DefaultModel == "" {
+			cfg.DefaultModel = mc.Name
 		}
+		cfg.Models = append(cfg.Models, mc)
+	}
+	if raw.SkillPath != nil {
+		cfg.SkillPath = *raw.SkillPath
+	}
+	if raw.Permissions != nil {
+		applyPermissions(&cfg.Permissions, raw.Permissions)
+	}
+	return cfg, nil
+}
 
-		indent := countIndent(line)
-
-		if indent == 0 {
-			block = blockNone
-			permSub = ""
-			if strings.HasPrefix(trimmed, "skill_path:") {
-				_, val, ok := splitYAMLKV(trimmed)
-				if ok {
-					cfg.SkillPath = val
-				}
-				continue
-			}
-			if strings.HasPrefix(trimmed, "primary_model:") {
-				block = blockPrimary
-				continue
-			}
-			if strings.HasPrefix(trimmed, "permissions:") {
-				block = blockPerm
-				if !permHad {
-					cfg.Permissions = permission.DefaultPolicy()
-					permHad = true
-				}
-				continue
-			}
-			continue
-		}
-
-		switch block {
-		case blockPrimary:
-			if indent < 1 {
-				continue
-			}
-			key, val, ok := splitYAMLKV(trimmed)
-			if !ok {
-				continue
-			}
-			switch key {
-			case "name":
-				cfg.PrimaryModel.Name = val
-			case "api_key":
-				cfg.PrimaryModel.APIKey = val
-			case "base_url":
-				cfg.PrimaryModel.BaseURL = val
-			case "context_window":
-				if n, err := strconv.Atoi(val); err == nil && n > 0 {
-					cfg.PrimaryModel.ContextWindow = n
-				}
-			}
-
-		case blockPerm:
-			parsePermissionsLine(cfg, &permSub, indent, trimmed)
-		}
+func modelEntryToConfig(m modelEntry) llm.ModelConfig {
+	cfg := llm.ModelConfig{Name: m.Name, APIKey: m.APIKey, BaseURL: m.BaseURL}
+	if m.ContextWindow != nil && *m.ContextWindow > 0 {
+		cfg.ContextWindow = *m.ContextWindow
 	}
 	return cfg
 }
 
-func parsePermissionsLine(cfg *Config, permSub *string, indent int, trimmed string) {
-	// List item
-	if strings.HasPrefix(trimmed, "- ") {
-		item := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
-		item = strings.Trim(item, `"'`)
-		switch *permSub {
-		case "bash.allow":
-			cfg.Permissions.BashAllow = append(cfg.Permissions.BashAllow, item)
-		case "bash.deny":
-			cfg.Permissions.BashDeny = append(cfg.Permissions.BashDeny, item)
-		case "fetch.allowed_hosts":
-			cfg.Permissions.FetchAllowedHosts = append(cfg.Permissions.FetchAllowedHosts, item)
-		}
-		return
-	}
+// fileConfig mirrors the YAML keys in ~/.phi/config.yaml.
+type fileConfig struct {
+	Models      []modelEntry `yaml:"models"`
+	SkillPath   *string      `yaml:"skill_path"`
+	Permissions *permConfig  `yaml:"permissions"`
+}
 
-	key, val, ok := splitYAMLKV(trimmed)
-	if !ok {
-		return
-	}
+type modelEntry struct {
+	Name          string `yaml:"name"`
+	APIKey        string `yaml:"api_key"`
+	BaseURL       string `yaml:"base_url"`
+	ContextWindow *int   `yaml:"context_window"`
+	Default       bool   `yaml:"default"`
+}
 
-	// Section headers / keys under permissions
-	switch {
-	case indent == 1 && key == "bash":
-		*permSub = "bash"
-		return
-	case indent == 1 && key == "fetch":
-		*permSub = "fetch"
-		return
-	case indent == 1:
-		*permSub = ""
-		switch key {
-		case "mode":
-			cfg.Permissions.Mode = permission.Mode(val)
-		case "workspace_only_writes":
-			cfg.Permissions.WorkspaceOnlyWrites = parseBool(val, true)
-		case "ask_timeout_sec":
-			if n, err := strconv.Atoi(val); err == nil && n > 0 {
-				cfg.Permissions.AskTimeoutSec = n
-			}
-		case "dangerously_allow_all":
-			cfg.Permissions.DangerouslyAllowAll = parseBool(val, false)
-		}
-		return
-	case *permSub == "bash" && indent >= 2:
-		switch key {
-		case "default":
-			cfg.Permissions.BashDefault = parseDecision(val, permission.Ask)
-		case "allow":
-			*permSub = "bash.allow"
-			cfg.Permissions.BashAllow = nil // replace defaults when explicitly set
-			if val != "" && val != "[]" {
-				cfg.Permissions.BashAllow = append(cfg.Permissions.BashAllow, strings.Trim(val, `"'`))
-			}
-		case "deny":
-			*permSub = "bash.deny"
-			cfg.Permissions.BashDeny = nil
-			if val != "" && val != "[]" {
-				cfg.Permissions.BashDeny = append(cfg.Permissions.BashDeny, strings.Trim(val, `"'`))
-			}
-		}
-		return
-	case *permSub == "fetch" && indent >= 2:
-		switch key {
-		case "default":
-			cfg.Permissions.FetchDefault = parseDecision(val, permission.Ask)
-		case "allowed_hosts":
-			*permSub = "fetch.allowed_hosts"
-			cfg.Permissions.FetchAllowedHosts = nil
-			if val != "" && val != "[]" {
-				cfg.Permissions.FetchAllowedHosts = append(cfg.Permissions.FetchAllowedHosts, strings.Trim(val, `"'`))
-			}
-		}
-		return
-	case strings.HasPrefix(*permSub, "bash.") && indent == 2:
-		// Leaving a list for another bash key
-		switch key {
-		case "default":
-			*permSub = "bash"
-			cfg.Permissions.BashDefault = parseDecision(val, permission.Ask)
-		case "allow":
-			*permSub = "bash.allow"
-			cfg.Permissions.BashAllow = nil
-		case "deny":
-			*permSub = "bash.deny"
-			cfg.Permissions.BashDeny = nil
-		}
-		return
-	case strings.HasPrefix(*permSub, "fetch.") && indent == 2:
-		switch key {
-		case "default":
-			*permSub = "fetch"
-			cfg.Permissions.FetchDefault = parseDecision(val, permission.Ask)
-		case "allowed_hosts":
-			*permSub = "fetch.allowed_hosts"
-			cfg.Permissions.FetchAllowedHosts = nil
-		}
-		return
+type permConfig struct {
+	Mode                permission.Mode `yaml:"mode"`
+	WorkspaceOnlyWrites *bool           `yaml:"workspace_only_writes"`
+	AskTimeoutSec       *int            `yaml:"ask_timeout_sec"`
+	DangerouslyAllowAll *bool           `yaml:"dangerously_allow_all"`
+	Bash                *bashConfig     `yaml:"bash"`
+	Fetch               *fetchConfig    `yaml:"fetch"`
+}
+
+type bashConfig struct {
+	Default *string     `yaml:"default"`
+	Allow   *stringList `yaml:"allow"`
+	Deny    *stringList `yaml:"deny"`
+}
+
+type fetchConfig struct {
+	Default      *string     `yaml:"default"`
+	AllowedHosts *stringList `yaml:"allowed_hosts"`
+}
+
+// applyPermissions merges the file's permissions block over DefaultPolicy.
+// An explicitly set list (even an empty one) replaces the default list.
+func applyPermissions(p *permission.Policy, raw *permConfig) {
+	if raw.Mode != "" {
+		p.Mode = raw.Mode
 	}
+	if raw.WorkspaceOnlyWrites != nil {
+		p.WorkspaceOnlyWrites = *raw.WorkspaceOnlyWrites
+	}
+	if raw.AskTimeoutSec != nil && *raw.AskTimeoutSec > 0 {
+		p.AskTimeoutSec = *raw.AskTimeoutSec
+	}
+	if raw.DangerouslyAllowAll != nil {
+		p.DangerouslyAllowAll = *raw.DangerouslyAllowAll
+	}
+	if b := raw.Bash; b != nil {
+		if b.Default != nil {
+			p.BashDefault = parseDecision(*b.Default, p.BashDefault)
+		}
+		if b.Allow != nil {
+			p.BashAllow = *b.Allow
+		}
+		if b.Deny != nil {
+			p.BashDeny = *b.Deny
+		}
+	}
+	if f := raw.Fetch; f != nil {
+		if f.Default != nil {
+			p.FetchDefault = parseDecision(*f.Default, p.FetchDefault)
+		}
+		if f.AllowedHosts != nil {
+			p.FetchAllowedHosts = *f.AllowedHosts
+		}
+	}
+}
+
+// stringList accepts either a single YAML scalar or a sequence, so both
+// `allow: "go test ./..."` and the block list form in the README work.
+type stringList []string
+
+func (s *stringList) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		*s = stringList{node.Value}
+	case yaml.SequenceNode:
+		items := make(stringList, 0, len(node.Content))
+		for _, n := range node.Content {
+			items = append(items, n.Value)
+		}
+		*s = items
+	default:
+		return fmt.Errorf("expected a string or a list of strings")
+	}
+	return nil
 }
 
 func countIndent(line string) int {
@@ -252,17 +253,6 @@ func countIndent(line string) int {
 	return n / 2
 }
 
-func parseBool(val string, def bool) bool {
-	switch strings.ToLower(strings.TrimSpace(val)) {
-	case "true", "yes", "1":
-		return true
-	case "false", "no", "0":
-		return false
-	default:
-		return def
-	}
-}
-
 func parseDecision(val string, def permission.Decision) permission.Decision {
 	switch strings.ToLower(strings.TrimSpace(val)) {
 	case "allow":
@@ -278,28 +268,18 @@ func parseDecision(val string, def permission.Decision) permission.Decision {
 
 func applyEnvOverrides(c *Config) {
 	if v := firstEnv("PHI_API_KEY"); v != "" {
-		c.PrimaryModel.APIKey = v
+		c.defaultEntry().APIKey = v
 	}
 	if v := firstEnv("PHI_BASE_URL"); v != "" {
-		c.PrimaryModel.BaseURL = v
+		c.defaultEntry().BaseURL = v
 	}
 	if v := firstEnv("PHI_MODEL"); v != "" {
-		c.PrimaryModel.Name = v
+		c.defaultEntry().Name = v
+		c.DefaultModel = v
 	}
 	if v := firstEnv("PHI_SKILL_PATH"); v != "" {
 		c.SkillPath = v
 	}
-}
-
-func splitYAMLKV(line string) (key, val string, ok bool) {
-	i := strings.IndexByte(line, ':')
-	if i < 0 {
-		return "", "", false
-	}
-	key = strings.TrimSpace(line[:i])
-	val = strings.TrimSpace(line[i+1:])
-	val = strings.Trim(val, `"'`)
-	return key, val, key != ""
 }
 
 func firstEnv(keys ...string) string {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -38,17 +38,17 @@ func TestDiscoverCreatesGlobalDirs(t *testing.T) {
 func TestLoadConfigDefaults(t *testing.T) {
 	p := discoverInTempHome(t)
 	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
-primary_model:
-  name: deepseek-chat
-  api_key: sk-test
+models:
+  - name: deepseek-chat
+    api_key: sk-test
 `), 0o644))
 
 	require.NoError(t, p.LoadConfig())
 	cfg := p.Config()
 
-	assert.Equal(t, "deepseek-chat", cfg.PrimaryModel.Name)
-	assert.Equal(t, "sk-test", cfg.PrimaryModel.APIKey)
-	assert.Equal(t, "https://api.openai.com/v1", cfg.PrimaryModel.BaseURL)
+	assert.Equal(t, "deepseek-chat", cfg.Model().Name)
+	assert.Equal(t, "sk-test", cfg.Model().APIKey)
+	assert.Equal(t, "https://api.openai.com/v1", cfg.Model().BaseURL)
 	assert.Equal(t, p.Global().SkillsDir(), cfg.SkillPath)
 	// Model() carries the skill path for agent.NewEngine.
 	assert.Equal(t, p.Global().SkillsDir(), cfg.Model().SkillPath)
@@ -57,9 +57,9 @@ primary_model:
 func TestLoadConfigEnvOverrides(t *testing.T) {
 	p := discoverInTempHome(t)
 	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
-primary_model:
-  name: file-model
-  api_key: file-key
+models:
+  - name: file-model
+    api_key: file-key
 skill_path: /from/file
 `), 0o644))
 
@@ -70,15 +70,15 @@ skill_path: /from/file
 
 	require.NoError(t, p.LoadConfig())
 	cfg := p.Config()
-	assert.Equal(t, "env-model", cfg.PrimaryModel.Name)
-	assert.Equal(t, "env-key", cfg.PrimaryModel.APIKey)
-	assert.Equal(t, "https://env.example/v1", cfg.PrimaryModel.BaseURL)
+	assert.Equal(t, "env-model", cfg.Model().Name)
+	assert.Equal(t, "env-key", cfg.Model().APIKey)
+	assert.Equal(t, "https://env.example/v1", cfg.Model().BaseURL)
 	assert.Equal(t, "/from/env", cfg.SkillPath)
 }
 
 func TestLoadConfigMissingAPIKey(t *testing.T) {
 	p := discoverInTempHome(t)
-	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte("primary_model:\n  name: x\n"), 0o644))
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte("models:\n  - name: x\n"), 0o644))
 	t.Setenv("PHI_API_KEY", "")
 
 	err := p.LoadConfig()
@@ -93,16 +93,16 @@ func TestLoadConfigConfigFileMissing(t *testing.T) {
 	t.Setenv("PHI_API_KEY", "env-key")
 
 	require.NoError(t, p.LoadConfig())
-	assert.Equal(t, "env-model", p.Config().PrimaryModel.Name)
+	assert.Equal(t, "env-model", p.Config().Model().Name)
 	assert.Equal(t, "interactive", string(p.Config().Permissions.Mode))
 }
 
 func TestLoadConfigPermissions(t *testing.T) {
 	p := discoverInTempHome(t)
 	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
-primary_model:
-  name: m
-  api_key: k
+models:
+  - name: m
+    api_key: k
 permissions:
   mode: headless-strict
   ask_timeout_sec: 30
@@ -110,9 +110,9 @@ permissions:
   bash:
     default: ask
     allow:
-      - "^echo\b"
+      - '^echo\b'
     deny:
-      - "\bsudo\b"
+      - '\bsudo\b'
   fetch:
     default: ask
     allowed_hosts:
@@ -126,4 +126,101 @@ permissions:
 	assert.Equal(t, []string{`^echo\b`}, perm.BashAllow)
 	assert.Equal(t, []string{`\bsudo\b`}, perm.BashDeny)
 	assert.Equal(t, []string{"docs.github.com"}, perm.FetchAllowedHosts)
+}
+
+func TestLoadConfigScalarOrInlineListForms(t *testing.T) {
+	// The old line scanner only understood block lists (and treated an inline
+	// sequence as one literal string); real YAML handles scalar and flow forms.
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
+models:
+  - name: m
+    api_key: k
+permissions:
+  bash:
+    allow: "go test ./..."
+    deny: ['rm -rf', 'sudo']
+  fetch:
+    allowed_hosts: ["github.com", docs.github.com]
+`), 0o644))
+
+	require.NoError(t, p.LoadConfig())
+	perm := p.Config().Permissions
+	assert.Equal(t, []string{"go test ./..."}, perm.BashAllow)
+	assert.Equal(t, []string{"rm -rf", "sudo"}, perm.BashDeny)
+	assert.Equal(t, []string{"github.com", "docs.github.com"}, perm.FetchAllowedHosts)
+}
+
+func TestLoadConfigInvalidYAML(t *testing.T) {
+	// A malformed config must fail loudly instead of silently degrading to
+	// defaults (the old line scanner ignored malformed lines).
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(
+		"models:\n  - name: m\n    api_key: k\npermissions: [unclosed\n",
+	), 0o644))
+
+	require.Error(t, p.LoadConfig())
+}
+
+func TestLoadConfigModelsFlat(t *testing.T) {
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
+models:
+  - name: p
+    api_key: pk
+    base_url: https://primary.example/v1
+    context_window: 1000
+    default: true
+  - name: a1
+    api_key: ak1
+    base_url: https://a1.example/v1
+  - name: a2
+    api_key: ak2
+    base_url: https://a2.example/v1
+    context_window: 2000
+`), 0o644))
+
+	require.NoError(t, p.LoadConfig())
+	cfg := p.Config()
+	require.Len(t, cfg.Models, 3)
+	assert.Equal(t, "p", cfg.Models[0].Name)
+	assert.Equal(t, "ak1", cfg.Models[1].APIKey)
+	assert.Equal(t, 2000, cfg.Models[2].ContextWindow)
+	assert.Equal(t, "p", cfg.DefaultModel)
+
+	// Model() returns the entry marked default, with the skill path applied.
+	m := cfg.Model()
+	assert.Equal(t, "p", m.Name)
+	assert.Equal(t, p.Global().SkillsDir(), m.SkillPath)
+
+	// Models() lists every entry with the skill path applied.
+	models := cfg.AllModels()
+	require.Len(t, models, 3)
+	for _, mm := range models {
+		assert.Equal(t, p.Global().SkillsDir(), mm.SkillPath)
+	}
+
+	// FindModel returns the full per-model connection config.
+	a2, ok := cfg.FindModel("a2")
+	require.True(t, ok)
+	assert.Equal(t, "https://a2.example/v1", a2.BaseURL)
+	_, ok = cfg.FindModel("nope")
+	assert.False(t, ok)
+}
+
+func TestLoadConfigDefaultFallsBackToFirst(t *testing.T) {
+	// No entry marked default → the first entry wins.
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
+models:
+  - name: first
+    api_key: k1
+  - name: second
+    api_key: k2
+`), 0o644))
+
+	require.NoError(t, p.LoadConfig())
+	cfg := p.Config()
+	assert.Equal(t, "", cfg.DefaultModel)
+	assert.Equal(t, "first", cfg.Model().Name)
 }

--- a/internal/tui/controller.go
+++ b/internal/tui/controller.go
@@ -153,8 +153,13 @@ func (c *Controller) SetModel(name string) error {
 	if err := proj.LoadConfig(); err != nil {
 		return err
 	}
-	cfg := proj.Config().Model()
-	cfg.Name = name
+	cfg, ok := proj.Config().FindModel(name)
+	if !ok {
+		// Not a configured model: keep the primary's connection settings and
+		// only swap the name (arbitrary-model workflow).
+		cfg = proj.Config().Model()
+		cfg.Name = name
+	}
 	c.Cancel()
 	c.initGate(proj.Config().Permissions)
 	if c.engine == nil {


### PR DESCRIPTION
Replace the hand-rolled line scanner with real YAML (gopkg.in/yaml.v3) and rework config around a flat models list:

- models: [...] replaces primary_model; the entry marked default: true (or the first entry) is used at startup
- AllModels/FindModel expose every configured model, so the TUI can switch to one with its own api_key/base_url/context_window
- malformed YAML now fails loudly instead of silently degrading to defaults; pointer fields keep "key absent" distinct from zero values so permission defaults survive decoding
- new `phi config` command serves a browser-based editor for ~/.phi/config.yaml with lossless YAML/JSON round-tripping

Tests and README updated to the new format.