### PR TITLE
feat(agent): load AGENTS.md/CLAUDE.md into system prompt

### DIFF
--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// contextFileCandidates are checked in order within a single directory;
+// the first readable match wins (same as pi-main).
+var contextFileCandidates = []string{
+	"AGENTS.md",
+	"AGENTS.MD",
+	"CLAUDE.md",
+	"CLAUDE.MD",
+}
+
+// ContextFile is one loaded project-instruction file.
+type ContextFile struct {
+	Path    string
+	Content string
+}
+
+// loadContextFileFromDir returns the first candidate context file in dir, or nil.
+func loadContextFileFromDir(dir string) *ContextFile {
+	for _, name := range contextFileCandidates {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		return &ContextFile{Path: path, Content: string(data)}
+	}
+	return nil
+}
+
+// loadProjectContextFiles discovers AGENTS.md / CLAUDE.md like pi-main:
+//  1. global agent dir (~/.phi) first
+//  2. then every ancestor from filesystem root down to cwd (cwd last)
+//
+// Each directory contributes at most one file. Paths are deduped.
+func loadProjectContextFiles(cwd, agentDir string) []ContextFile {
+	seen := make(map[string]struct{})
+	var out []ContextFile
+
+	add := func(f *ContextFile) {
+		if f == nil {
+			return
+		}
+		key := f.Path
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, *f)
+	}
+
+	if agentDir != "" {
+		if abs, err := filepath.Abs(agentDir); err == nil {
+			agentDir = abs
+		}
+		add(loadContextFileFromDir(agentDir))
+	}
+
+	if cwd == "" {
+		return out
+	}
+	if abs, err := filepath.Abs(cwd); err == nil {
+		cwd = abs
+	}
+
+	var ancestors []ContextFile
+	dir := cwd
+	for {
+		if f := loadContextFileFromDir(dir); f != nil {
+			if _, ok := seen[f.Path]; !ok {
+				seen[f.Path] = struct{}{}
+				ancestors = append([]ContextFile{*f}, ancestors...)
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	out = append(out, ancestors...)
+	return out
+}
+
+// formatProjectContext builds the <project_context> block for the system prompt.
+func formatProjectContext(files []ContextFile) string {
+	if len(files) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("<project_context>\n\n")
+	sb.WriteString("Project-specific instructions and guidelines:\n\n")
+	for _, f := range files {
+		sb.WriteString("<project_instructions path=\"")
+		sb.WriteString(f.Path)
+		sb.WriteString("\">\n")
+		sb.WriteString(f.Content)
+		if !strings.HasSuffix(f.Content, "\n") {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString("</project_instructions>\n\n")
+	}
+	sb.WriteString("</project_context>")
+	return sb.String()
+}
+
+func phiAgentDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".phi")
+}

--- a/internal/agent/context_test.go
+++ b/internal/agent/context_test.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadContextFileFromDirPrefersAGENTS(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "CLAUDE.md"), "claude rules")
+	mustWrite(t, filepath.Join(dir, "AGENTS.md"), "agents rules")
+
+	got := loadContextFileFromDir(dir)
+	if got == nil {
+		t.Fatal("expected a context file")
+	}
+	if got.Content != "agents rules" {
+		t.Fatalf("prefer AGENTS.md, got %q", got.Content)
+	}
+}
+
+func TestLoadContextFileFromDirFallsBackToCLAUDE(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "CLAUDE.md"), "claude only")
+
+	got := loadContextFileFromDir(dir)
+	if got == nil || got.Content != "claude only" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestLoadProjectContextFilesOrder(t *testing.T) {
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agent")
+	mid := filepath.Join(root, "proj")
+	cwd := filepath.Join(mid, "nested")
+	mustMkdir(t, agentDir)
+	mustMkdir(t, cwd)
+
+	mustWrite(t, filepath.Join(agentDir, "AGENTS.md"), "global")
+	mustWrite(t, filepath.Join(mid, "AGENTS.md"), "mid")
+	mustWrite(t, filepath.Join(cwd, "CLAUDE.md"), "cwd")
+
+	files := loadProjectContextFiles(cwd, agentDir)
+	if len(files) != 3 {
+		t.Fatalf("expected 3 files, got %d: %+v", len(files), files)
+	}
+	want := []string{"global", "mid", "cwd"}
+	for i, w := range want {
+		if files[i].Content != w {
+			t.Fatalf("files[%d]=%q want %q", i, files[i].Content, w)
+		}
+	}
+}
+
+func TestLoadProjectContextFilesDedupesAgentDir(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "AGENTS.md"), "once")
+
+	// When cwd == agentDir, only one entry should appear.
+	files := loadProjectContextFiles(dir, dir)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestFormatProjectContext(t *testing.T) {
+	got := formatProjectContext([]ContextFile{
+		{Path: "/tmp/AGENTS.md", Content: "use gofmt"},
+	})
+	if !strings.Contains(got, "<project_context>") {
+		t.Fatalf("missing wrapper: %q", got)
+	}
+	if !strings.Contains(got, `<project_instructions path="/tmp/AGENTS.md">`) {
+		t.Fatalf("missing path attr: %q", got)
+	}
+	if !strings.Contains(got, "use gofmt") {
+		t.Fatalf("missing body: %q", got)
+	}
+	if formatProjectContext(nil) != "" {
+		t.Fatal("empty files should yield empty string")
+	}
+}
+
+func TestPromptIncludesContext(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "AGENTS.md"), "always use tabs")
+
+	ctx := formatProjectContext(loadProjectContextFiles(dir, t.TempDir()))
+	if !strings.Contains(ctx, "always use tabs") {
+		t.Fatalf("expected cwd AGENTS.md in context, got %q", ctx)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -44,15 +44,19 @@ func GetWorkspaceDir() string {
 	return ""
 }
 
-// Prompt builds the system prompt. If skillPath is non-empty, skills are loaded
-// from that directory and injected into the prompt.
+// Prompt builds the system prompt. Loads AGENTS.md/CLAUDE.md (global ~/.phi +
+// cwd ancestors, same rules as pi-main) into <project_context>, then optionally
+// appends a Skills block when skillPath is non-empty.
 func Prompt(skillPath string) string {
 	base := fmt.Sprintf(systemPromptTmpl, GetCurrentDir(), GetWorkspaceDir())
-	skillBlock := loadSkillsBlock(skillPath)
-	if skillBlock == "" {
-		return base
+	parts := []string{base}
+	if ctx := formatProjectContext(loadProjectContextFiles(GetCurrentDir(), phiAgentDir())); ctx != "" {
+		parts = append(parts, ctx)
 	}
-	return base + "\n\n# Skills\n\n" + skillBlock
+	if skillBlock := loadSkillsBlock(skillPath); skillBlock != "" {
+		parts = append(parts, "# Skills\n\n"+skillBlock)
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 // loadSkillsBlock loads skills from the given directory and returns a


### PR DESCRIPTION
- Discover context files from ~/.phi and cwd ancestors (pi-main rules)
- Inject matched files as a <project_context> block before the Skills section