### PR TITLE
feat(config): improve editor UX and model discovery

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,16 +6,23 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"sort"
+	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/pulseaiclub/phi/internal/project"
+	"github.com/pulseaiclub/phi/internal/util"
 )
 
 //go:embed config.html
@@ -31,6 +38,7 @@ type configDoc struct {
 	Models      []modelDoc `yaml:"models" json:"models"`
 	SkillPath   *string    `yaml:"skill_path,omitempty" json:"skillPath,omitempty"`
 	Permissions *permDoc   `yaml:"permissions,omitempty" json:"permissions,omitempty"`
+	Agents      *agentsDoc `yaml:"agents,omitempty" json:"agents,omitempty"`
 }
 
 type modelDoc struct {
@@ -60,6 +68,34 @@ type fetchDoc struct {
 	Default      *string  `yaml:"default,omitempty" json:"default,omitempty"`
 	AllowedHosts []string `yaml:"allowed_hosts" json:"allowedHosts,omitempty"`
 }
+
+type agentsDoc struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+}
+
+type modelListRequest struct {
+	BaseURL string `json:"baseUrl"`
+	APIKey  string `json:"apiKey"`
+	Model   string `json:"model"`
+}
+
+type modelListItem struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+}
+
+type modelListResponse struct {
+	Data   []modelListItem `json:"data"`
+	Models []modelListItem `json:"models"`
+}
+
+const (
+	defaultOpenAIBaseURL  = "https://api.openai.com/v1"
+	anthropicAPIVersion   = "2023-06-01"
+	modelListRequestLimit = 15 * time.Second
+	modelListBodyLimit    = int64(4 << 20)
+)
 
 // configCmd starts a local web server (loopback only) that edits config.yaml
 // in the browser.
@@ -106,12 +142,19 @@ type configHandler struct {
 }
 
 func (h *configHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if (r.URL.Path == "/api/config" || r.URL.Path == "/api/models") && !isLoopbackHost(r.Host) {
+		writeConfigErr(w, http.StatusForbidden, errors.New("request origin is not allowed"))
+		return
+	}
+
 	switch r.URL.Path {
 	case "/":
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Write(configHTML)
 	case "/api/config":
 		h.handleConfig(w, r)
+	case "/api/models":
+		h.handleModels(w, r)
 	default:
 		http.NotFound(w, r)
 	}
@@ -128,6 +171,10 @@ func (h *configHandler) handleConfig(w http.ResponseWriter, r *http.Request) {
 		doc.Path = h.configPath
 		writeConfigJSON(w, doc)
 	case http.MethodPost:
+		if status, err := validateLocalJSONRequest(r); err != nil {
+			writeConfigErr(w, status, err)
+			return
+		}
 		var doc configDoc
 		if err := json.NewDecoder(r.Body).Decode(&doc); err != nil {
 			writeConfigErr(w, http.StatusBadRequest, fmt.Errorf("bad request: %w", err))
@@ -145,6 +192,200 @@ func (h *configHandler) handleConfig(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// handleModels fetches model IDs through the local config server so the page
+// does not need cross-origin access to a provider API.
+func (h *configHandler) handleModels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if status, err := validateLocalJSONRequest(r); err != nil {
+		writeConfigErr(w, status, err)
+		return
+	}
+
+	var input modelListRequest
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		writeConfigErr(w, http.StatusBadRequest, fmt.Errorf("bad request: %w", err))
+		return
+	}
+
+	baseURL := strings.TrimSpace(input.BaseURL)
+	apiKey := strings.TrimSpace(input.APIKey)
+	anthropic := isAnthropicModelRequest(baseURL, input.Model)
+	if baseURL == "" {
+		if anthropic {
+			baseURL = "https://api.anthropic.com"
+		} else {
+			baseURL = defaultOpenAIBaseURL
+		}
+	}
+	endpoint, err := modelListEndpoint(baseURL, anthropic)
+	if err != nil {
+		writeConfigErr(w, http.StatusBadRequest, err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), modelListRequestLimit)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		writeConfigErr(w, http.StatusBadRequest, fmt.Errorf("build model list request: %w", err))
+		return
+	}
+	request.Header.Set("Accept", "application/json")
+	if anthropic {
+		request.Header.Set("X-Api-Key", apiKey)
+		request.Header.Set("Anthropic-Version", anthropicAPIVersion)
+	} else {
+		request.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	response, err := modelListHTTPClient().Do(request)
+	if err != nil {
+		writeConfigErr(w, http.StatusBadGateway, fmt.Errorf("fetch model list: %w", err))
+		return
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, modelListBodyLimit+1))
+	if err != nil {
+		writeConfigErr(w, http.StatusBadGateway, fmt.Errorf("read model list: %w", err))
+		return
+	}
+	if int64(len(body)) > modelListBodyLimit {
+		writeConfigErr(w, http.StatusBadGateway, errors.New("model list response is too large"))
+		return
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		message := strings.TrimSpace(string(body))
+		if len(message) > 500 {
+			message = message[:500]
+		}
+		if message == "" {
+			message = response.Status
+		}
+		writeConfigErr(w, http.StatusBadGateway, fmt.Errorf("model list request failed: %s", message))
+		return
+	}
+
+	var payload modelListResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		writeConfigErr(w, http.StatusBadGateway, fmt.Errorf("decode model list: %w", err))
+		return
+	}
+	models := collectModelIDs(append(payload.Data, payload.Models...))
+	sort.Strings(models)
+	writeConfigJSON(w, struct {
+		Models []string `json:"models"`
+	}{Models: models})
+}
+
+func modelListHTTPClient() *http.Client {
+	client := *util.DefaultHTTPClient()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		origin := via[0].URL
+		if !strings.EqualFold(req.URL.Scheme, origin.Scheme) ||
+			!strings.EqualFold(req.URL.Host, origin.Host) {
+			return errors.New("model list redirect changed origin")
+		}
+		return nil
+	}
+	return &client
+}
+
+func isAnthropicModelRequest(baseURL, model string) bool {
+	return strings.Contains(strings.ToLower(baseURL), "anthropic") ||
+		strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "claude")
+}
+
+func modelListEndpoint(baseURL string, anthropic bool) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("base URL must be an absolute HTTP(S) URL")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("base URL must use http or https")
+	}
+
+	path := strings.TrimRight(u.Path, "/")
+	if !strings.HasSuffix(path, "/models") {
+		if anthropic && !strings.HasSuffix(path, "/v1") {
+			path += "/v1"
+		}
+		path += "/models"
+	}
+	u.Path = path
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+func collectModelIDs(items []modelListItem) []string {
+	seen := make(map[string]struct{}, len(items))
+	models := make([]string, 0, len(items))
+	for _, item := range items {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			id = strings.TrimSpace(item.Name)
+		}
+		if id == "" {
+			id = strings.TrimSpace(item.DisplayName)
+		}
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		models = append(models, id)
+	}
+	return models
+}
+
+// validateLocalJSONRequest requires browser POSTs to use a non-simple content
+// type and come from the config page's own origin. ServeHTTP separately checks
+// that every API request uses a loopback Host.
+func validateLocalJSONRequest(r *http.Request) (int, error) {
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return http.StatusUnsupportedMediaType, errors.New("content type must be application/json")
+	}
+	origin := r.Header.Get("Origin")
+	originURL, err := url.Parse(origin)
+	if err != nil || origin == "" || originURL.Scheme == "" || originURL.Host == "" ||
+		originURL.User != nil || originURL.Path != "" || originURL.RawQuery != "" || originURL.Fragment != "" {
+		return http.StatusForbidden, errors.New("request origin is not allowed")
+	}
+
+	expectedScheme := "http"
+	if r.TLS != nil {
+		expectedScheme = "https"
+	}
+	if !strings.EqualFold(originURL.Scheme, expectedScheme) || !strings.EqualFold(originURL.Host, r.Host) {
+		return http.StatusForbidden, errors.New("request origin is not allowed")
+	}
+	return 0, nil
+}
+
+func isLoopbackHost(rawHost string) bool {
+	u, err := url.Parse("http://" + rawHost)
+	if err != nil || u.Host != rawHost || u.User != nil || u.Path != "" {
+		return false
+	}
+	hostname := u.Hostname()
+	if strings.EqualFold(hostname, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && ip.IsLoopback()
 }
 
 // readConfigDoc loads the current config file into the editor document. A

--- a/cmd/config.html
+++ b/cmd/config.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>phi 配置中心</title>
+<title>phi config</title>
 <style>
   :root {
     color-scheme: dark;
@@ -55,7 +55,7 @@
     padding: 32px 0 48px;
   }
 
-  .page-header { padding-bottom: 28px; }
+  .page-header { padding-bottom: 16px; }
 
   .section-head,
   .panel-head,
@@ -93,14 +93,14 @@
   .brand-line {
     display: flex;
     align-items: center;
-    gap: 9px;
+    gap: 7px;
     color: var(--text-muted);
-    font-size: 13px;
+    font-size: 12px;
   }
 
   .brand {
     color: var(--text);
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 700;
   }
 
@@ -109,9 +109,9 @@
   h1, h2, h3, p { margin: 0; }
 
   h1 {
-    margin-top: 26px;
-    font-size: 30px;
-    line-height: 1.2;
+    margin-top: 12px;
+    font-size: 22px;
+    line-height: 1.25;
     letter-spacing: 0;
   }
 
@@ -139,27 +139,29 @@
   }
 
   .lede {
-    max-width: 680px;
-    margin-top: 8px;
-    font-size: 15px;
+    max-width: 640px;
+    margin-top: 4px;
+    font-size: 13px;
+    line-height: 1.45;
   }
 
   .path-strip {
     display: flex;
     align-items: baseline;
-    gap: 10px;
+    gap: 8px;
     min-width: 0;
-    margin-top: 22px;
-    padding: 11px 14px;
+    margin-top: 12px;
+    padding: 7px 10px;
     border: 1px solid var(--border);
     border-radius: 6px;
     background: var(--surface-muted);
+    font-size: 12px;
   }
 
   .path-label {
     flex: 0 0 auto;
     color: var(--text-subtle);
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 600;
   }
 
@@ -684,7 +686,7 @@
     .section-head, .panel-head, .model-card-head, .footer-inner { flex-direction: column; }
     .section-head > .button { width: 100%; }
     .dirty-state { align-self: flex-start; }
-    h1 { margin-top: 21px; font-size: 27px; }
+    h1 { margin-top: 10px; font-size: 20px; }
     .path-strip { align-items: flex-start; flex-direction: column; gap: 3px; }
     .section, .rules-section { padding: 24px 0; }
     .model-card { padding: 17px; }
@@ -702,6 +704,37 @@
     .footer-actions .button { flex: 1 0 112px; }
     .backup-note { display: none; }
   }
+
+  .header-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .lang-toggle {
+    flex: 0 0 auto;
+    min-height: 28px;
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    padding: 3px 9px;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: .02em;
+  }
+
+  .lang-toggle:not(:disabled):hover {
+    border-color: var(--blue);
+    color: var(--text);
+    background: #263347;
+  }
+
+  .lang-toggle:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
 </style>
 </head>
 <body>
@@ -711,14 +744,15 @@
       <div class="brand-line">
         <span class="brand">phi</span>
         <span class="brand-divider">/</span>
-        <span>本地配置</span>
+        <span data-i18n="brandLocal">Local config</span>
       </div>
+      <button class="lang-toggle" id="langToggle" type="button" aria-label="Switch language">中文</button>
     </div>
-    <h1>配置中心</h1>
-    <p class="lede">管理模型连接、技能目录和 Agent 权限。保存后会立即写入本地配置文件。</p>
+    <h1 data-i18n="pageTitle">Config</h1>
+    <p class="lede" data-i18n="pageLede">Manage model connections, skills path, and agent permissions. Saves write straight to the local config file.</p>
     <div class="path-strip">
-      <span class="path-label">配置文件</span>
-      <code id="path">正在加载...</code>
+      <span class="path-label" data-i18n="configFile">Config file</span>
+      <code id="path">Loading...</code>
     </div>
   </header>
 
@@ -727,12 +761,12 @@
       <div class="section-head">
         <div>
           <div class="section-title-row">
-            <h2>模型</h2>
-            <div class="section-count" id="modelCount">0 个模型</div>
+            <h2 data-i18n="modelsHeading">Models</h2>
+            <div class="section-count" id="modelCount">0 models</div>
           </div>
-          <p class="section-help">必须至少保留 1 个模型；只能设置 1 个启动模型。</p>
+          <p class="section-help" data-i18n="modelsHelp">Keep at least one model; only one can be the startup model.</p>
         </div>
-        <button class="button secondary" id="add" type="button">+ 添加模型</button>
+        <button class="button secondary" id="add" type="button" data-i18n="addModel">+ Add model</button>
       </div>
       <div class="model-list" id="models"></div>
     </section>
@@ -741,15 +775,15 @@
       <section class="panel">
         <div class="panel-head">
           <div>
-            <div class="panel-title">通用设置</div>
-            <p class="panel-help">指定技能文件的加载目录。</p>
+            <div class="panel-title" data-i18n="generalHeading">General</div>
+            <p class="panel-help" data-i18n="generalHelp">Choose where skill files are loaded from.</p>
           </div>
         </div>
         <div class="panel-body settings-fields">
           <div class="field field-full">
-            <label class="field-label" for="skillPath">技能目录</label>
-            <div class="field-help">读取其中的 <code>SKILL.md</code> 文件；留空则使用默认目录。</div>
-            <input id="skillPath" type="text" placeholder="例如 ~/.phi/skills" autocomplete="off">
+            <label class="field-label" for="skillPath" data-i18n="skillPathLabel">Skills directory</label>
+            <div class="field-help" data-i18n-html="skillPathHelp">Reads <code>SKILL.md</code> files inside; leave empty for the default path.</div>
+            <input id="skillPath" type="text" data-i18n-placeholder="skillPathPlaceholder" placeholder="e.g. ~/.phi/skills" autocomplete="off">
           </div>
         </div>
       </section>
@@ -757,41 +791,41 @@
       <section class="panel">
         <div class="panel-head">
           <div>
-            <div class="panel-title">权限模式</div>
-            <p class="panel-help">控制 Agent 执行命令、读写文件和联网请求时的行为。</p>
+            <div class="panel-title" data-i18n="permHeading">Permission mode</div>
+            <p class="panel-help" data-i18n="permHelp">Controls how the agent runs commands, reads or writes files, and makes network requests.</p>
           </div>
         </div>
         <div class="panel-body settings-fields">
           <div class="field">
-            <label class="field-label" for="mode">运行模式</label>
-            <div class="field-help">不同模式会改变需要确认的操作。</div>
+            <label class="field-label" for="mode" data-i18n="modeLabel">Run mode</label>
+            <div class="field-help" data-i18n="modeHelp">Different modes change which actions require confirmation.</div>
             <select id="mode">
-              <option value="interactive">交互确认</option>
-              <option value="readonly">只读</option>
-              <option value="autopilot">自动执行</option>
-              <option value="headless-strict">无界面严格模式</option>
+              <option value="interactive" data-i18n="modeInteractive">Interactive</option>
+              <option value="readonly" data-i18n="modeReadonly">Read-only</option>
+              <option value="autopilot" data-i18n="modeAutopilot">Autopilot</option>
+              <option value="headless-strict" data-i18n="modeHeadless">Headless strict</option>
             </select>
             <p class="mode-hint" id="modeHint"></p>
           </div>
           <div class="field">
-            <label class="field-label" for="askTimeout">审批超时 <span class="field-unit">seconds</span></label>
-            <div class="field-help">权限请求最多等待的时间。</div>
-            <input id="askTimeout" type="number" min="1" step="1" inputmode="numeric" placeholder="例如 120">
+            <label class="field-label" for="askTimeout"><span data-i18n="askTimeoutLabel">Approval timeout</span> <span class="field-unit">seconds</span></label>
+            <div class="field-help" data-i18n="askTimeoutHelp">How long permission prompts wait before timing out.</div>
+            <input id="askTimeout" type="number" min="1" step="1" inputmode="numeric" data-i18n-placeholder="askTimeoutPlaceholder" placeholder="e.g. 120">
           </div>
         </div>
         <div class="toggle-list">
           <label class="toggle-row">
             <input id="wow" type="checkbox">
             <span>
-              <span class="toggle-title">仅允许工作区写入</span>
-              <span class="toggle-help">禁止写入当前项目目录之外的文件。</span>
+              <span class="toggle-title" data-i18n="wowTitle">Workspace-only writes</span>
+              <span class="toggle-help" data-i18n="wowHelp">Block writes outside the current project directory.</span>
             </span>
           </label>
           <label class="toggle-row danger">
             <input id="daa" type="checkbox">
             <span>
-              <span class="toggle-title">跳过所有权限检查</span>
-              <span class="toggle-help">高风险设置。开启后 Agent 不会再请求操作确认。</span>
+              <span class="toggle-title" data-i18n="daaTitle">Skip all permission checks</span>
+              <span class="toggle-help" data-i18n="daaHelp">High risk. When enabled, the agent will not ask for confirmation.</span>
             </span>
           </label>
         </div>
@@ -801,8 +835,8 @@
     <section class="section rules-section">
       <div class="section-head">
         <div>
-          <h2>工具规则</h2>
-          <p class="section-help">按命令和目标主机进一步限制 Agent 的操作范围。</p>
+          <h2 data-i18n="rulesHeading">Tool rules</h2>
+          <p class="section-help" data-i18n="rulesHelp">Further limit the agent by command and destination host.</p>
         </div>
       </div>
       <div class="rules-grid">
@@ -810,30 +844,30 @@
           <label class="rule-head" for="bashOn">
             <input id="bashOn" type="checkbox">
             <span>
-              <span class="rule-title">命令执行规则</span>
-              <span class="rule-help">启用后覆盖默认的 bash 许可策略。</span>
+              <span class="rule-title" data-i18n="bashTitle">Command rules</span>
+              <span class="rule-help" data-i18n="bashHelp">When enabled, overrides the default bash policy.</span>
             </span>
           </label>
           <div class="rule-body" id="bashBody" hidden>
             <div class="field">
-              <label class="field-label" for="bashDefault">未匹配命令的策略</label>
-              <div class="field-help">默认询问、允许或拒绝。</div>
+              <label class="field-label" for="bashDefault" data-i18n="bashDefaultLabel">Unmatched command policy</label>
+              <div class="field-help" data-i18n="policyHelp">Ask, allow, or deny by default.</div>
               <select id="bashDefault">
-                <option value="ask">询问</option>
-                <option value="allow">允许</option>
-                <option value="deny">拒绝</option>
+                <option value="ask" data-i18n="policyAsk">Ask</option>
+                <option value="allow" data-i18n="policyAllow">Allow</option>
+                <option value="deny" data-i18n="policyDeny">Deny</option>
               </select>
             </div>
             <div class="field"></div>
             <div class="field field-wide">
-              <label class="field-label" for="bashAllow">允许的命令规则</label>
-              <div class="field-help">每行一条正则表达式。</div>
-              <textarea id="bashAllow" placeholder="例如 ^go test\b"></textarea>
+              <label class="field-label" for="bashAllow" data-i18n="bashAllowLabel">Allow command rules</label>
+              <div class="field-help" data-i18n="bashAllowHelp">One regular expression per line.</div>
+              <textarea id="bashAllow" data-i18n-placeholder="bashAllowPlaceholder" placeholder="e.g. ^go test\b"></textarea>
             </div>
             <div class="field field-wide">
-              <label class="field-label" for="bashDeny">拒绝的命令规则</label>
-              <div class="field-help">拒绝规则优先于允许规则。</div>
-              <textarea id="bashDeny" placeholder="例如 rm\s+-rf"></textarea>
+              <label class="field-label" for="bashDeny" data-i18n="bashDenyLabel">Deny command rules</label>
+              <div class="field-help" data-i18n="bashDenyHelp">Deny rules take priority over allow rules.</div>
+              <textarea id="bashDeny" data-i18n-placeholder="bashDenyPlaceholder" placeholder="e.g. rm\s+-rf"></textarea>
             </div>
           </div>
         </fieldset>
@@ -842,24 +876,24 @@
           <label class="rule-head" for="fetchOn">
             <input id="fetchOn" type="checkbox">
             <span>
-              <span class="rule-title">网络请求规则</span>
-              <span class="rule-help">启用后限制 fetch 工具可以访问的主机。</span>
+              <span class="rule-title" data-i18n="fetchTitle">Network rules</span>
+              <span class="rule-help" data-i18n="fetchHelp">When enabled, limits hosts the fetch tool may access.</span>
             </span>
           </label>
           <div class="rule-body" id="fetchBody" hidden>
             <div class="field">
-              <label class="field-label" for="fetchDefault">未匹配主机的策略</label>
-              <div class="field-help">默认询问、允许或拒绝。</div>
+              <label class="field-label" for="fetchDefault" data-i18n="fetchDefaultLabel">Unmatched host policy</label>
+              <div class="field-help" data-i18n="policyHelp">Ask, allow, or deny by default.</div>
               <select id="fetchDefault">
-                <option value="ask">询问</option>
-                <option value="allow">允许</option>
-                <option value="deny">拒绝</option>
+                <option value="ask" data-i18n="policyAsk">Ask</option>
+                <option value="allow" data-i18n="policyAllow">Allow</option>
+                <option value="deny" data-i18n="policyDeny">Deny</option>
               </select>
             </div>
             <div class="field field-wide">
-              <label class="field-label" for="fetchHosts">允许访问的主机</label>
-              <div class="field-help">每行一个主机名，例如 <code>github.com</code>。</div>
-              <textarea id="fetchHosts" placeholder="例如 github.com"></textarea>
+              <label class="field-label" for="fetchHosts" data-i18n="fetchHostsLabel">Allowed hosts</label>
+              <div class="field-help" data-i18n-html="fetchHostsHelp">One hostname per line, e.g. <code>github.com</code>.</div>
+              <textarea id="fetchHosts" data-i18n-placeholder="fetchHostsPlaceholder" placeholder="e.g. github.com"></textarea>
             </div>
           </div>
         </fieldset>
@@ -870,12 +904,12 @@
   <footer class="save-footer">
     <div class="footer-inner">
       <div class="save-summary">
-        <span class="dirty-state" id="dirtyState" aria-live="polite">已保存</span>
-        <div class="status loading" id="status" aria-live="polite">正在加载配置...</div>
+        <span class="dirty-state" id="dirtyState" aria-live="polite">Saved</span>
+        <div class="status loading" id="status" aria-live="polite">Loading config...</div>
       </div>
       <div class="footer-actions">
-        <div class="backup-note">自动备份为 <code>config.yaml.bak</code></div>
-        <button class="button secondary" id="save" type="button" disabled>保存配置</button>
+        <div class="backup-note" data-i18n-html="backupNote">Auto-backs up to <code>config.yaml.bak</code></div>
+        <button class="button secondary" id="save" type="button" disabled data-i18n="saveConfig">Save config</button>
       </div>
     </div>
   </footer>
@@ -884,11 +918,243 @@
 <script>
 "use strict";
 
+const LANG_KEY = "phi-config-lang";
+const I18N = {
+  en: {
+    documentTitle: "phi config",
+    brandLocal: "Local config",
+    pageTitle: "Config",
+    pageLede: "Manage model connections, skills path, and agent permissions. Saves write straight to the local config file.",
+    configFile: "Config file",
+    loadingPath: "Loading...",
+    modelsHeading: "Models",
+    modelsHelp: "Keep at least one model; only one can be the startup model.",
+    addModel: "+ Add model",
+    generalHeading: "General",
+    generalHelp: "Choose where skill files are loaded from.",
+    skillPathLabel: "Skills directory",
+    skillPathHelp: "Reads <code>SKILL.md</code> files inside; leave empty for the default path.",
+    skillPathPlaceholder: "e.g. ~/.phi/skills",
+    permHeading: "Permission mode",
+    permHelp: "Controls how the agent runs commands, reads or writes files, and makes network requests.",
+    modeLabel: "Run mode",
+    modeHelp: "Different modes change which actions require confirmation.",
+    modeInteractive: "Interactive",
+    modeReadonly: "Read-only",
+    modeAutopilot: "Autopilot",
+    modeHeadless: "Headless strict",
+    askTimeoutLabel: "Approval timeout",
+    askTimeoutHelp: "How long permission prompts wait before timing out.",
+    askTimeoutPlaceholder: "e.g. 120",
+    wowTitle: "Workspace-only writes",
+    wowHelp: "Block writes outside the current project directory.",
+    daaTitle: "Skip all permission checks",
+    daaHelp: "High risk. When enabled, the agent will not ask for confirmation.",
+    rulesHeading: "Tool rules",
+    rulesHelp: "Further limit the agent by command and destination host.",
+    bashTitle: "Command rules",
+    bashHelp: "When enabled, overrides the default bash policy.",
+    bashDefaultLabel: "Unmatched command policy",
+    policyHelp: "Ask, allow, or deny by default.",
+    policyAsk: "Ask",
+    policyAllow: "Allow",
+    policyDeny: "Deny",
+    bashAllowLabel: "Allow command rules",
+    bashAllowHelp: "One regular expression per line.",
+    bashAllowPlaceholder: "e.g. ^go test\\b",
+    bashDenyLabel: "Deny command rules",
+    bashDenyHelp: "Deny rules take priority over allow rules.",
+    bashDenyPlaceholder: "e.g. rm\\s+-rf",
+    fetchTitle: "Network rules",
+    fetchHelp: "When enabled, limits hosts the fetch tool may access.",
+    fetchDefaultLabel: "Unmatched host policy",
+    fetchHostsLabel: "Allowed hosts",
+    fetchHostsHelp: "One hostname per line, e.g. <code>github.com</code>.",
+    fetchHostsPlaceholder: "e.g. github.com",
+    backupNote: "Auto-backs up to <code>config.yaml.bak</code>",
+    saveConfig: "Save config",
+    saveChanges: "Save changes",
+    saving: "Saving",
+    saved: "Saved",
+    unsaved: "Unsaved changes",
+    switchToZh: "中文",
+    switchToEn: "English",
+    switchLangAria: "Switch language",
+    modelCount: "{n} models",
+    modelCountOne: "1 model",
+    modelNumber: "Model {n}",
+    emptyModels: "No models yet. Add one to get started.",
+    keepOneModel: "At least one model is required",
+    removeModel: "Remove this model",
+    remove: "Remove",
+    startupModel: "Startup model",
+    setStartupModel: "Set as startup model",
+    unnamedModel: "Untitled model",
+    modelName: "Model name",
+    modelNameHelp: "Type a name, or fetch the list from the current API base URL and pick one.",
+    modelNamePlaceholder: "e.g. gpt-4o",
+    apiBase: "API base URL",
+    apiBaseHelp: "OpenAI-compatible or Anthropic-compatible endpoint.",
+    apiBasePlaceholder: "e.g. https://api.openai.com/v1",
+    apiKey: "API Key",
+    apiKeyHelp: "Hidden by default; click Show to reveal temporarily.",
+    apiKeyPlaceholder: "Enter API key",
+    contextWindow: "Context window",
+    contextWindowHelp: "Maximum context length the model can handle.",
+    contextPlaceholder: "e.g. 200000",
+    fetchModels: "Fetch models",
+    fetchModelsTitle: "Fetch model list from the current API base URL",
+    selectModel: "Select a model",
+    chooseFromList: "Choose a model from the list",
+    showKey: "Show",
+    hideKey: "Hide",
+    toggleKeyTitle: "Show or hide API key",
+    fetchingModels: "Fetching model list...",
+    fetchModelsFailed: "Failed to fetch model list.",
+    fetchedModels: "Fetched {n} models.",
+    noModelsReturned: "Provider returned no models.",
+    fetchFailedPrefix: "Fetch failed: ",
+    modeHintInteractive: "Actions that need confirmation wait for approval in the TUI.",
+    modeHintReadonly: "Writes, edits, and non-allowlisted commands are denied.",
+    modeHintAutopilot: "Actions that need confirmation are auto-approved. Use with care.",
+    modeHintHeadless: "With no approval UI, actions that need confirmation are denied.",
+    statusLoading: "Loading config...",
+    statusLoaded: "Config loaded.",
+    statusLoadFailed: "Failed to load config.",
+    statusLoadFailedPrefix: "Failed to load config:\n",
+    statusSaving: "Saving...",
+    statusSaved: "Config saved. Previous file backed up.",
+    statusSavedPending: "Saved previous changes; you still have unsaved edits.",
+    statusSaveFailedPrefix: "Save failed:\n",
+    statusServerError: "The server returned an error.",
+    validateModelName: "Model {n} needs a name.",
+    validateDefaultKey: "The startup model needs an API key.",
+    validatePositiveInt: "{label} must be an integer greater than 0.",
+    validateContextLabel: "Model {n} context window",
+    validateAskTimeoutLabel: "Approval timeout",
+  },
+  zh: {
+    documentTitle: "phi 配置中心",
+    brandLocal: "本地配置",
+    pageTitle: "配置中心",
+    pageLede: "管理模型连接、技能目录和 Agent 权限。保存后会立即写入本地配置文件。",
+    configFile: "配置文件",
+    loadingPath: "正在加载...",
+    modelsHeading: "模型",
+    modelsHelp: "必须至少保留 1 个模型；只能设置 1 个启动模型。",
+    addModel: "+ 添加模型",
+    generalHeading: "通用设置",
+    generalHelp: "指定技能文件的加载目录。",
+    skillPathLabel: "技能目录",
+    skillPathHelp: "读取其中的 <code>SKILL.md</code> 文件；留空则使用默认目录。",
+    skillPathPlaceholder: "例如 ~/.phi/skills",
+    permHeading: "权限模式",
+    permHelp: "控制 Agent 执行命令、读写文件和联网请求时的行为。",
+    modeLabel: "运行模式",
+    modeHelp: "不同模式会改变需要确认的操作。",
+    modeInteractive: "交互确认",
+    modeReadonly: "只读",
+    modeAutopilot: "自动执行",
+    modeHeadless: "无界面严格模式",
+    askTimeoutLabel: "审批超时",
+    askTimeoutHelp: "权限请求最多等待的时间。",
+    askTimeoutPlaceholder: "例如 120",
+    wowTitle: "仅允许工作区写入",
+    wowHelp: "禁止写入当前项目目录之外的文件。",
+    daaTitle: "跳过所有权限检查",
+    daaHelp: "高风险设置。开启后 Agent 不会再请求操作确认。",
+    rulesHeading: "工具规则",
+    rulesHelp: "按命令和目标主机进一步限制 Agent 的操作范围。",
+    bashTitle: "命令执行规则",
+    bashHelp: "启用后覆盖默认的 bash 许可策略。",
+    bashDefaultLabel: "未匹配命令的策略",
+    policyHelp: "默认询问、允许或拒绝。",
+    policyAsk: "询问",
+    policyAllow: "允许",
+    policyDeny: "拒绝",
+    bashAllowLabel: "允许的命令规则",
+    bashAllowHelp: "每行一条正则表达式。",
+    bashAllowPlaceholder: "例如 ^go test\\b",
+    bashDenyLabel: "拒绝的命令规则",
+    bashDenyHelp: "拒绝规则优先于允许规则。",
+    bashDenyPlaceholder: "例如 rm\\s+-rf",
+    fetchTitle: "网络请求规则",
+    fetchHelp: "启用后限制 fetch 工具可以访问的主机。",
+    fetchDefaultLabel: "未匹配主机的策略",
+    fetchHostsLabel: "允许访问的主机",
+    fetchHostsHelp: "每行一个主机名，例如 <code>github.com</code>。",
+    fetchHostsPlaceholder: "例如 github.com",
+    backupNote: "自动备份为 <code>config.yaml.bak</code>",
+    saveConfig: "保存配置",
+    saveChanges: "保存修改",
+    saving: "正在保存",
+    saved: "已保存",
+    unsaved: "有未保存的修改",
+    switchToZh: "中文",
+    switchToEn: "English",
+    switchLangAria: "切换语言",
+    modelCount: "{n} 个模型",
+    modelCountOne: "1 个模型",
+    modelNumber: "模型 {n}",
+    emptyModels: "暂未配置模型，请先添加一个模型。",
+    keepOneModel: "必须至少保留一个模型",
+    removeModel: "删除此模型",
+    remove: "删除",
+    startupModel: "启动模型",
+    setStartupModel: "设为启动模型",
+    unnamedModel: "未命名模型",
+    modelName: "模型名称",
+    modelNameHelp: "可手动填写，也可以从当前 API 地址获取列表后选择。",
+    modelNamePlaceholder: "例如 gpt-4o",
+    apiBase: "API 地址",
+    apiBaseHelp: "OpenAI-compatible 或 Anthropic 兼容地址。",
+    apiBasePlaceholder: "例如 https://api.openai.com/v1",
+    apiKey: "API Key",
+    apiKeyHelp: "默认隐藏，仅在点击“显示”时临时展示。",
+    apiKeyPlaceholder: "输入 API Key",
+    contextWindow: "上下文窗口",
+    contextWindowHelp: "模型可处理的最大上下文长度。",
+    contextPlaceholder: "例如 200000",
+    fetchModels: "获取模型",
+    fetchModelsTitle: "从当前 API 地址获取模型列表",
+    selectModel: "选择模型",
+    chooseFromList: "从列表中选择模型",
+    showKey: "显示",
+    hideKey: "隐藏",
+    toggleKeyTitle: "显示或隐藏 API Key",
+    fetchingModels: "正在获取模型列表...",
+    fetchModelsFailed: "模型列表获取失败。",
+    fetchedModels: "已获取 {n} 个模型。",
+    noModelsReturned: "服务商未返回可用模型。",
+    fetchFailedPrefix: "获取失败：",
+    modeHintInteractive: "需要确认的操作会在 TUI 中等待你的批准。",
+    modeHintReadonly: "写入、编辑和未列入白名单的命令会被拒绝。",
+    modeHintAutopilot: "需要确认的操作会自动放行，请谨慎使用。",
+    modeHintHeadless: "没有确认界面，需要批准的操作会直接拒绝。",
+    statusLoading: "正在加载配置...",
+    statusLoaded: "配置已加载。",
+    statusLoadFailed: "配置加载失败。",
+    statusLoadFailedPrefix: "配置加载失败：\n",
+    statusSaving: "正在保存...",
+    statusSaved: "配置已保存，旧文件已备份。",
+    statusSavedPending: "已保存先前修改；当前仍有未保存的修改。",
+    statusSaveFailedPrefix: "保存失败：\n",
+    statusServerError: "服务器返回了错误。",
+    validateModelName: "模型 {n} 需要填写模型名称。",
+    validateDefaultKey: "启动模型需要填写 API Key。",
+    validatePositiveInt: "{label}必须是大于 0 的整数。",
+    validateContextLabel: "模型 {n} 的上下文窗口",
+    validateAskTimeoutLabel: "审批超时",
+  },
+};
+
 const $ = id => document.getElementById(id);
+let lang = detectLang();
 let orig = null;
 let modelSequence = 0;
 let saving = false;
 let changeVersion = 0;
+let statusState = { key: "statusLoading", tone: "loading", vars: null, fallback: "" };
 const modelRows = [];
 const dirty = {
   models: false,
@@ -901,6 +1167,24 @@ const dirty = {
   fetch: false,
 };
 
+function detectLang() {
+  try {
+    const saved = localStorage.getItem(LANG_KEY);
+    if (saved === "zh" || saved === "en") return saved;
+  } catch (_) {}
+  const nav = (navigator.language || "en").toLowerCase();
+  return nav.startsWith("zh") ? "zh" : "en";
+}
+
+function t(key, vars) {
+  const table = I18N[lang] || I18N.en;
+  let text = table[key] || I18N.en[key] || key;
+  if (vars) {
+    for (const name in vars) text = text.split("{" + name + "}").join(String(vars[name]));
+  }
+  return text;
+}
+
 function el(tag, attrs, ...kids) {
   const node = document.createElement(tag);
   for (const key in attrs || {}) node.setAttribute(key, attrs[key]);
@@ -911,15 +1195,15 @@ function el(tag, attrs, ...kids) {
   return node;
 }
 
-function field(labelText, helpText, control, className, labelFor, unitText, labelAction) {
-  const label = el("label", { class: "field-label" }, labelText);
+function field(labelKey, helpKey, control, className, labelFor, unitText, labelAction) {
+  const label = el("label", { class: "field-label", "data-i18n": labelKey }, t(labelKey));
   if (unitText) label.appendChild(el("span", { class: "field-unit" }, unitText));
   if (labelFor) label.setAttribute("for", labelFor);
   const labelRow = labelAction
     ? el("div", { class: "field-label-row" }, label, labelAction)
     : label;
   const body = el("div", { class: "field" + (className ? " " + className : "") }, labelRow);
-  if (helpText) body.appendChild(el("div", { class: "field-help" }, helpText));
+  if (helpKey) body.appendChild(el("div", { class: "field-help", "data-i18n": helpKey }, t(helpKey)));
   body.appendChild(control);
   return body;
 }
@@ -929,9 +1213,23 @@ function splitLines(value) {
 }
 
 function setStatus(text, tone) {
+  statusState = { key: null, tone: tone || "", vars: null, fallback: text };
   const status = $("status");
   status.className = "status " + (tone || "");
   status.textContent = text;
+}
+
+function setStatusKey(key, tone, vars) {
+  statusState = { key, tone: tone || "", vars: vars || null, fallback: "" };
+  const status = $("status");
+  status.className = "status " + (tone || "");
+  status.textContent = t(key, vars);
+}
+
+function refreshStatus() {
+  const status = $("status");
+  status.className = "status " + (statusState.tone || "");
+  status.textContent = statusState.key ? t(statusState.key, statusState.vars) : statusState.fallback;
 }
 
 function hasUnsavedChanges() {
@@ -943,11 +1241,11 @@ function updateDirtyState() {
   const button = $("save");
   const pending = hasUnsavedChanges();
   state.className = "dirty-state" + (saving ? " saving" : (pending ? " pending" : ""));
-  state.textContent = saving ? "正在保存" : (pending ? "有未保存的修改" : "已保存");
+  state.textContent = saving ? t("saving") : (pending ? t("unsaved") : t("saved"));
   button.classList.toggle("primary", pending || saving);
   button.classList.toggle("secondary", !pending && !saving);
   button.disabled = saving || !pending;
-  button.textContent = saving ? "正在保存" : (pending ? "保存修改" : "保存配置");
+  button.textContent = saving ? t("saving") : (pending ? t("saveChanges") : t("saveConfig"));
   if (saving) button.setAttribute("aria-busy", "true");
   else button.removeAttribute("aria-busy");
 }
@@ -960,23 +1258,26 @@ function markDirty(key) {
 
 function updateModeHint() {
   const hints = {
-    interactive: "需要确认的操作会在 TUI 中等待你的批准。",
-    readonly: "写入、编辑和未列入白名单的命令会被拒绝。",
-    autopilot: "需要确认的操作会自动放行，请谨慎使用。",
-    "headless-strict": "没有确认界面，需要批准的操作会直接拒绝。",
+    interactive: "modeHintInteractive",
+    readonly: "modeHintReadonly",
+    autopilot: "modeHintAutopilot",
+    "headless-strict": "modeHintHeadless",
   };
-  $("modeHint").textContent = hints[$("mode").value] || "";
+  const key = hints[$("mode").value];
+  $("modeHint").textContent = key ? t(key) : "";
 }
 
 function updateModelCount() {
   const count = modelRows.length;
-  $("modelCount").textContent = count + " 个模型";
+  $("modelCount").textContent = count === 1 ? t("modelCountOne") : t("modelCount", { n: count });
   modelRows.forEach((row, index) => {
-    row.number.textContent = "模型 " + String(index + 1).padStart(2, "0");
+    row.number.textContent = t("modelNumber", { n: String(index + 1).padStart(2, "0") });
   });
   const empty = $("emptyModels");
   if (count === 0 && !empty) {
-    $("models").appendChild(el("div", { class: "empty-models", id: "emptyModels" }, "暂未配置模型，请先添加一个模型。"));
+    $("models").appendChild(el("div", { class: "empty-models", id: "emptyModels", "data-i18n": "emptyModels" }, t("emptyModels")));
+  } else if (count === 0 && empty) {
+    empty.textContent = t("emptyModels");
   } else if (count > 0 && empty) {
     empty.remove();
   }
@@ -992,13 +1293,25 @@ function syncModelStates() {
     row.badge.hidden = !active;
     row.defaultLabel.hidden = active;
     row.remove.disabled = modelRows.length <= 1;
-    row.remove.title = row.remove.disabled ? "必须至少保留一个模型" : "删除此模型";
+    row.remove.title = row.remove.disabled ? t("keepOneModel") : t("removeModel");
+    row.remove.setAttribute("aria-label", t("removeModel"));
   }
 }
 
 function setModelFetchStatus(row, text, tone) {
+  row.fetchStatusKey = null;
+  row.fetchStatusVars = null;
+  row.fetchStatusFallback = text;
   row.fetchStatus.className = "model-fetch-status" + (tone ? " " + tone : "");
   row.fetchStatus.textContent = text;
+}
+
+function setModelFetchStatusKey(row, key, tone, vars) {
+  row.fetchStatusKey = key;
+  row.fetchStatusVars = vars || null;
+  row.fetchStatusFallback = "";
+  row.fetchStatus.className = "model-fetch-status" + (tone ? " " + tone : "");
+  row.fetchStatus.textContent = key ? t(key, vars) : "";
 }
 
 function clearModelOptions(row) {
@@ -1015,7 +1328,7 @@ function clearModelOptions(row) {
 
 function setModelOptions(row, models) {
   row.modelPicker.innerHTML = "";
-  row.modelPicker.appendChild(el("option", { value: "" }, "从列表中选择模型"));
+  row.modelPicker.appendChild(el("option", { value: "", "data-i18n": "chooseFromList" }, t("chooseFromList")));
   for (const model of models) {
     row.modelPicker.appendChild(el("option", { value: model }, model));
   }
@@ -1030,7 +1343,7 @@ async function fetchModels(row) {
   row.fetchController = controller;
   row.fetchButton.disabled = true;
   row.fetchButton.setAttribute("aria-busy", "true");
-  setModelFetchStatus(row, "正在获取模型列表...", "loading");
+  setModelFetchStatusKey(row, "fetchingModels", "loading");
   try {
     const res = await fetch("/api/models", {
       method: "POST",
@@ -1044,13 +1357,14 @@ async function fetchModels(row) {
     });
     const body = await res.json().catch(() => ({}));
     if (row.fetchController !== controller || !row.dom.isConnected) return;
-    if (!res.ok) throw new Error(body.error || "模型列表获取失败。");
+    if (!res.ok) throw new Error(body.error || t("fetchModelsFailed"));
     const models = Array.isArray(body.models) ? body.models.filter(Boolean) : [];
     setModelOptions(row, models);
-    setModelFetchStatus(row, models.length ? `已获取 ${models.length} 个模型。` : "服务商未返回可用模型。", models.length ? "success" : "");
+    if (models.length) setModelFetchStatusKey(row, "fetchedModels", "success", { n: models.length });
+    else setModelFetchStatusKey(row, "noModelsReturned", "");
   } catch (err) {
     if (row.fetchController === controller && err.name !== "AbortError") {
-      setModelFetchStatus(row, "获取失败：" + err.message, "error");
+      setModelFetchStatus(row, t("fetchFailedPrefix") + err.message, "error");
     }
   } finally {
     if (row.fetchController === controller) {
@@ -1061,27 +1375,83 @@ async function fetchModels(row) {
   }
 }
 
+function refreshModelRow(row) {
+  row.name.placeholder = t("modelNamePlaceholder");
+  row.key.placeholder = t("apiKeyPlaceholder");
+  row.base.placeholder = t("apiBasePlaceholder");
+  row.context.placeholder = t("contextPlaceholder");
+  row.fetchButton.textContent = t("fetchModels");
+  row.fetchButton.title = t("fetchModelsTitle");
+  row.modelPicker.setAttribute("aria-label", t("selectModel"));
+  const pickPlaceholder = row.modelPicker.querySelector('option[value=""]');
+  if (pickPlaceholder) pickPlaceholder.textContent = t("chooseFromList");
+  row.keyToggle.textContent = row.key.type === "text" ? t("hideKey") : t("showKey");
+  row.keyToggle.title = t("toggleKeyTitle");
+  row.keyToggle.setAttribute("aria-label", t("toggleKeyTitle"));
+  row.remove.textContent = t("remove");
+  row.badge.textContent = t("startupModel");
+  if (!row.name.value.trim()) row.preview.textContent = t("unnamedModel");
+  row.dom.querySelectorAll("[data-i18n]").forEach(node => {
+    node.textContent = t(node.getAttribute("data-i18n"));
+  });
+  if (row.fetchStatusKey) {
+    row.fetchStatus.textContent = t(row.fetchStatusKey, row.fetchStatusVars);
+  } else if (row.fetchStatusFallback) {
+    row.fetchStatus.textContent = row.fetchStatusFallback;
+  }
+}
+
+function applyLang() {
+  document.documentElement.lang = lang === "zh" ? "zh-CN" : "en";
+  document.title = t("documentTitle");
+  document.querySelectorAll("[data-i18n]").forEach(node => {
+    node.textContent = t(node.getAttribute("data-i18n"));
+  });
+  document.querySelectorAll("[data-i18n-html]").forEach(node => {
+    node.innerHTML = t(node.getAttribute("data-i18n-html"));
+  });
+  document.querySelectorAll("[data-i18n-placeholder]").forEach(node => {
+    node.setAttribute("placeholder", t(node.getAttribute("data-i18n-placeholder")));
+  });
+  if (!orig) $("path").textContent = t("loadingPath");
+  const toggle = $("langToggle");
+  toggle.textContent = lang === "zh" ? t("switchToEn") : t("switchToZh");
+  toggle.setAttribute("aria-label", t("switchLangAria"));
+  modelRows.forEach(refreshModelRow);
+  updateModeHint();
+  updateModelCount();
+  syncModelStates();
+  updateDirtyState();
+  refreshStatus();
+}
+
+function setLang(next) {
+  lang = next === "zh" ? "zh" : "en";
+  try { localStorage.setItem(LANG_KEY, lang); } catch (_) {}
+  applyLang();
+}
+
 function addModelRow(model) {
   const id = ++modelSequence;
   const value = model || {};
   const name = el("input", {
     id: "model-name-" + id,
     type: "text",
-    placeholder: "例如 gpt-4o",
+    placeholder: t("modelNamePlaceholder"),
     autocomplete: "off",
     required: "required",
   });
   const key = el("input", {
     id: "model-key-" + id,
     type: "password",
-    placeholder: "输入 API Key",
+    placeholder: t("apiKeyPlaceholder"),
     autocomplete: "new-password",
     spellcheck: "false",
   });
   const base = el("input", {
     id: "model-base-" + id,
     type: "text",
-    placeholder: "例如 https://api.openai.com/v1",
+    placeholder: t("apiBasePlaceholder"),
     autocomplete: "url",
   });
   const context = el("input", {
@@ -1089,34 +1459,34 @@ function addModelRow(model) {
     type: "number",
     min: "1",
     step: "1",
-    placeholder: "例如 200000",
+    placeholder: t("contextPlaceholder"),
     inputmode: "numeric",
   });
   const def = el("input", { type: "radio", name: "default-model" });
   const fetchButton = el("button", {
     type: "button",
     class: "button tertiary small model-fetch",
-    title: "从当前 API 地址获取模型列表",
-  }, "获取模型");
+    title: t("fetchModelsTitle"),
+  }, t("fetchModels"));
   const modelPicker = el("select", {
     class: "model-picker",
     hidden: "hidden",
-    "aria-label": "选择模型",
+    "aria-label": t("selectModel"),
   });
   const fetchStatus = el("div", { class: "model-fetch-status", "aria-live": "polite" });
   const keyToggle = el("button", {
     type: "button",
     class: "secret-toggle",
-    title: "显示或隐藏 API Key",
-    "aria-label": "显示或隐藏 API Key",
+    title: t("toggleKeyTitle"),
+    "aria-label": t("toggleKeyTitle"),
     "aria-pressed": "false",
-  }, "显示");
+  }, t("showKey"));
   const remove = el("button", {
     type: "button",
     class: "button danger small",
-    title: "删除此模型",
-    "aria-label": "删除此模型",
-  }, "删除");
+    title: t("removeModel"),
+    "aria-label": t("removeModel"),
+  }, t("remove"));
 
   if (value.name) name.value = value.name;
   if (value.apiKey) key.value = value.apiKey;
@@ -1124,8 +1494,8 @@ function addModelRow(model) {
   if (value.contextWindow) context.value = value.contextWindow;
   if (value.default || (!model && modelRows.length === 0)) def.checked = true;
 
-  const badge = el("span", { class: "model-badge", hidden: "hidden" }, "启动模型");
-  const preview = el("h3", null, "未命名模型");
+  const badge = el("span", { class: "model-badge", hidden: "hidden" }, t("startupModel"));
+  const preview = el("h3", null, t("unnamedModel"));
   const number = el("span", { class: "model-number" });
   const row = {
     name,
@@ -1136,12 +1506,16 @@ function addModelRow(model) {
     fetchButton,
     modelPicker,
     fetchStatus,
+    keyToggle,
     badge,
     preview,
     number,
     remove,
     defaultLabel: null,
     fetchController: null,
+    fetchStatusKey: null,
+    fetchStatusVars: null,
+    fetchStatusFallback: "",
     dom: null,
   };
 
@@ -1152,13 +1526,13 @@ function addModelRow(model) {
     fetchStatus,
   );
   const fields = el("div", { class: "model-fields" },
-    field("模型名称", "可手动填写，也可以从当前 API 地址获取列表后选择。", nameControl, "field-name", name.id, null, fetchButton),
-    field("API 地址", "OpenAI-compatible 或 Anthropic 兼容地址。", base, "field-base", base.id),
-    field("API Key", "默认隐藏，仅在点击“显示”时临时展示。", keyShell, "field-key", key.id),
-    field("上下文窗口", "模型可处理的最大上下文长度。", context, "field-context", context.id, "tokens"),
+    field("modelName", "modelNameHelp", nameControl, "field-name", name.id, null, fetchButton),
+    field("apiBase", "apiBaseHelp", base, "field-base", base.id),
+    field("apiKey", "apiKeyHelp", keyShell, "field-key", key.id),
+    field("contextWindow", "contextWindowHelp", context, "field-context", context.id, "tokens"),
   );
 
-  const defaultLabel = el("label", { class: "default-control" }, def, "设为启动模型");
+  const defaultLabel = el("label", { class: "default-control" }, def, el("span", { "data-i18n": "setStartupModel" }, t("setStartupModel")));
   row.defaultLabel = defaultLabel;
   const heading = el("div", { class: "model-heading" },
     number,
@@ -1173,7 +1547,7 @@ function addModelRow(model) {
   );
 
   function syncPreview() {
-    preview.textContent = name.value.trim() || "未命名模型";
+    preview.textContent = name.value.trim() || t("unnamedModel");
     name.setAttribute("aria-invalid", "false");
     clearModelOptions(row);
     markDirty("models");
@@ -1201,7 +1575,7 @@ function addModelRow(model) {
   keyToggle.addEventListener("click", () => {
     const visible = key.type === "text";
     key.type = visible ? "password" : "text";
-    keyToggle.textContent = visible ? "显示" : "隐藏";
+    keyToggle.textContent = visible ? t("showKey") : t("hideKey");
     keyToggle.setAttribute("aria-pressed", String(!visible));
   });
   remove.addEventListener("click", () => {
@@ -1259,7 +1633,7 @@ function validatePositiveInteger(input, label) {
   const valid = value === "" || (Number.isSafeInteger(Number(value)) && Number(value) > 0);
   input.setAttribute("aria-invalid", String(!valid));
   if (!valid) {
-    setStatus(label + "必须是大于 0 的整数。", "error");
+    setStatusKey("validatePositiveInt", "error", { label });
     input.focus();
     return false;
   }
@@ -1277,33 +1651,33 @@ function validateForm() {
     row.key.setAttribute("aria-invalid", "false");
     if (!row.name.value.trim()) {
       row.name.setAttribute("aria-invalid", "true");
-      setStatus("模型 " + (i + 1) + " 需要填写模型名称。", "error");
+      setStatusKey("validateModelName", "error", { n: i + 1 });
       row.name.focus();
       return false;
     }
     if (row.def.checked && !row.key.value.trim()) {
       row.key.setAttribute("aria-invalid", "true");
-      setStatus("启动模型需要填写 API Key。", "error");
+      setStatusKey("validateDefaultKey", "error");
       row.key.focus();
       return false;
     }
-    if (!validatePositiveInteger(row.context, "模型 " + (i + 1) + " 的上下文窗口")) return false;
+    if (!validatePositiveInteger(row.context, t("validateContextLabel", { n: i + 1 }))) return false;
   }
-  return validatePositiveInteger($("askTimeout"), "审批超时");
+  return validatePositiveInteger($("askTimeout"), t("validateAskTimeoutLabel"));
 }
 
-async function load(message, expectedVersion) {
-  setStatus("正在加载配置...", "loading");
+async function load(messageKey, expectedVersion) {
+  setStatusKey("statusLoading", "loading");
   try {
     const res = await fetch("/api/config");
     const doc = await res.json();
     if (!res.ok) {
-      setStatus(doc.error || "配置加载失败。", "error");
+      setStatus(doc.error || t("statusLoadFailed"), "error");
       return;
     }
 
     if (expectedVersion != null && changeVersion !== expectedVersion) {
-      setStatus("已保存先前修改；当前仍有未保存的修改。", "warning");
+      setStatusKey("statusSavedPending", "warning");
       return;
     }
 
@@ -1339,9 +1713,10 @@ async function load(message, expectedVersion) {
 
     updateModeHint();
     resetDirty();
-    setStatus(message || "配置已加载。", "success");
+    if (messageKey) setStatusKey(messageKey, "success");
+    else setStatusKey("statusLoaded", "success");
   } catch (err) {
-    setStatus("配置加载失败：\n" + err.message, "error");
+    setStatus(t("statusLoadFailedPrefix") + err.message, "error");
   } finally {
     $("editor").removeAttribute("inert");
   }
@@ -1395,7 +1770,7 @@ async function save() {
   const savedVersion = changeVersion;
   saving = true;
   updateDirtyState();
-  setStatus("正在保存...", "loading");
+  setStatusKey("statusSaving", "loading");
   try {
     const res = await fetch("/api/config", {
       method: "POST",
@@ -1404,22 +1779,23 @@ async function save() {
     });
     const body = await res.json();
     if (!res.ok) {
-      setStatus("保存失败：\n" + (body.error || "服务器返回了错误。"), "error");
+      setStatus(t("statusSaveFailedPrefix") + (body.error || t("statusServerError")), "error");
       return;
     }
     if (changeVersion === savedVersion) {
-      await load("配置已保存，旧文件已备份。", savedVersion);
+      await load("statusSaved", savedVersion);
     } else {
-      setStatus("已保存先前修改；当前仍有未保存的修改。", "warning");
+      setStatusKey("statusSavedPending", "warning");
     }
   } catch (err) {
-    setStatus("保存失败：\n" + err.message, "error");
+    setStatus(t("statusSaveFailedPrefix") + err.message, "error");
   } finally {
     saving = false;
     updateDirtyState();
   }
 }
 
+$("langToggle").addEventListener("click", () => setLang(lang === "zh" ? "en" : "zh"));
 $("add").addEventListener("click", () => addModelRow(null));
 $("save").addEventListener("click", save);
 wire("mode", "mode", "change");
@@ -1430,6 +1806,7 @@ wire("skillPath", "skillPath");
 wireRule("bashOn", "bashBody", "bash", "bashDefault", "bashAllow", "bashDeny");
 wireRule("fetchOn", "fetchBody", "fetch", "fetchDefault", "fetchHosts");
 
+applyLang();
 load();
 </script>
 </body>

--- a/cmd/config.html
+++ b/cmd/config.html
@@ -1,234 +1,1374 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>phi config</title>
+<title>phi 配置中心</title>
 <style>
-  :root { color-scheme: dark; }
-  body { font-family: system-ui, -apple-system, sans-serif; background: #14161a; color: #e6e6e6; margin: 0; padding: 24px; max-width: 980px; }
-  h1 { font-size: 20px; margin: 0 0 4px; }
-  h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .08em; color: #9aa4b2; margin: 24px 0 8px; }
-  .path { color: #9aa4b2; font-size: 12px; margin-bottom: 4px; }
-  .card { background: #1d2128; border: 1px solid #2a2f3a; border-radius: 8px; padding: 12px; margin-top: 8px; }
-  .row { display: flex; gap: 8px; align-items: flex-end; flex-wrap: wrap; padding: 10px 0; border-bottom: 1px solid #262b34; }
-  .row:last-child { border-bottom: none; }
-  .f { display: flex; flex-direction: column; gap: 4px; }
-  .f label { font-size: 11px; color: #9aa4b2; }
-  .grow { flex: 1; min-width: 140px; }
-  input, select, textarea { background: #14161a; color: #e6e6e6; border: 1px solid #333a46; border-radius: 4px; padding: 6px 8px; font-size: 13px; }
-  input:focus, select:focus, textarea:focus { outline: 1px solid #4a9eff; }
-  textarea { font-family: ui-monospace, Menlo, monospace; width: 100%; min-height: 64px; resize: vertical; box-sizing: border-box; }
-  label.check { font-size: 13px; color: #e6e6e6; display: inline-flex; align-items: center; gap: 6px; margin-right: 16px; }
-  button { background: #2a2f3a; color: #e6e6e6; border: 1px solid #3a4250; border-radius: 4px; padding: 6px 12px; font-size: 13px; cursor: pointer; }
-  button:hover { background: #333a46; }
-  button.primary { background: #2f6fed; border-color: #2f6fed; padding: 8px 20px; font-size: 14px; }
-  button.danger { background: transparent; border-color: #6b3b3b; color: #e08a8a; }
-  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 16px; }
-  #status { margin-top: 12px; font-size: 13px; }
-  #status.ok { color: #7bc47f; }
-  #status.err { color: #e08a8a; white-space: pre-wrap; }
-  .block { margin-top: 12px; padding-top: 12px; border-top: 1px dashed #2a2f3a; }
+  :root {
+    color-scheme: dark;
+    --bg: #0e1218;
+    --surface: #171c24;
+    --surface-strong: #1d2430;
+    --surface-muted: #12171e;
+    --border: #2a3442;
+    --border-strong: #3b4a5e;
+    --text: #edf2f7;
+    --text-muted: #9aa8b7;
+    --text-subtle: #718092;
+    --blue: #72a7ff;
+    --blue-strong: #3f80ea;
+    --green: #76d39a;
+    --amber: #e4b76a;
+    --red: #f08d8d;
+  }
+
+  * { box-sizing: border-box; }
+
+  html { min-width: 320px; background: var(--bg); }
+
+  body {
+    margin: 0;
+    padding-bottom: 86px;
+    background: var(--bg);
+    color: var(--text);
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  button, input, select, textarea { font: inherit; }
+
+  button { cursor: pointer; }
+  button:disabled { cursor: not-allowed; opacity: .55; }
+  button[aria-busy="true"] { cursor: progress; }
+
+  code {
+    color: #c6d8f2;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: .92em;
+  }
+
+  .page-shell {
+    width: min(100% - 32px, 1240px);
+    margin: 0 auto;
+    padding: 32px 0 48px;
+  }
+
+  .page-header { padding-bottom: 28px; }
+
+  .section-head,
+  .panel-head,
+  .model-card-head,
+  .footer-inner {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+  }
+
+  .dirty-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .dirty-state::before {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--green);
+    content: "";
+  }
+
+  .dirty-state.pending { color: var(--amber); }
+  .dirty-state.pending::before { background: var(--amber); }
+  .dirty-state.saving { color: var(--blue); }
+  .dirty-state.saving::before { background: var(--blue); }
+
+  .brand-line {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .brand {
+    color: var(--text);
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  .brand-divider { color: var(--text-subtle); }
+
+  h1, h2, h3, p { margin: 0; }
+
+  h1 {
+    margin-top: 26px;
+    font-size: 30px;
+    line-height: 1.2;
+    letter-spacing: 0;
+  }
+
+  h2 {
+    margin-top: 3px;
+    font-size: 20px;
+    line-height: 1.25;
+    letter-spacing: 0;
+  }
+
+  h3 {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: 16px;
+    line-height: 1.3;
+    letter-spacing: 0;
+  }
+
+  .lede,
+  .section-help,
+  .panel-help,
+  .field-help,
+  .toggle-help {
+    color: var(--text-muted);
+  }
+
+  .lede {
+    max-width: 680px;
+    margin-top: 8px;
+    font-size: 15px;
+  }
+
+  .path-strip {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    min-width: 0;
+    margin-top: 22px;
+    padding: 11px 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface-muted);
+  }
+
+  .path-label {
+    flex: 0 0 auto;
+    color: var(--text-subtle);
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  #path {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--text-muted);
+  }
+
+  .button {
+    min-height: 38px;
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    padding: 8px 14px;
+    background: var(--surface-strong);
+    color: var(--text);
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
+  .button:not(:disabled):hover { border-color: var(--blue); background: #263347; }
+
+  .button:focus-visible,
+  .secret-toggle:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+
+  .button.primary {
+    border-color: var(--blue-strong);
+    background: var(--blue-strong);
+    color: #fff;
+    box-shadow: 0 6px 16px rgba(63, 128, 234, .22);
+  }
+
+  .button.primary:not(:disabled):hover { border-color: #6098f0; background: #4d8af0; }
+
+  .button.secondary { background: transparent; }
+
+  .button.tertiary {
+    min-height: 30px;
+    border-color: transparent;
+    padding: 4px 7px;
+    background: transparent;
+    color: var(--blue);
+  }
+
+  .button.tertiary:not(:disabled):hover {
+    border-color: transparent;
+    background: rgba(114, 167, 255, .1);
+  }
+
+  .button.danger {
+    border-color: transparent;
+    background: transparent;
+    color: var(--text-muted);
+  }
+
+  .button.danger:not(:disabled):hover { border-color: #633e48; background: #2a1d25; color: var(--red); }
+
+  .button.small { min-height: 34px; padding: 7px 11px; font-size: 13px; }
+
+  main { border-top: 1px solid var(--border); }
+
+  .section { padding: 30px 0; border-bottom: 1px solid var(--border); }
+
+  .section-help { margin-top: 7px; font-size: 13px; }
+
+  .section-title-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .section-count {
+    flex: 0 0 auto;
+    padding: 5px 9px;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    color: var(--text-muted);
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  .model-list {
+    display: grid;
+    gap: 14px;
+    margin-top: 22px;
+  }
+
+  .model-card {
+    min-width: 0;
+    padding: 20px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+  }
+
+  .model-card.is-default {
+    border-color: #4e7e6a;
+    box-shadow: 0 0 0 1px rgba(118, 211, 154, .08);
+  }
+
+  .model-card-head { align-items: flex-start; }
+
+  .model-heading {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px 10px;
+    min-width: 0;
+  }
+
+  .model-number {
+    color: var(--text-subtle);
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  .model-badge {
+    padding: 3px 7px;
+    border: 1px solid #407257;
+    border-radius: 4px;
+    color: var(--green);
+    font-size: 11px;
+    font-weight: 700;
+  }
+
+  .model-badge[hidden] { display: none; }
+
+  .model-card-actions {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .default-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-height: 34px;
+    padding: 6px 10px;
+    border: 1px solid var(--border-strong);
+    border-radius: 5px;
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .default-control[hidden] { display: none; }
+
+  .model-card.is-default .default-control {
+    border-color: #407257;
+    color: var(--green);
+  }
+
+  input[type="radio"],
+  input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    accent-color: var(--blue-strong);
+  }
+
+  .model-card.is-default input[type="radio"] { accent-color: var(--green); }
+
+  .model-fields {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 17px 16px;
+    margin-top: 20px;
+    padding-top: 18px;
+    border-top: 1px solid var(--border);
+  }
+
+  .field { min-width: 0; }
+
+  .field-name { grid-column: span 5; }
+  .field-base { grid-column: span 7; }
+  .field-key { grid-column: span 9; }
+  .field-context { grid-column: span 3; }
+
+  .field-label-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  .field-label-row .field-label { min-width: 0; }
+
+  .field-label {
+    display: flex;
+    align-items: baseline;
+    gap: 7px;
+    min-height: 20px;
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 650;
+  }
+
+  .field-unit {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .required {
+    color: var(--text-subtle);
+    font-size: 11px;
+    font-weight: 500;
+  }
+
+  .field-help {
+    min-height: 18px;
+    margin-top: 2px;
+    font-size: 12px;
+  }
+
+  input[type="text"],
+  input[type="number"],
+  input[type="password"],
+  select,
+  textarea {
+    width: 100%;
+    min-width: 0;
+    margin-top: 7px;
+    border: 1px solid var(--border-strong);
+    border-radius: 6px;
+    outline: none;
+    background: var(--surface-muted);
+    color: var(--text);
+    font-size: 13px;
+  }
+
+  input[type="text"],
+  input[type="number"],
+  input[type="password"],
+  select {
+    height: 40px;
+    padding: 8px 10px;
+  }
+
+  input:focus, select:focus, textarea:focus {
+    border-color: var(--blue);
+    box-shadow: 0 0 0 2px rgba(114, 167, 255, .14);
+  }
+
+  input[aria-invalid="true"],
+  select[aria-invalid="true"],
+  textarea[aria-invalid="true"] {
+    border-color: var(--red);
+    box-shadow: 0 0 0 2px rgba(240, 141, 141, .12);
+  }
+
+  textarea {
+    min-height: 112px;
+    padding: 9px 10px;
+    resize: vertical;
+    line-height: 1.45;
+  }
+
+  input::placeholder, textarea::placeholder { color: #637183; }
+
+  .input-shell {
+    display: flex;
+    min-width: 0;
+    margin-top: 7px;
+  }
+
+  .input-shell input {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-top: 0;
+    border-radius: 6px 0 0 6px;
+    border-right: 0;
+  }
+
+  .secret-toggle {
+    flex: 0 0 auto;
+    min-width: 56px;
+    border: 1px solid var(--border-strong);
+    border-radius: 0 6px 6px 0;
+    background: var(--surface-strong);
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .secret-toggle:hover { color: var(--text); background: #263347; }
+
+  .empty-models {
+    padding: 26px;
+    border: 1px dashed var(--border-strong);
+    border-radius: 6px;
+    color: var(--text-muted);
+    text-align: center;
+  }
+
+  .model-name-control {
+    display: grid;
+    gap: 7px;
+    min-width: 0;
+    margin-top: 7px;
+  }
+
+  .model-name-control > input {
+    min-width: 0;
+    margin-top: 0;
+  }
+
+  .model-fetch {
+    flex: 0 0 auto;
+    min-width: 84px;
+    white-space: nowrap;
+  }
+
+  .model-picker {
+    min-width: 0;
+    margin-top: 0;
+  }
+
+  .model-picker[hidden] { display: none; }
+
+  .model-fetch-status {
+    min-height: 18px;
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+
+  .model-fetch-status.error { color: var(--red); }
+  .model-fetch-status.success { color: var(--green); }
+  .model-fetch-status.loading { color: var(--blue); }
+
+  .settings-layout {
+    display: grid;
+    grid-template-columns: minmax(260px, .8fr) minmax(0, 1.2fr);
+    gap: 0;
+    padding: 30px 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .panel {
+    min-width: 0;
+    padding-right: 28px;
+  }
+
+  .panel + .panel {
+    border-left: 1px solid var(--border);
+    padding-right: 0;
+    padding-left: 28px;
+  }
+
+  .panel-head { align-items: baseline; gap: 12px; }
+
+  .panel-title { font-size: 16px; font-weight: 700; }
+
+  .panel-help { margin-top: 4px; font-size: 12px; }
+
+  .panel-body { margin-top: 20px; }
+
+  .settings-fields {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(150px, .55fr);
+    gap: 17px 16px;
+  }
+
+  .settings-fields .field-full { grid-column: 1 / -1; }
+
+  .toggle-list {
+    display: grid;
+    gap: 14px;
+    margin-top: 18px;
+  }
+
+  .toggle-row {
+    display: grid;
+    grid-template-columns: 18px minmax(0, 1fr);
+    gap: 10px;
+    align-items: start;
+    cursor: pointer;
+  }
+
+  .toggle-row input { margin-top: 3px; }
+
+  .toggle-title {
+    display: block;
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 650;
+  }
+
+  .toggle-help {
+    display: block;
+    margin-top: 2px;
+    font-size: 12px;
+  }
+
+  .toggle-row.danger .toggle-title { color: var(--amber); }
+  .toggle-row.danger input { accent-color: var(--amber); }
+
+  .mode-hint {
+    margin-top: 7px;
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+
+  .rules-section { padding-bottom: 32px; }
+
+  .rules-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px;
+    margin-top: 22px;
+  }
+
+  .rule-group {
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  .rule-group + .rule-group {
+    padding-left: 24px;
+    border-left: 1px solid var(--border);
+  }
+
+  .rule-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .rule-head input { margin-top: 3px; }
+
+  .rule-title {
+    display: block;
+    color: var(--text);
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  .rule-help { margin-top: 2px; color: var(--text-muted); font-size: 12px; }
+
+  .rule-body {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 17px 16px;
+    margin-top: 18px;
+    padding-top: 18px;
+    border-top: 1px solid var(--border);
+  }
+
+  .rule-body[hidden] { display: none; }
+
+  .rule-body .field-wide { grid-column: 1 / -1; }
+
+  .save-footer {
+    position: fixed;
+    z-index: 20;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border-top: 1px solid var(--border);
+    background: var(--surface-muted);
+  }
+
+  .footer-inner {
+    align-items: center;
+    width: min(100% - 32px, 1240px);
+    min-height: 68px;
+    margin: 0 auto;
+    padding: 10px 0;
+  }
+
+  .save-summary,
+  .footer-actions {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 0;
+  }
+
+  .save-summary .status {
+    border-left: 1px solid var(--border);
+    padding-left: 14px;
+  }
+
+  .status {
+    min-width: 0;
+    color: var(--text-muted);
+    font-size: 12px;
+    white-space: pre-wrap;
+  }
+
+  .status.success { color: var(--green); }
+  .status.warning { color: var(--amber); }
+  .status.error { color: var(--red); }
+  .status.loading { color: var(--blue); }
+
+  .backup-note { color: var(--text-subtle); font-size: 12px; text-align: right; }
+
+  .footer-actions .button { min-width: 112px; }
+
+  @media (max-width: 900px) {
+    .model-fields { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+    .field-name, .field-base { grid-column: span 3; }
+    .field-key { grid-column: span 4; }
+    .field-context { grid-column: span 2; }
+  }
+
+  @media (max-width: 720px) {
+    body { padding-bottom: 168px; }
+    .page-shell { width: min(100% - 24px, 620px); padding-top: 20px; }
+    .section-head, .panel-head, .model-card-head, .footer-inner { flex-direction: column; }
+    .section-head > .button { width: 100%; }
+    .dirty-state { align-self: flex-start; }
+    h1 { margin-top: 21px; font-size: 27px; }
+    .path-strip { align-items: flex-start; flex-direction: column; gap: 3px; }
+    .section, .rules-section { padding: 24px 0; }
+    .model-card { padding: 17px; }
+    .model-card-actions { width: 100%; justify-content: flex-end; }
+    .default-control { flex: 1 1 auto; }
+    .model-fields, .settings-fields, .rules-grid, .rule-body { grid-template-columns: minmax(0, 1fr); }
+    .field-name, .field-base, .field-key, .field-context, .settings-fields .field-full, .rule-body .field-wide { grid-column: auto; }
+    .panel { padding-right: 0; }
+    .panel + .panel { margin-top: 26px; padding-top: 26px; padding-left: 0; border-top: 1px solid var(--border); border-left: 0; }
+    .rule-group + .rule-group { padding-top: 24px; padding-left: 0; border-top: 1px solid var(--border); border-left: 0; }
+    .footer-inner { width: min(100% - 24px, 620px); min-height: 136px; align-items: stretch; gap: 8px; }
+    .save-summary { flex-direction: column; align-items: flex-start; gap: 4px; }
+    .save-summary .status { border-left: 0; padding-left: 0; white-space: normal; overflow-wrap: anywhere; }
+    .footer-actions { justify-content: space-between; }
+    .footer-actions .button { flex: 1 0 112px; }
+    .backup-note { display: none; }
+  }
 </style>
 </head>
 <body>
-<h1>phi config</h1>
-<div class="path" id="path"></div>
-
-<section>
-  <h2>Models</h2>
-  <div class="card" id="models"></div>
-  <button id="add" style="margin-top:8px">+ Add model</button>
-</section>
-
-<section>
-  <h2>General</h2>
-  <div class="card">
-    <div class="f" style="max-width:480px">
-      <label>skill_path (directory of SKILL.md files to load; leave empty for default)</label>
-      <input id="skillPath" placeholder="~/.phi/skills">
-    </div>
-  </div>
-</section>
-
-<section>
-  <h2>Permissions</h2>
-  <div class="card">
-    <div class="grid2">
-      <div class="f">
-        <label>mode</label>
-        <select id="mode">
-          <option value="interactive">interactive</option>
-          <option value="readonly">readonly</option>
-          <option value="autopilot">autopilot</option>
-          <option value="headless-strict">headless-strict</option>
-        </select>
-      </div>
-      <div class="f">
-        <label>ask_timeout_sec (seconds)</label>
-        <input id="askTimeout" type="number" min="1">
+<div class="page-shell">
+  <header class="page-header">
+    <div class="header-top">
+      <div class="brand-line">
+        <span class="brand">phi</span>
+        <span class="brand-divider">/</span>
+        <span>本地配置</span>
       </div>
     </div>
-    <div style="margin-top:10px">
-      <label class="check"><input id="wow" type="checkbox"> workspace_only_writes</label>
-      <label class="check"><input id="daa" type="checkbox"> dangerously_allow_all</label>
+    <h1>配置中心</h1>
+    <p class="lede">管理模型连接、技能目录和 Agent 权限。保存后会立即写入本地配置文件。</p>
+    <div class="path-strip">
+      <span class="path-label">配置文件</span>
+      <code id="path">正在加载...</code>
     </div>
-  </div>
+  </header>
 
-  <div class="card">
-    <label class="check"><input id="bashOn" type="checkbox"> Custom bash rules</label>
-    <div id="bashBody" class="block" style="display:none">
-      <div class="grid2">
-        <div class="f">
-          <label>bash.default</label>
-          <select id="bashDefault">
-            <option value="ask">ask</option>
-            <option value="allow">allow</option>
-            <option value="deny">deny</option>
-          </select>
+  <main id="editor" inert>
+    <section class="section model-section">
+      <div class="section-head">
+        <div>
+          <div class="section-title-row">
+            <h2>模型</h2>
+            <div class="section-count" id="modelCount">0 个模型</div>
+          </div>
+          <p class="section-help">必须至少保留 1 个模型；只能设置 1 个启动模型。</p>
         </div>
-        <div></div>
-        <div class="f"><label>bash.allow (one regex per line)</label><textarea id="bashAllow" placeholder="go test ./..."></textarea></div>
-        <div class="f"><label>bash.deny (one regex per line)</label><textarea id="bashDeny" placeholder="rm -rf *"></textarea></div>
+        <button class="button secondary" id="add" type="button">+ 添加模型</button>
       </div>
-    </div>
-  </div>
+      <div class="model-list" id="models"></div>
+    </section>
 
-  <div class="card">
-    <label class="check"><input id="fetchOn" type="checkbox"> Custom fetch rules</label>
-    <div id="fetchBody" class="block" style="display:none">
-      <div class="grid2">
-        <div class="f">
-          <label>fetch.default</label>
-          <select id="fetchDefault">
-            <option value="ask">ask</option>
-            <option value="allow">allow</option>
-            <option value="deny">deny</option>
-          </select>
+    <div class="settings-layout">
+      <section class="panel">
+        <div class="panel-head">
+          <div>
+            <div class="panel-title">通用设置</div>
+            <p class="panel-help">指定技能文件的加载目录。</p>
+          </div>
         </div>
-        <div class="f"><label>fetch.allowed_hosts (one host per line)</label><textarea id="fetchHosts" placeholder="github.com"></textarea></div>
+        <div class="panel-body settings-fields">
+          <div class="field field-full">
+            <label class="field-label" for="skillPath">技能目录</label>
+            <div class="field-help">读取其中的 <code>SKILL.md</code> 文件；留空则使用默认目录。</div>
+            <input id="skillPath" type="text" placeholder="例如 ~/.phi/skills" autocomplete="off">
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <div>
+            <div class="panel-title">权限模式</div>
+            <p class="panel-help">控制 Agent 执行命令、读写文件和联网请求时的行为。</p>
+          </div>
+        </div>
+        <div class="panel-body settings-fields">
+          <div class="field">
+            <label class="field-label" for="mode">运行模式</label>
+            <div class="field-help">不同模式会改变需要确认的操作。</div>
+            <select id="mode">
+              <option value="interactive">交互确认</option>
+              <option value="readonly">只读</option>
+              <option value="autopilot">自动执行</option>
+              <option value="headless-strict">无界面严格模式</option>
+            </select>
+            <p class="mode-hint" id="modeHint"></p>
+          </div>
+          <div class="field">
+            <label class="field-label" for="askTimeout">审批超时 <span class="field-unit">seconds</span></label>
+            <div class="field-help">权限请求最多等待的时间。</div>
+            <input id="askTimeout" type="number" min="1" step="1" inputmode="numeric" placeholder="例如 120">
+          </div>
+        </div>
+        <div class="toggle-list">
+          <label class="toggle-row">
+            <input id="wow" type="checkbox">
+            <span>
+              <span class="toggle-title">仅允许工作区写入</span>
+              <span class="toggle-help">禁止写入当前项目目录之外的文件。</span>
+            </span>
+          </label>
+          <label class="toggle-row danger">
+            <input id="daa" type="checkbox">
+            <span>
+              <span class="toggle-title">跳过所有权限检查</span>
+              <span class="toggle-help">高风险设置。开启后 Agent 不会再请求操作确认。</span>
+            </span>
+          </label>
+        </div>
+      </section>
+    </div>
+
+    <section class="section rules-section">
+      <div class="section-head">
+        <div>
+          <h2>工具规则</h2>
+          <p class="section-help">按命令和目标主机进一步限制 Agent 的操作范围。</p>
+        </div>
+      </div>
+      <div class="rules-grid">
+        <fieldset class="rule-group">
+          <label class="rule-head" for="bashOn">
+            <input id="bashOn" type="checkbox">
+            <span>
+              <span class="rule-title">命令执行规则</span>
+              <span class="rule-help">启用后覆盖默认的 bash 许可策略。</span>
+            </span>
+          </label>
+          <div class="rule-body" id="bashBody" hidden>
+            <div class="field">
+              <label class="field-label" for="bashDefault">未匹配命令的策略</label>
+              <div class="field-help">默认询问、允许或拒绝。</div>
+              <select id="bashDefault">
+                <option value="ask">询问</option>
+                <option value="allow">允许</option>
+                <option value="deny">拒绝</option>
+              </select>
+            </div>
+            <div class="field"></div>
+            <div class="field field-wide">
+              <label class="field-label" for="bashAllow">允许的命令规则</label>
+              <div class="field-help">每行一条正则表达式。</div>
+              <textarea id="bashAllow" placeholder="例如 ^go test\b"></textarea>
+            </div>
+            <div class="field field-wide">
+              <label class="field-label" for="bashDeny">拒绝的命令规则</label>
+              <div class="field-help">拒绝规则优先于允许规则。</div>
+              <textarea id="bashDeny" placeholder="例如 rm\s+-rf"></textarea>
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset class="rule-group">
+          <label class="rule-head" for="fetchOn">
+            <input id="fetchOn" type="checkbox">
+            <span>
+              <span class="rule-title">网络请求规则</span>
+              <span class="rule-help">启用后限制 fetch 工具可以访问的主机。</span>
+            </span>
+          </label>
+          <div class="rule-body" id="fetchBody" hidden>
+            <div class="field">
+              <label class="field-label" for="fetchDefault">未匹配主机的策略</label>
+              <div class="field-help">默认询问、允许或拒绝。</div>
+              <select id="fetchDefault">
+                <option value="ask">询问</option>
+                <option value="allow">允许</option>
+                <option value="deny">拒绝</option>
+              </select>
+            </div>
+            <div class="field field-wide">
+              <label class="field-label" for="fetchHosts">允许访问的主机</label>
+              <div class="field-help">每行一个主机名，例如 <code>github.com</code>。</div>
+              <textarea id="fetchHosts" placeholder="例如 github.com"></textarea>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </section>
+  </main>
+
+  <footer class="save-footer">
+    <div class="footer-inner">
+      <div class="save-summary">
+        <span class="dirty-state" id="dirtyState" aria-live="polite">已保存</span>
+        <div class="status loading" id="status" aria-live="polite">正在加载配置...</div>
+      </div>
+      <div class="footer-actions">
+        <div class="backup-note">自动备份为 <code>config.yaml.bak</code></div>
+        <button class="button secondary" id="save" type="button" disabled>保存配置</button>
       </div>
     </div>
-  </div>
-</section>
-
-<button class="primary" id="save" style="margin-top:16px">Save config</button>
-<div id="status">Note: saving rewrites config.yaml (auto-backup to config.yaml.bak)</div>
+  </footer>
+</div>
 
 <script>
 "use strict";
-const $ = id => document.getElementById(id);
 
+const $ = id => document.getElementById(id);
 let orig = null;
+let modelSequence = 0;
+let saving = false;
+let changeVersion = 0;
 const modelRows = [];
-const dirty = { mode: false, askTimeout: false, wow: false, daa: false, skillPath: false, bash: false, fetch: false };
+const dirty = {
+  models: false,
+  mode: false,
+  askTimeout: false,
+  wow: false,
+  daa: false,
+  skillPath: false,
+  bash: false,
+  fetch: false,
+};
 
 function el(tag, attrs, ...kids) {
-  const e = document.createElement(tag);
-  for (const k in attrs || {}) e.setAttribute(k, attrs[k]);
-  for (const k of kids) { if (typeof k === "string") e.appendChild(document.createTextNode(k)); else if (k) e.appendChild(k); }
-  return e;
-}
-function cell(label, inputEl, grow) {
-  const c = el("div", { class: "f" + (grow ? " grow" : "") }, el("label", null, label), inputEl);
-  return c;
-}
-function splitLines(s) { return (s || "").split("\n").map(x => x.trim()).filter(Boolean); }
-
-function addModelRow(m) {
-  const name = el("input", { placeholder: "model name, e.g. deepseek-chat" });
-  const key = el("input", { placeholder: "api_key" });
-  const base = el("input", { placeholder: "base_url, e.g. https://api.deepseek.com" });
-  const ctx = el("input", { type: "number", min: "1", placeholder: "optional" });
-  const def = el("input", { type: "radio", name: "def" });
-  if (m) {
-    if (m.name) name.value = m.name;
-    if (m.apiKey) key.value = m.apiKey;
-    if (m.baseUrl) base.value = m.baseUrl;
-    if (m.contextWindow) ctx.value = m.contextWindow;
-    if (m.default) def.checked = true;
+  const node = document.createElement(tag);
+  for (const key in attrs || {}) node.setAttribute(key, attrs[key]);
+  for (const child of kids) {
+    if (typeof child === "string") node.appendChild(document.createTextNode(child));
+    else if (child) node.appendChild(child);
   }
-  const rm = el("button", { class: "danger" }, "Remove");
-  const row = { name, key, base, ctx, def, dom: null };
-  row.dom = el("div", { class: "row" },
-    el("label", { class: "check", title: "Default model" }, def, "default"),
-    cell("name", name, true),
-    cell("api_key", key, true),
-    cell("base_url", base, true),
-    cell("context_window", ctx),
-    rm,
-  );
-  rm.onclick = () => {
-    row.dom.remove();
-    const i = modelRows.indexOf(row);
-    if (i >= 0) modelRows.splice(i, 1);
+  return node;
+}
+
+function field(labelText, helpText, control, className, labelFor, unitText, labelAction) {
+  const label = el("label", { class: "field-label" }, labelText);
+  if (unitText) label.appendChild(el("span", { class: "field-unit" }, unitText));
+  if (labelFor) label.setAttribute("for", labelFor);
+  const labelRow = labelAction
+    ? el("div", { class: "field-label-row" }, label, labelAction)
+    : label;
+  const body = el("div", { class: "field" + (className ? " " + className : "") }, labelRow);
+  if (helpText) body.appendChild(el("div", { class: "field-help" }, helpText));
+  body.appendChild(control);
+  return body;
+}
+
+function splitLines(value) {
+  return (value || "").split("\n").map(line => line.trim()).filter(Boolean);
+}
+
+function setStatus(text, tone) {
+  const status = $("status");
+  status.className = "status " + (tone || "");
+  status.textContent = text;
+}
+
+function hasUnsavedChanges() {
+  return Object.values(dirty).some(Boolean);
+}
+
+function updateDirtyState() {
+  const state = $("dirtyState");
+  const button = $("save");
+  const pending = hasUnsavedChanges();
+  state.className = "dirty-state" + (saving ? " saving" : (pending ? " pending" : ""));
+  state.textContent = saving ? "正在保存" : (pending ? "有未保存的修改" : "已保存");
+  button.classList.toggle("primary", pending || saving);
+  button.classList.toggle("secondary", !pending && !saving);
+  button.disabled = saving || !pending;
+  button.textContent = saving ? "正在保存" : (pending ? "保存修改" : "保存配置");
+  if (saving) button.setAttribute("aria-busy", "true");
+  else button.removeAttribute("aria-busy");
+}
+
+function markDirty(key) {
+  dirty[key] = true;
+  changeVersion++;
+  updateDirtyState();
+}
+
+function updateModeHint() {
+  const hints = {
+    interactive: "需要确认的操作会在 TUI 中等待你的批准。",
+    readonly: "写入、编辑和未列入白名单的命令会被拒绝。",
+    autopilot: "需要确认的操作会自动放行，请谨慎使用。",
+    "headless-strict": "没有确认界面，需要批准的操作会直接拒绝。",
   };
+  $("modeHint").textContent = hints[$("mode").value] || "";
+}
+
+function updateModelCount() {
+  const count = modelRows.length;
+  $("modelCount").textContent = count + " 个模型";
+  modelRows.forEach((row, index) => {
+    row.number.textContent = "模型 " + String(index + 1).padStart(2, "0");
+  });
+  const empty = $("emptyModels");
+  if (count === 0 && !empty) {
+    $("models").appendChild(el("div", { class: "empty-models", id: "emptyModels" }, "暂未配置模型，请先添加一个模型。"));
+  } else if (count > 0 && empty) {
+    empty.remove();
+  }
+}
+
+function syncModelStates() {
+  if (modelRows.length > 0 && !modelRows.some(row => row.def.checked)) {
+    modelRows[0].def.checked = true;
+  }
+  for (const row of modelRows) {
+    const active = row.def.checked;
+    row.dom.classList.toggle("is-default", active);
+    row.badge.hidden = !active;
+    row.defaultLabel.hidden = active;
+    row.remove.disabled = modelRows.length <= 1;
+    row.remove.title = row.remove.disabled ? "必须至少保留一个模型" : "删除此模型";
+  }
+}
+
+function setModelFetchStatus(row, text, tone) {
+  row.fetchStatus.className = "model-fetch-status" + (tone ? " " + tone : "");
+  row.fetchStatus.textContent = text;
+}
+
+function clearModelOptions(row) {
+  if (row.fetchController) {
+    row.fetchController.abort();
+    row.fetchController = null;
+  }
+  row.fetchButton.disabled = false;
+  row.fetchButton.removeAttribute("aria-busy");
+  row.modelPicker.innerHTML = "";
+  row.modelPicker.hidden = true;
+  setModelFetchStatus(row, "", "");
+}
+
+function setModelOptions(row, models) {
+  row.modelPicker.innerHTML = "";
+  row.modelPicker.appendChild(el("option", { value: "" }, "从列表中选择模型"));
+  for (const model of models) {
+    row.modelPicker.appendChild(el("option", { value: model }, model));
+  }
+  row.modelPicker.hidden = models.length === 0;
+  const current = row.name.value.trim();
+  row.modelPicker.value = models.includes(current) ? current : "";
+}
+
+async function fetchModels(row) {
+  if (row.fetchController) row.fetchController.abort();
+  const controller = new AbortController();
+  row.fetchController = controller;
+  row.fetchButton.disabled = true;
+  row.fetchButton.setAttribute("aria-busy", "true");
+  setModelFetchStatus(row, "正在获取模型列表...", "loading");
+  try {
+    const res = await fetch("/api/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl: row.base.value.trim(),
+        apiKey: row.key.value.trim(),
+        model: row.name.value.trim(),
+      }),
+      signal: controller.signal,
+    });
+    const body = await res.json().catch(() => ({}));
+    if (row.fetchController !== controller || !row.dom.isConnected) return;
+    if (!res.ok) throw new Error(body.error || "模型列表获取失败。");
+    const models = Array.isArray(body.models) ? body.models.filter(Boolean) : [];
+    setModelOptions(row, models);
+    setModelFetchStatus(row, models.length ? `已获取 ${models.length} 个模型。` : "服务商未返回可用模型。", models.length ? "success" : "");
+  } catch (err) {
+    if (row.fetchController === controller && err.name !== "AbortError") {
+      setModelFetchStatus(row, "获取失败：" + err.message, "error");
+    }
+  } finally {
+    if (row.fetchController === controller) {
+      row.fetchController = null;
+      row.fetchButton.disabled = false;
+      row.fetchButton.removeAttribute("aria-busy");
+    }
+  }
+}
+
+function addModelRow(model) {
+  const id = ++modelSequence;
+  const value = model || {};
+  const name = el("input", {
+    id: "model-name-" + id,
+    type: "text",
+    placeholder: "例如 gpt-4o",
+    autocomplete: "off",
+    required: "required",
+  });
+  const key = el("input", {
+    id: "model-key-" + id,
+    type: "password",
+    placeholder: "输入 API Key",
+    autocomplete: "new-password",
+    spellcheck: "false",
+  });
+  const base = el("input", {
+    id: "model-base-" + id,
+    type: "text",
+    placeholder: "例如 https://api.openai.com/v1",
+    autocomplete: "url",
+  });
+  const context = el("input", {
+    id: "model-context-" + id,
+    type: "number",
+    min: "1",
+    step: "1",
+    placeholder: "例如 200000",
+    inputmode: "numeric",
+  });
+  const def = el("input", { type: "radio", name: "default-model" });
+  const fetchButton = el("button", {
+    type: "button",
+    class: "button tertiary small model-fetch",
+    title: "从当前 API 地址获取模型列表",
+  }, "获取模型");
+  const modelPicker = el("select", {
+    class: "model-picker",
+    hidden: "hidden",
+    "aria-label": "选择模型",
+  });
+  const fetchStatus = el("div", { class: "model-fetch-status", "aria-live": "polite" });
+  const keyToggle = el("button", {
+    type: "button",
+    class: "secret-toggle",
+    title: "显示或隐藏 API Key",
+    "aria-label": "显示或隐藏 API Key",
+    "aria-pressed": "false",
+  }, "显示");
+  const remove = el("button", {
+    type: "button",
+    class: "button danger small",
+    title: "删除此模型",
+    "aria-label": "删除此模型",
+  }, "删除");
+
+  if (value.name) name.value = value.name;
+  if (value.apiKey) key.value = value.apiKey;
+  if (value.baseUrl) base.value = value.baseUrl;
+  if (value.contextWindow) context.value = value.contextWindow;
+  if (value.default || (!model && modelRows.length === 0)) def.checked = true;
+
+  const badge = el("span", { class: "model-badge", hidden: "hidden" }, "启动模型");
+  const preview = el("h3", null, "未命名模型");
+  const number = el("span", { class: "model-number" });
+  const row = {
+    name,
+    key,
+    base,
+    context,
+    def,
+    fetchButton,
+    modelPicker,
+    fetchStatus,
+    badge,
+    preview,
+    number,
+    remove,
+    defaultLabel: null,
+    fetchController: null,
+    dom: null,
+  };
+
+  const keyShell = el("div", { class: "input-shell" }, key, keyToggle);
+  const nameControl = el("div", { class: "model-name-control" },
+    name,
+    modelPicker,
+    fetchStatus,
+  );
+  const fields = el("div", { class: "model-fields" },
+    field("模型名称", "可手动填写，也可以从当前 API 地址获取列表后选择。", nameControl, "field-name", name.id, null, fetchButton),
+    field("API 地址", "OpenAI-compatible 或 Anthropic 兼容地址。", base, "field-base", base.id),
+    field("API Key", "默认隐藏，仅在点击“显示”时临时展示。", keyShell, "field-key", key.id),
+    field("上下文窗口", "模型可处理的最大上下文长度。", context, "field-context", context.id, "tokens"),
+  );
+
+  const defaultLabel = el("label", { class: "default-control" }, def, "设为启动模型");
+  row.defaultLabel = defaultLabel;
+  const heading = el("div", { class: "model-heading" },
+    number,
+    preview,
+    badge,
+  );
+  const info = el("div", null, heading);
+  const actions = el("div", { class: "model-card-actions" }, defaultLabel, remove);
+  row.dom = el("article", { class: "model-card" },
+    el("div", { class: "model-card-head" }, info, actions),
+    fields,
+  );
+
+  function syncPreview() {
+    preview.textContent = name.value.trim() || "未命名模型";
+    name.setAttribute("aria-invalid", "false");
+    clearModelOptions(row);
+    markDirty("models");
+  }
+
+  name.addEventListener("input", syncPreview);
+  modelPicker.addEventListener("change", () => {
+    if (!modelPicker.value) return;
+    name.value = modelPicker.value;
+    preview.textContent = name.value;
+    markDirty("models");
+  });
+  fetchButton.addEventListener("click", () => fetchModels(row));
+  base.addEventListener("input", () => { clearModelOptions(row); markDirty("models"); });
+  key.addEventListener("input", () => {
+    key.setAttribute("aria-invalid", "false");
+    clearModelOptions(row);
+    markDirty("models");
+  });
+  context.addEventListener("input", () => { markDirty("models"); });
+  def.addEventListener("change", () => {
+    markDirty("models");
+    syncModelStates();
+  });
+  keyToggle.addEventListener("click", () => {
+    const visible = key.type === "text";
+    key.type = visible ? "password" : "text";
+    keyToggle.textContent = visible ? "显示" : "隐藏";
+    keyToggle.setAttribute("aria-pressed", String(!visible));
+  });
+  remove.addEventListener("click", () => {
+    const wasDefault = row.def.checked;
+    clearModelOptions(row);
+    row.dom.remove();
+    const index = modelRows.indexOf(row);
+    if (index >= 0) modelRows.splice(index, 1);
+    if (wasDefault && modelRows.length > 0) modelRows[0].def.checked = true;
+    markDirty("models");
+    syncModelStates();
+    updateModelCount();
+  });
+
   modelRows.push(row);
   $("models").appendChild(row.dom);
+  syncPreview();
+  syncModelStates();
+  updateModelCount();
 }
 
-function setStatus(text, ok) {
-  const s = $("status");
-  s.className = ok ? "ok" : "err";
-  s.textContent = text;
+function setRuleVisibility(onId, bodyId) {
+  $(bodyId).hidden = !$(onId).checked;
 }
 
-async function load() {
-  const res = await fetch("/api/config");
-  const doc = await res.json();
-  if (!res.ok) { setStatus(doc.error || "Failed to load", false); return; }
-  orig = doc;
-  $("path").textContent = "config: " + (doc.path || "");
+function wire(id, key, event) {
+  $(id).addEventListener(event || "input", () => {
+    markDirty(key);
+    if (id === "mode") updateModeHint();
+  });
+}
 
-  $("models").innerHTML = "";
-  modelRows.length = 0;
-  if (doc.models && doc.models.length) doc.models.forEach(addModelRow);
-  else addModelRow(null);
+function wireRule(onId, bodyId, key, ...fieldIds) {
+  const on = $(onId);
+  on.addEventListener("change", () => {
+    markDirty(key);
+    setRuleVisibility(onId, bodyId);
+  });
+  for (const id of fieldIds) {
+    $(id).addEventListener("input", () => {
+      if (!on.checked) on.checked = true;
+      markDirty(key);
+      setRuleVisibility(onId, bodyId);
+    });
+  }
+}
 
-  const p = doc.permissions || {};
-  $("skillPath").value = doc.skillPath || "";
-  $("mode").value = p.mode || "interactive";
-  $("askTimeout").value = p.askTimeoutSec != null ? p.askTimeoutSec : 120;
-  $("wow").checked = p.workspaceOnlyWrites != null ? p.workspaceOnlyWrites : true;
-  $("daa").checked = p.dangerouslyAllowAll != null ? p.dangerouslyAllowAll : false;
+function resetDirty() {
+  for (const key in dirty) dirty[key] = false;
+  updateDirtyState();
+}
 
-  const b = p.bash || {};
-  $("bashOn").checked = !!p.bash;
-  $("bashDefault").value = b.default || "ask";
-  $("bashAllow").value = (b.allow || []).join("\n");
-  $("bashDeny").value = (b.deny || []).join("\n");
-  $("bashBody").style.display = $("bashOn").checked ? "" : "none";
+function validatePositiveInteger(input, label) {
+  const value = input.value.trim();
+  const valid = value === "" || (Number.isSafeInteger(Number(value)) && Number(value) > 0);
+  input.setAttribute("aria-invalid", String(!valid));
+  if (!valid) {
+    setStatus(label + "必须是大于 0 的整数。", "error");
+    input.focus();
+    return false;
+  }
+  return true;
+}
 
-  const f = p.fetch || {};
-  $("fetchOn").checked = !!p.fetch;
-  $("fetchDefault").value = f.default || "ask";
-  $("fetchHosts").value = (f.allowedHosts || []).join("\n");
-  $("fetchBody").style.display = $("fetchOn").checked ? "" : "none";
+function readOptionalInteger(input) {
+  return input.value.trim() ? Number(input.value) : null;
+}
 
-  for (const k in dirty) dirty[k] = false;
-  setStatus("Loaded. Saving rewrites config.yaml (auto-backup to config.yaml.bak)", true);
+function validateForm() {
+  for (let i = 0; i < modelRows.length; i++) {
+    const row = modelRows[i];
+    row.name.setAttribute("aria-invalid", "false");
+    row.key.setAttribute("aria-invalid", "false");
+    if (!row.name.value.trim()) {
+      row.name.setAttribute("aria-invalid", "true");
+      setStatus("模型 " + (i + 1) + " 需要填写模型名称。", "error");
+      row.name.focus();
+      return false;
+    }
+    if (row.def.checked && !row.key.value.trim()) {
+      row.key.setAttribute("aria-invalid", "true");
+      setStatus("启动模型需要填写 API Key。", "error");
+      row.key.focus();
+      return false;
+    }
+    if (!validatePositiveInteger(row.context, "模型 " + (i + 1) + " 的上下文窗口")) return false;
+  }
+  return validatePositiveInteger($("askTimeout"), "审批超时");
+}
+
+async function load(message, expectedVersion) {
+  setStatus("正在加载配置...", "loading");
+  try {
+    const res = await fetch("/api/config");
+    const doc = await res.json();
+    if (!res.ok) {
+      setStatus(doc.error || "配置加载失败。", "error");
+      return;
+    }
+
+    if (expectedVersion != null && changeVersion !== expectedVersion) {
+      setStatus("已保存先前修改；当前仍有未保存的修改。", "warning");
+      return;
+    }
+
+    orig = doc || {};
+    $("path").textContent = doc.path || "~/.phi/config.yaml";
+    $("models").innerHTML = "";
+    modelRows.length = 0;
+    modelSequence = 0;
+    if (Array.isArray(doc.models) && doc.models.length > 0) doc.models.forEach(addModelRow);
+    else addModelRow(null);
+    syncModelStates();
+    updateModelCount();
+
+    const permissions = doc.permissions || {};
+    $("skillPath").value = doc.skillPath || "";
+    $("mode").value = permissions.mode || "interactive";
+    $("askTimeout").value = permissions.askTimeoutSec != null ? permissions.askTimeoutSec : 120;
+    $("wow").checked = permissions.workspaceOnlyWrites != null ? permissions.workspaceOnlyWrites : true;
+    $("daa").checked = permissions.dangerouslyAllowAll != null ? permissions.dangerouslyAllowAll : false;
+
+    const bash = permissions.bash || {};
+    $("bashOn").checked = !!permissions.bash;
+    $("bashDefault").value = bash.default || "ask";
+    $("bashAllow").value = (bash.allow || []).join("\n");
+    $("bashDeny").value = (bash.deny || []).join("\n");
+    setRuleVisibility("bashOn", "bashBody");
+
+    const fetchRules = permissions.fetch || {};
+    $("fetchOn").checked = !!permissions.fetch;
+    $("fetchDefault").value = fetchRules.default || "ask";
+    $("fetchHosts").value = (fetchRules.allowedHosts || []).join("\n");
+    setRuleVisibility("fetchOn", "fetchBody");
+
+    updateModeHint();
+    resetDirty();
+    setStatus(message || "配置已加载。", "success");
+  } catch (err) {
+    setStatus("配置加载失败：\n" + err.message, "error");
+  } finally {
+    $("editor").removeAttribute("inert");
+  }
 }
 
 function buildPayload() {
-  const p = orig && orig.permissions || {};
+  const permissions = orig && orig.permissions || {};
   const payload = {
-    models: modelRows.map(r => ({
-      name: r.name.value.trim(),
-      apiKey: r.key.value.trim(),
-      baseUrl: r.base.value.trim(),
-      contextWindow: r.ctx.value ? parseInt(r.ctx.value, 10) : null,
-      default: r.def.checked,
+    models: modelRows.map(row => ({
+      name: row.name.value.trim(),
+      apiKey: row.key.value.trim(),
+      baseUrl: row.base.value.trim(),
+      contextWindow: readOptionalInteger(row.context),
+      default: row.def.checked,
     })),
-    skillPath: dirty.skillPath ? ($("skillPath").value.trim() || null) : (p.skillPath ?? null),
+    skillPath: dirty.skillPath ? ($("skillPath").value.trim() || null) : (orig && orig.skillPath != null ? orig.skillPath : null),
+    agents: orig && orig.agents != null ? orig.agents : null,
     permissions: {
-      mode: dirty.mode ? $("mode").value : (p.mode ?? null),
-      workspaceOnlyWrites: dirty.wow ? $("wow").checked : (p.workspaceOnlyWrites ?? null),
-      askTimeoutSec: dirty.askTimeout ? (parseInt($("askTimeout").value, 10) || null) : (p.askTimeoutSec ?? null),
-      dangerouslyAllowAll: dirty.daa ? $("daa").checked : (p.dangerouslyAllowAll ?? null),
+      mode: dirty.mode ? $("mode").value : (permissions.mode != null ? permissions.mode : null),
+      workspaceOnlyWrites: dirty.wow ? $("wow").checked : (permissions.workspaceOnlyWrites != null ? permissions.workspaceOnlyWrites : null),
+      askTimeoutSec: dirty.askTimeout ? (readOptionalInteger($("askTimeout")) || null) : (permissions.askTimeoutSec != null ? permissions.askTimeoutSec : null),
+      dangerouslyAllowAll: dirty.daa ? $("daa").checked : (permissions.dangerouslyAllowAll != null ? permissions.dangerouslyAllowAll : null),
     },
   };
-  if (orig && orig.permissions && orig.permissions.bash && !dirty.bash) {
-    payload.permissions.bash = orig.permissions.bash;
+
+  if (permissions.bash && !dirty.bash) {
+    payload.permissions.bash = permissions.bash;
   } else if ($("bashOn").checked) {
     payload.permissions.bash = {
       default: $("bashDefault").value || null,
@@ -236,51 +1376,59 @@ function buildPayload() {
       deny: splitLines($("bashDeny").value),
     };
   }
-  if (orig && orig.permissions && orig.permissions.fetch && !dirty.fetch) {
-    payload.permissions.fetch = orig.permissions.fetch;
+
+  if (permissions.fetch && !dirty.fetch) {
+    payload.permissions.fetch = permissions.fetch;
   } else if ($("fetchOn").checked) {
     payload.permissions.fetch = {
       default: $("fetchDefault").value || null,
       allowedHosts: splitLines($("fetchHosts").value),
     };
   }
+
   return payload;
 }
 
 async function save() {
-  setStatus("Saving…", true);
-  const res = await fetch("/api/config", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(buildPayload()),
-  });
-  const body = await res.json();
-  if (!res.ok) { setStatus("Save failed:\n" + (body.error || ""), false); return; }
-  setStatus("Saved ✓", true);
-  await load();
+  if (saving || !validateForm()) return;
+  const payload = buildPayload();
+  const savedVersion = changeVersion;
+  saving = true;
+  updateDirtyState();
+  setStatus("正在保存...", "loading");
+  try {
+    const res = await fetch("/api/config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const body = await res.json();
+    if (!res.ok) {
+      setStatus("保存失败：\n" + (body.error || "服务器返回了错误。"), "error");
+      return;
+    }
+    if (changeVersion === savedVersion) {
+      await load("配置已保存，旧文件已备份。", savedVersion);
+    } else {
+      setStatus("已保存先前修改；当前仍有未保存的修改。", "warning");
+    }
+  } catch (err) {
+    setStatus("保存失败：\n" + err.message, "error");
+  } finally {
+    saving = false;
+    updateDirtyState();
+  }
 }
 
-// --- wiring ---
-$("add").onclick = () => addModelRow(null);
-$("save").onclick = save;
-
-const wire = (id, key, evt) => $(id).addEventListener(evt || "input", () => { dirty[key] = true; });
+$("add").addEventListener("click", () => addModelRow(null));
+$("save").addEventListener("click", save);
 wire("mode", "mode", "change");
 wire("askTimeout", "askTimeout");
 wire("wow", "wow", "change");
 wire("daa", "daa", "change");
 wire("skillPath", "skillPath");
-
-function wireBlock(onId, bodyId, key, ...fieldIds) {
-  const on = $(onId);
-  const body = $(bodyId);
-  const show = () => { body.style.display = on.checked ? "" : "none"; dirty[key] = true; };
-  on.addEventListener("change", () => { dirty[key] = true; show(); });
-  for (const id of fieldIds) $(id).addEventListener("input", () => { if (!on.checked) { on.checked = true; } dirty[key] = true; show(); });
-  // keep the block visible even when untouched so the user sees it exists
-}
-wireBlock("bashOn", "bashBody", "bash", "bashDefault", "bashAllow", "bashDeny");
-wireBlock("fetchOn", "fetchBody", "fetch", "fetchDefault", "fetchHosts");
+wireRule("bashOn", "bashBody", "bash", "bashDefault", "bashAllow", "bashDeny");
+wireRule("fetchOn", "fetchBody", "fetch", "fetchDefault", "fetchHosts");
 
 load();
 </script>

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pulseaiclub/phi/internal/project"
@@ -30,6 +33,8 @@ permissions:
     default: ask
     allow:
       - "^git "
+agents:
+  enabled: false
 `
 
 func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
@@ -43,7 +48,7 @@ func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
 
 	// GET serves the current document.
 	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/config", nil))
+	h.ServeHTTP(rr, newLocalAPIRequest(http.MethodGet, "/api/config", nil))
 	require.Equal(t, http.StatusOK, rr.Code)
 	var got configDoc
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
@@ -53,6 +58,8 @@ func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
 	require.NotNil(t, got.Permissions)
 	require.NotNil(t, got.Permissions.Bash)
 	assert.Equal(t, []string{"^git "}, got.Permissions.Bash.Allow)
+	require.NotNil(t, got.Agents)
+	assert.False(t, got.Agents.Enabled)
 	assert.Equal(t, path, got.Path)
 
 	// Edit: drop model-b and change the api_key, keep permissions untouched.
@@ -62,7 +69,7 @@ func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	rr = httptest.NewRecorder()
-	h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
+	h.ServeHTTP(rr, newJSONAPIRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	// The app must be able to load the written file with the same results.
@@ -77,6 +84,7 @@ func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
 	assert.Equal(t, "readonly", string(cfg.Permissions.Mode))
 	assert.True(t, cfg.Permissions.DangerouslyAllowAll)
 	assert.Equal(t, []string{"^git "}, cfg.Permissions.BashAllow)
+	assert.False(t, cfg.Agents.Enabled)
 
 	// The previous file content is kept as a backup.
 	bak, err := os.ReadFile(path + ".bak")
@@ -87,7 +95,7 @@ func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
 func TestConfigHandlerMissingFile(t *testing.T) {
 	h := &configHandler{configPath: filepath.Join(t.TempDir(), "nope.yaml")}
 	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/config", nil))
+	h.ServeHTTP(rr, newLocalAPIRequest(http.MethodGet, "/api/config", nil))
 	require.Equal(t, http.StatusOK, rr.Code)
 	var doc configDoc
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &doc))
@@ -110,7 +118,7 @@ func TestConfigHandlerValidation(t *testing.T) {
 			body, err := json.Marshal(tc.doc)
 			require.NoError(t, err)
 			rr := httptest.NewRecorder()
-			h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
+			h.ServeHTTP(rr, newJSONAPIRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
 			require.Equal(t, http.StatusBadRequest, rr.Code)
 		})
 	}
@@ -120,7 +128,7 @@ func TestConfigHandlerValidation(t *testing.T) {
 	body, err := json.Marshal(doc)
 	require.NoError(t, err)
 	rr := httptest.NewRecorder()
-	h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
+	h.ServeHTTP(rr, newJSONAPIRequest(http.MethodPost, "/api/config", strings.NewReader(string(body))))
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	data, err := os.ReadFile(h.configPath)
@@ -134,6 +142,216 @@ func TestConfigHandlerServesPage(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), "phi config")
+	assert.Contains(t, rr.Body.String(), `lang="zh-CN"`)
+	assert.Contains(t, rr.Body.String(), "配置中心")
+	require.Contains(t, rr.Body.String(), `type: "password"`)
+	assert.Contains(t, rr.Body.String(), "tokens")
+	assert.Contains(t, rr.Body.String(), "seconds")
 	assert.Contains(t, rr.Body.String(), "/api/config")
+	assert.Contains(t, rr.Body.String(), "/api/models")
+}
+
+func TestConfigHandlerListsModels(t *testing.T) {
+	cases := []struct {
+		name       string
+		model      string
+		response   string
+		wantPath   string
+		wantModels []string
+		checkAuth  func(*testing.T, *http.Request)
+	}{
+		{
+			name:       "openai compatible",
+			model:      "gpt-4o",
+			response:   `{"data":[{"id":"z-model"},{"id":"a-model"},{"id":"z-model"}]}`,
+			wantPath:   "/v1/models",
+			wantModels: []string{"a-model", "z-model"},
+			checkAuth: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+				assert.Empty(t, r.Header.Get("Anthropic-Version"))
+			},
+		},
+		{
+			name:       "anthropic",
+			model:      "claude-sonnet-4-20250514",
+			response:   `{"data":[{"id":"claude-sonnet-4-20250514","display_name":"Claude Sonnet"}]}`,
+			wantPath:   "/v1/models",
+			wantModels: []string{"claude-sonnet-4-20250514"},
+			checkAuth: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "test-key", r.Header.Get("X-Api-Key"))
+				assert.Equal(t, "2023-06-01", r.Header.Get("Anthropic-Version"))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tc.wantPath, r.URL.Path)
+				tc.checkAuth(t, r)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.response))
+			}))
+			defer server.Close()
+
+			body, err := json.Marshal(modelListRequest{
+				BaseURL: server.URL + "/v1",
+				APIKey:  "test-key",
+				Model:   tc.model,
+			})
+			require.NoError(t, err)
+
+			h := &configHandler{configPath: filepath.Join(t.TempDir(), "config.yaml")}
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, newJSONAPIRequest(http.MethodPost, "/api/models", strings.NewReader(string(body))))
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			var got struct {
+				Models []string `json:"models"`
+			}
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+			assert.Equal(t, tc.wantModels, got.Models)
+		})
+	}
+}
+
+func TestConfigHandlerModelListRedirects(t *testing.T) {
+	t.Run("same origin is followed", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/v1/models":
+				http.Redirect(w, r, "/models-final", http.StatusTemporaryRedirect)
+			case "/models-final":
+				assert.Equal(t, "test-key", r.Header.Get("X-Api-Key"))
+				_, _ = w.Write([]byte(`{"data":[{"id":"claude-model"}]}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		rr := requestModelList(t, server.URL+"/v1", "claude-model")
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "claude-model")
+	})
+
+	t.Run("cross origin is rejected without forwarding key", func(t *testing.T) {
+		var targetRequests atomic.Int32
+		target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			targetRequests.Add(1)
+			assert.Empty(t, r.Header.Get("X-Api-Key"))
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		}))
+		defer target.Close()
+
+		source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, target.URL+"/models", http.StatusTemporaryRedirect)
+		}))
+		defer source.Close()
+
+		rr := requestModelList(t, source.URL+"/v1", "claude-model")
+		require.Equal(t, http.StatusBadGateway, rr.Code)
+		assert.Zero(t, targetRequests.Load())
+	})
+}
+
+func TestConfigHandlerRejectsUnsafePOSTs(t *testing.T) {
+	const localHost = "127.0.0.1:43210"
+	const localOrigin = "http://127.0.0.1:43210"
+
+	var targetRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetRequests.Add(1)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer target.Close()
+
+	configBody := `{"models":[{"name":"model","apiKey":"key","default":true}]}`
+	modelBody := fmt.Sprintf(`{"baseUrl":%q,"apiKey":"key","model":"model"}`, target.URL)
+	cases := []struct {
+		name        string
+		path        string
+		body        string
+		contentType string
+		host        string
+		origin      string
+		wantStatus  int
+	}{
+		{"config rejects non-JSON", "/api/config", configBody, "text/plain", localHost, localOrigin, http.StatusUnsupportedMediaType},
+		{"config rejects missing origin", "/api/config", configBody, "application/json", localHost, "", http.StatusForbidden},
+		{"config rejects cross-origin", "/api/config", configBody, "application/json", localHost, "https://attacker.example", http.StatusForbidden},
+		{"config rejects non-loopback host", "/api/config", configBody, "application/json", "attacker.example", "http://attacker.example", http.StatusForbidden},
+		{"models rejects non-JSON", "/api/models", modelBody, "text/plain", localHost, localOrigin, http.StatusUnsupportedMediaType},
+		{"models rejects missing origin", "/api/models", modelBody, "application/json", localHost, "", http.StatusForbidden},
+		{"models rejects cross-origin", "/api/models", modelBody, "application/json", localHost, "https://attacker.example", http.StatusForbidden},
+		{"models rejects non-loopback host", "/api/models", modelBody, "application/json", "attacker.example", "http://attacker.example", http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := targetRequests.Load()
+			h := &configHandler{configPath: filepath.Join(t.TempDir(), "config.yaml")}
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			req.Host = tc.host
+			req.Header.Set("Content-Type", tc.contentType)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			rr := httptest.NewRecorder()
+
+			h.ServeHTTP(rr, req)
+
+			assert.Equal(t, tc.wantStatus, rr.Code)
+			assert.Equal(t, before, targetRequests.Load())
+			_, err := os.Stat(h.configPath)
+			assert.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestConfigHandlerRejectsNonLoopbackGET(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`models:
+  - name: secret-model
+    api_key: secret-key
+    default: true
+`), 0o600))
+
+	h := &configHandler{configPath: path}
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req.Host = "attacker.example"
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "secret-key")
+}
+
+func requestModelList(t *testing.T, baseURL, model string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(modelListRequest{
+		BaseURL: baseURL,
+		APIKey:  "test-key",
+		Model:   model,
+	})
+	require.NoError(t, err)
+
+	h := &configHandler{configPath: filepath.Join(t.TempDir(), "config.yaml")}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, newJSONAPIRequest(http.MethodPost, "/api/models", strings.NewReader(string(body))))
+	return rr
+}
+
+func newJSONAPIRequest(method, target string, body io.Reader) *http.Request {
+	req := newLocalAPIRequest(method, target, body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://"+req.Host)
+	return req
+}
+
+func newLocalAPIRequest(method, target string, body io.Reader) *http.Request {
+	req := httptest.NewRequest(method, target, body)
+	req.Host = "127.0.0.1:43210"
+	return req
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -142,13 +142,16 @@ func TestConfigHandlerServesPage(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
 	require.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), `lang="zh-CN"`)
-	assert.Contains(t, rr.Body.String(), "配置中心")
-	require.Contains(t, rr.Body.String(), `type: "password"`)
-	assert.Contains(t, rr.Body.String(), "tokens")
-	assert.Contains(t, rr.Body.String(), "seconds")
-	assert.Contains(t, rr.Body.String(), "/api/config")
-	assert.Contains(t, rr.Body.String(), "/api/models")
+	body := rr.Body.String()
+	assert.Contains(t, body, `id="langToggle"`)
+	assert.Contains(t, body, "phi-config-lang")
+	assert.Contains(t, body, "配置中心")
+	assert.Contains(t, body, "Config")
+	require.Contains(t, body, `type: "password"`)
+	assert.Contains(t, body, "tokens")
+	assert.Contains(t, body, "seconds")
+	assert.Contains(t, body, "/api/config")
+	assert.Contains(t, body, "/api/models")
 }
 
 func TestConfigHandlerListsModels(t *testing.T) {


### PR DESCRIPTION
## Summary

- localize and redesign the `phi config` editor for clearer hierarchy and responsive layouts
- hide API keys by default, add dirty/save feedback, input constraints, units, and safer save-state handling
- fetch model lists from OpenAI-compatible and Anthropic endpoints through the local config server
- preserve all supported config sections, including `agents.enabled`, when saving
- protect local APIs with loopback Host, same-origin JSON POST, response-size, timeout, and redirect-origin checks

## Why

The existing editor exposed API keys, used limited page width, and made model/default/save state difficult to understand. Model names also had to be entered manually. This change keeps the editor dependency-free while making routine configuration clearer and allowing model discovery from the configured provider.

## User impact

- the editor is fully usable in Chinese on desktop and mobile
- only unsaved changes activate the primary save action
- model credentials and limits are easier to scan and validate
- model lists can be fetched without exposing provider credentials to cross-origin redirects
- edits made while a save is in flight are not overwritten by the follow-up reload

## Validation

- `go test ./...`
- `go vet ./...`
- embedded JavaScript syntax checked with `node --check`
- desktop and 390px mobile layouts checked in Chromium
