### PR TITLE
feat(bashtool): support Windows with native shell resolution

### DIFF
--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -7,7 +7,7 @@ import (
 )
 
 // contextFileCandidates are checked in order within a single directory;
-// the first readable match wins (same as pi-main).
+// the first readable match wins.
 var contextFileCandidates = []string{
 	"AGENTS.md",
 	"AGENTS.MD",
@@ -34,7 +34,7 @@ func loadContextFileFromDir(dir string) *ContextFile {
 	return nil
 }
 
-// loadProjectContextFiles discovers AGENTS.md / CLAUDE.md like pi-main:
+// loadProjectContextFiles discovers AGENTS.md / CLAUDE.md in the workspace:
 //  1. global agent dir (~/.phi) first
 //  2. then every ancestor from filesystem root down to cwd (cwd last)
 //

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -217,7 +217,7 @@ type LoopOpts struct {
 // Loop appends the user prompt and runs inference + tool rounds until the
 // model stops calling tools or the context is cancelled.
 //
-// Compaction follows pi-main: persist the turn first, then check usage after
+// Compaction: persist the turn first, then check usage after
 // the agent turn ends (final assistant with no tool_calls) — never mid-tool-loop.
 func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) iter.Seq2[session.Event, error] {
 	return func(yield func(session.Event, error) bool) {

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -45,7 +45,7 @@ func GetWorkspaceDir() string {
 }
 
 // Prompt builds the system prompt. Loads AGENTS.md/CLAUDE.md (global ~/.phi +
-// cwd ancestors, same rules as pi-main) into <project_context>, then optionally
+// cwd ancestors, same rules as the context loader) into <project_context>, then optionally
 // appends a Skills block when skillPath is non-empty.
 func Prompt(skillPath string) string {
 	base := fmt.Sprintf(systemPromptTmpl, GetCurrentDir(), GetWorkspaceDir())

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -26,7 +26,7 @@ func (g GlobalLayout) SessionBase() string { return filepath.Join(g.root, "sessi
 func (g GlobalLayout) JobsDir() string     { return filepath.Join(g.root, "jobs") }
 
 // SessionDir returns the per-cwd session storage directory
-// (~/.phi/session/<encoded-cwd>/), matching panda / pi layout.
+// (~/.phi/session/<encoded-cwd>/), matching panda's layout.
 func (p *Project) SessionDir() string {
 	return ProjectSessionDir(p.global.SessionBase(), p.root)
 }

--- a/internal/project/session_dir.go
+++ b/internal/project/session_dir.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ProjectDirName returns a filesystem-safe directory name derived from cwd,
-// matching panda / pi coding-agent:
+// matching panda's coding-agent:
 //
 //	--<cwd with leading path sep stripped and / \ : replaced by ->--
 func ProjectDirName(cwd string) string {

--- a/internal/tools/bashtool/bash.go
+++ b/internal/tools/bashtool/bash.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/pulseaiclub/phi/internal/tools/tooldef"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -77,11 +76,14 @@ func runBash(ctx context.Context, input json.RawMessage) (tooldef.Result, error)
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	c := exec.CommandContext(ctx, "bash", "-c", cmd)
+	c, err := buildShellCommand(ctx, cmd)
+	if err != nil {
+		return tooldef.Result{}, err
+	}
 	var buf bytes.Buffer
 	c.Stdout = &buf
 	c.Stderr = &buf
-	err := c.Run()
+	err = c.Run()
 
 	out := FormatBashOutput(buf.String())
 	if strings.TrimSpace(out) == "" {

--- a/internal/tools/bashtool/command.go
+++ b/internal/tools/bashtool/command.go
@@ -1,0 +1,94 @@
+package bashtool
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// shellWaitDelay is how long Cmd.Wait waits after Cancel for the process tree
+// to exit before sending a hard kill (TerminateProcess / SIGKILL). Prevents
+// indefinite hangs when taskkill fails or a child breaks out of the tree.
+const shellWaitDelay = 3 * time.Second
+
+// shellEnv returns the environment for shell commands: the parent env with
+// phi's bin dir (~/.phi/bin, where fd/ripgrep are downloaded) prepended to
+// PATH.
+func shellEnv() []string {
+	env := os.Environ()
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		return env
+	}
+	binDir := filepath.Join(homeDir, ".phi", "bin")
+	if _, err := os.Stat(binDir); err != nil {
+		return env
+	}
+	return prependPathEntry(env, binDir)
+}
+
+// prependPathEntry prepends dir to the PATH entry of env (the PATH key is
+// matched case-insensitively, as Windows uses "Path"). Returns env unchanged
+// when dir is already present.
+func prependPathEntry(env []string, dir string) []string {
+	pathKey, pathIdx := "PATH", -1
+	for i, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if ok && strings.EqualFold(key, "PATH") {
+			pathKey, pathIdx = key, i
+			break
+		}
+	}
+	if pathIdx < 0 {
+		return append(env, pathKey+"="+dir)
+	}
+	cur := strings.TrimPrefix(env[pathIdx], pathKey+"=")
+	for _, seg := range filepath.SplitList(cur) {
+		if samePath(seg, dir) {
+			return env
+		}
+	}
+	updated := make([]string, len(env))
+	copy(updated, env)
+	updated[pathIdx] = pathKey + "=" + dir + string(os.PathListSeparator) + cur
+	return updated
+}
+
+func samePath(a, b string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+// buildShellCommand builds the shell command for command, applying the
+// resolved shell config, phi's bin dir on PATH, and process-group/tree
+// cancellation: on context cancellation the whole tree is killed
+// (taskkill /T on Windows, process-group SIGKILL elsewhere).
+func buildShellCommand(ctx context.Context, command string) (*exec.Cmd, error) {
+	cfg, err := resolveShellConfig()
+	if err != nil {
+		return nil, err
+	}
+	var cmd *exec.Cmd
+	if cfg.stdinMode {
+		cmd = exec.CommandContext(ctx, cfg.shell, cfg.args...)
+		cmd.Stdin = strings.NewReader(command)
+	} else {
+		cmd = exec.CommandContext(ctx, cfg.shell, append(cfg.args, command)...)
+	}
+	cmd.Env = shellEnv()
+	cmd.SysProcAttr = processGroupAttr()
+	cmd.WaitDelay = shellWaitDelay
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return killProcessTree(cmd.Process.Pid)
+	}
+	return cmd, nil
+}

--- a/internal/tools/bashtool/process_unix.go
+++ b/internal/tools/bashtool/process_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package bashtool
+
+import (
+	"syscall"
+)
+
+// processGroupAttr puts each shell in its own process group so the whole tree
+// can be killed with a single negative-pid signal.
+func processGroupAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessTree kills pid and all descendants (the process group), falling
+// back to killing the leader only if the group is already gone.
+func killProcessTree(pid int) error {
+	if pid <= 0 {
+		return nil
+	}
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
+		return syscall.Kill(pid, syscall.SIGKILL)
+	}
+	return nil
+}

--- a/internal/tools/bashtool/process_windows.go
+++ b/internal/tools/bashtool/process_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package bashtool
+
+import (
+	"io"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+// processGroupAttr hides the console window of spawned shells.
+// Windows has no POSIX signals; trees are killed via taskkill.
+func processGroupAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{HideWindow: true}
+}
+
+// killProcessTree terminates pid and its descendants via taskkill /T.
+// Errors are ignored (best-effort): the process may already be gone,
+// and Cmd.WaitDelay hard-kills the shell if the tree survives.
+func killProcessTree(pid int) error {
+	if pid <= 0 {
+		return nil
+	}
+	kill := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid))
+	kill.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	kill.Stdout = io.Discard
+	kill.Stderr = io.Discard
+	_ = kill.Run()
+	return nil
+}

--- a/internal/tools/bashtool/shell_exec.go
+++ b/internal/tools/bashtool/shell_exec.go
@@ -30,7 +30,10 @@ func ExecShell(ctx context.Context, command string, opts ShellExecOptions) (Shel
 		return ShellExecResult{}, fmt.Errorf("empty command")
 	}
 
-	cmd := exec.CommandContext(ctx, "bash", "-c", command)
+	cmd, err := buildShellCommand(ctx, command)
+	if err != nil {
+		return ShellExecResult{}, err
+	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return ShellExecResult{}, err

--- a/internal/tools/bashtool/shellconfig.go
+++ b/internal/tools/bashtool/shellconfig.go
@@ -1,0 +1,132 @@
+package bashtool
+
+// Shell resolution for the bash tool:
+//
+//   - Windows: Git Bash at known locations (%ProgramFiles%\Git\bin\bash.exe,
+//     %ProgramFiles(x86)%\Git\bin\bash.exe), then bash.exe on PATH
+//     (Cygwin, MSYS2, WSL).
+//   - WSL's legacy bash.exe shim (C:\Windows\System32\bash.exe) can't take
+//     "-c" arguments, so commands are fed via stdin ("bash -s").
+//   - Unix: /bin/bash, then bash on PATH, then fall back to sh.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// shellConfig describes how to launch the resolved shell.
+type shellConfig struct {
+	shell     string
+	args      []string
+	stdinMode bool // feed the command via stdin ("-s") instead of "-c <cmd>"
+}
+
+var (
+	shellCfgMu  sync.Mutex
+	shellCfg    shellConfig
+	shellCfgSet bool
+)
+
+// resolveShellConfig returns the cached shell config. On failure nothing is
+// cached, so installing Git Bash while phi runs takes effect on the next call.
+func resolveShellConfig() (shellConfig, error) {
+	shellCfgMu.Lock()
+	defer shellCfgMu.Unlock()
+	if shellCfgSet {
+		return shellCfg, nil
+	}
+	cfg, err := resolveShellConfigUncached()
+	if err == nil {
+		shellCfg, shellCfgSet = cfg, true
+	}
+	return cfg, err
+}
+
+func resolveShellConfigUncached() (shellConfig, error) {
+	if runtime.GOOS == "windows" {
+		var searched []string
+		for _, dir := range gitBashDirs() {
+			p := filepath.Join(dir, "Git", "bin", "bash.exe")
+			searched = append(searched, p)
+			if isFile(p) {
+				return configForShell(p), nil
+			}
+		}
+		if p := findBashOnPath(); p != "" {
+			return configForShell(p), nil
+		}
+		return shellConfig{}, fmt.Errorf(
+			"no bash shell found: install Git for Windows (https://git-scm.com/download/win) "+
+				"or add bash (Cygwin/MSYS2/WSL) to PATH; searched: %s",
+			strings.Join(searched, ", "))
+	}
+	if isFile("/bin/bash") {
+		return configForShell("/bin/bash"), nil
+	}
+	if p := findBashOnPath(); p != "" {
+		return configForShell(p), nil
+	}
+	return shellConfig{shell: "sh", args: []string{"-c"}}, nil
+}
+
+func gitBashDirs() []string {
+	var dirs []string
+	for _, key := range []string{"ProgramFiles", "ProgramFiles(x86)"} {
+		if v := os.Getenv(key); v != "" {
+			dirs = append(dirs, v)
+		}
+	}
+	return dirs
+}
+
+var wslBashRe = regexp.MustCompile(`^[a-z]:\\windows\\(?:system32|sysnative)\\bash\.exe$`)
+
+// isLegacyWslBashPath reports whether path is Windows' legacy WSL bash shim,
+// which doesn't handle "-c" arguments well.
+func isLegacyWslBashPath(path string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(path, "/", `\`))
+	return wslBashRe.MatchString(normalized)
+}
+
+func configForShell(path string) shellConfig {
+	if isLegacyWslBashPath(path) {
+		return shellConfig{shell: path, args: []string{"-s"}, stdinMode: true}
+	}
+	return shellConfig{shell: path, args: []string{"-c"}}
+}
+
+// findBashOnPath locates bash via `where bash.exe` (Windows) / `which bash`
+// (Unix). `where` can list paths that don't exist, so results are verified.
+func findBashOnPath() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	prog, arg := "which", "bash"
+	if runtime.GOOS == "windows" {
+		prog, arg = "where", "bash.exe"
+	}
+	out, err := exec.CommandContext(ctx, prog, arg).Output()
+	if err != nil {
+		return ""
+	}
+	first := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	if first == "" {
+		return ""
+	}
+	if runtime.GOOS == "windows" && !isFile(first) {
+		return ""
+	}
+	return first
+}
+
+func isFile(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
+}

--- a/internal/tools/bashtool/shellconfig_test.go
+++ b/internal/tools/bashtool/shellconfig_test.go
@@ -1,0 +1,98 @@
+package bashtool
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestIsLegacyWslBashPath(t *testing.T) {
+	for _, p := range []string{
+		`C:\Windows\System32\bash.exe`,
+		`c:\windows\system32\bash.exe`,
+		`C:/Windows/Sysnative/bash.exe`,
+	} {
+		if !isLegacyWslBashPath(p) {
+			t.Errorf("want WSL shim for %q", p)
+		}
+	}
+	for _, p := range []string{
+		`C:\Program Files\Git\bin\bash.exe`,
+		`C:\Program Files\WSL\bash.exe`,
+		`/bin/bash`,
+		`C:\Windows\System32\wsl.exe`,
+	} {
+		if isLegacyWslBashPath(p) {
+			t.Errorf("not a WSL shim for %q", p)
+		}
+	}
+}
+
+func TestConfigForShell(t *testing.T) {
+	cfg := configForShell(`C:\Program Files\Git\bin\bash.exe`)
+	if cfg.stdinMode || len(cfg.args) != 1 || cfg.args[0] != "-c" {
+		t.Fatalf("git bash config: %+v", cfg)
+	}
+	cfg = configForShell(`C:\Windows\System32\bash.exe`)
+	if !cfg.stdinMode || len(cfg.args) != 1 || cfg.args[0] != "-s" {
+		t.Fatalf("WSL shim must use stdin transport: %+v", cfg)
+	}
+}
+
+func TestResolveShellConfig(t *testing.T) {
+	cfg, err := resolveShellConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.shell == "" {
+		t.Fatal("empty shell")
+	}
+	if runtime.GOOS == "windows" && !cfg.stdinMode && (len(cfg.args) != 1 || cfg.args[0] != "-c") {
+		t.Fatalf("windows config: %+v", cfg)
+	}
+}
+
+func TestPrependPathEntry(t *testing.T) {
+	got := prependPathEntry([]string{"PATH=/usr/bin:/bin"}, "/x/bin")
+	if got[0] != "PATH=/x/bin:/usr/bin:/bin" {
+		t.Fatalf("got %q", got[0])
+	}
+
+	// Already present → unchanged.
+	got = prependPathEntry([]string{"PATH=/usr/bin:/x/bin"}, "/x/bin")
+	if len(got) != 1 || got[0] != "PATH=/usr/bin:/x/bin" {
+		t.Fatalf("expected unchanged, got %v", got)
+	}
+
+	// Windows-style key casing is matched case-insensitively.
+	got = prependPathEntry([]string{"Path=C:\\Windows"}, `C:\Phi\bin`)
+	if !strings.HasPrefix(got[0], "Path=") || !strings.Contains(got[0], `C:\Phi\bin`) {
+		t.Fatalf("got %q", got[0])
+	}
+
+	// No PATH entry → appended.
+	got = prependPathEntry([]string{"HOME=/home/x"}, "/x/bin")
+	if len(got) != 2 || got[1] != "PATH=/x/bin" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestBuildShellCommand(t *testing.T) {
+	cmd, err := buildShellCommand(context.Background(), "echo hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.SysProcAttr == nil {
+		t.Fatal("expected process-group syscall attr")
+	}
+	if cmd.Cancel == nil {
+		t.Fatal("expected tree-kill cancel")
+	}
+	if cmd.WaitDelay != shellWaitDelay {
+		t.Fatalf("WaitDelay=%v, want %v", cmd.WaitDelay, shellWaitDelay)
+	}
+	if len(cmd.Env) == 0 {
+		t.Fatal("expected enriched env")
+	}
+}


### PR DESCRIPTION
The bash tool no longer assumes bash is on PATH. It resolves a real shell per platform, so the same binary works on macOS, Linux, and Windows without a WSL bridge:

- Resolve the shell: Git Bash at known install locations (%ProgramFiles%\Git\bin\bash.exe, %ProgramFiles(x86)%\...), then bash.exe on PATH (Cygwin/MSYS2/WSL); Unix falls back through /bin/bash -> which bash -> sh. Success is cached; failures re-resolve so installing Git Bash later takes effect.
- Detect the legacy WSL bash shim (System32/Sysnative\bash.exe) and feed commands via stdin ("bash -s") instead of "-c", which it mishandles.
- Kill the whole process tree on cancel/timeout: taskkill /F /T on Windows, process-group SIGKILL (Setpgid) elsewhere, via cmd.Cancel.
- Hide the spawned console window on Windows.
- Prepend ~/.phi/bin to PATH (case-insensitive PATH key lookup) so downloaded fd/ripgrep resolve inside shell commands.

Both the agent bash tool and the TUI "!command" path go through the new buildShellCommand helper.

Also drop external project attributions from comments in agent/, project/, and bashtool/ packages.