### PR TITLE
feat(agent): gate sub-agent guidance in system prompt

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -73,7 +73,7 @@ func NewEngine(opts EngineOpts) (*Engine, error) {
 		engine.maxRounds = opts.MaxRounds
 	}
 	toolList := engine.buildToolList(opts.Tools)
-	engine.client = llmclient.NewClient(cfg, tools.Definitions(toolList), Prompt(cfg.SkillPath))
+	engine.client = llmclient.NewClient(cfg, tools.Definitions(toolList), Prompt(cfg.SkillPath, engine.jobs != nil))
 	engine.executor = NewExecutor(tools.NewRegistry(toolList), opts.Gate, opts.Ask)
 	return engine, nil
 }
@@ -118,7 +118,7 @@ func (engine *Engine) SetJobs(jobs *job.Manager) {
 
 func (engine *Engine) rebindTools() {
 	toolList := engine.buildToolList(nil)
-	engine.client = llmclient.NewClient(engine.modelCfg, tools.Definitions(toolList), Prompt(engine.skillPath))
+	engine.client = llmclient.NewClient(engine.modelCfg, tools.Definitions(toolList), Prompt(engine.skillPath, engine.jobs != nil))
 	engine.executor = NewExecutor(tools.NewRegistry(toolList), engine.gate, engine.ask)
 }
 

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/pulseaiclub/phi/internal/llm/skills"
 )
@@ -13,9 +14,17 @@ import (
 var (
 	//go:embed system-prompt.tmpl
 	systemPromptTmpl string
+
+	systemPrompt = template.Must(template.New("system").Parse(systemPromptTmpl))
 )
 
 const defaultMaxToolRounds = 64
+
+type promptData struct {
+	Cwd           string
+	Workspace     string
+	AgentsEnabled bool
+}
 
 func GetCurrentDir() string {
 	path, err := os.Getwd()
@@ -44,12 +53,22 @@ func GetWorkspaceDir() string {
 	return ""
 }
 
-// Prompt builds the system prompt. Loads AGENTS.md/CLAUDE.md (global ~/.phi +
-// cwd ancestors, same rules as the context loader) into <project_context>, then optionally
-// appends a Skills block when skillPath is non-empty.
-func Prompt(skillPath string) string {
-	base := fmt.Sprintf(systemPromptTmpl, GetCurrentDir(), GetWorkspaceDir())
-	parts := []string{base}
+// Prompt builds the system prompt. agentsEnabled controls whether sub-agent
+// discovery guidance is included (must match whether agent_* tools are registered).
+// Loads AGENTS.md/CLAUDE.md (global ~/.phi + cwd ancestors) into <project_context>,
+// then optionally appends a Skills block when skillPath is non-empty.
+func Prompt(skillPath string, agentsEnabled bool) string {
+	var buf strings.Builder
+	data := promptData{
+		Cwd:           GetCurrentDir(),
+		Workspace:     GetWorkspaceDir(),
+		AgentsEnabled: agentsEnabled,
+	}
+	if err := systemPrompt.Execute(&buf, data); err != nil {
+		// Parsed at init; Execute only fails on writer errors.
+		panic(fmt.Sprintf("system prompt: %v", err))
+	}
+	parts := []string{buf.String()}
 	if ctx := formatProjectContext(loadProjectContextFiles(GetCurrentDir(), phiAgentDir())); ctx != "" {
 		parts = append(parts, ctx)
 	}

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -1,0 +1,24 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPromptAgentsEnabledToggle(t *testing.T) {
+	with := Prompt("", true)
+	without := Prompt("", false)
+
+	if !strings.Contains(with, "agent_task") {
+		t.Fatal("expected agent_task guidance when agents enabled")
+	}
+	if !strings.Contains(with, "Sub-agents:") {
+		t.Fatal("expected Sub-agents section when agents enabled")
+	}
+	if strings.Contains(without, "agent_task") || strings.Contains(without, "agent_spawn") {
+		t.Fatal("did not expect sub-agent tool names when agents disabled")
+	}
+	if !strings.Contains(without, "`glob` / `grep` / `list` yourself") {
+		t.Fatal("expected direct-search guidance when agents disabled")
+	}
+}

--- a/internal/agent/system-prompt.tmpl
+++ b/internal/agent/system-prompt.tmpl
@@ -1,38 +1,40 @@
-You are phi, an autonomous coding agent in a shared workspace. Deliver the outcome the user wants: correct, minimal, verified. Prefer action over proposals unless they asked for advice, a plan, or an explanation only.
+You are phi, an autonomous coding agent in a shared workspace. Deliver the outcome the user wants: correct, minimal, verified.
 
-# Think before you act
-Classify the request, then choose a path:
-1. **Answer / explain** — use tools only to gather evidence; do not edit.
+# Classify
+Classify the request, then choose a path. Only Implement / Debug default to editing.
+1. **Answer / explain** — tools only for evidence; do not edit.
 2. **Implement / fix** — explore → change → verify → summarize.
-3. **Debug** — reproduce or locate failure → form a hypothesis → gather evidence → fix root cause → re-verify. Do not shotgun unrelated changes.
+3. **Debug** — reproduce or locate failure → hypothesis → evidence → fix root cause → re-verify. No shotgun unrelated changes.
 4. **Review / plan** — analyze and recommend; edit only if asked.
 
-When intent is ambiguous but low-risk, prefer the smallest useful action. Ask only when missing information would materially change the design or create meaningful risk—keep questions narrow.
+When intent is ambiguous but low-risk, take the smallest useful action on that path. Ask only when missing information would materially change the design, touch shared APIs, delete data, or drive a multi-file refactor—keep questions narrow.
 
-# Evidence over assumption
-- Ground claims about code, APIs, paths, and commands in tool results or injected context. Do not invent file contents, flags, or libraries.
-- Confirm a dependency exists in the repo (manifests, imports, neighbors) before using it.
-- Prefer the local pattern over a "cleaner" rewrite. Match naming, structure, and error handling already in the file.
-- If tool output contradicts your plan, update the plan; do not force a bad edit.
-- Redaction markers mean secrets were stripped at ingest—never treat placeholders as literal edit content.
+# Evidence
+- Do not invent file contents, APIs, flags, or libraries—ground claims in tool results or injected context.
+- Before using a dependency, confirm it exists in the repo (manifests, imports, or neighbors).
 
-# Discovery (stop when uncertainty is resolved)
-Use the narrowest tool that answers the next uncertainty:
-1. Known path or exact symbol → `list` / `glob` / `grep` / `read` directly (folders → list or glob first; never `read` a directory).
-2. Open-ended search (vague keyword, unsure where to look, likely many glob/grep rounds) → when available, prefer `agent_task` with `role=explore` (or parallel `agent_spawn`) so exploration stays out of this context; then act on the summary. Use `role=review` for check/diff pass; `role=worker` only for a scoped, already-planned implementation.
+# Discovery
+Use the narrowest tool that answers the next uncertainty; stop when uncertainty is resolved. Prefer specialized tools over `bash` (bash for builds, tests, git, and OS tasks those tools cannot do).
+1. Known path or exact symbol → `list` / `glob` / `grep` / `read` yourself (folders → list or glob first; never `read` a directory).
+{{- if .AgentsEnabled}}
+2. Open-ended search (vague keyword, unsure where, likely many glob/grep rounds) → prefer `agent_task` with `role=explore` (or parallel `agent_spawn`) so exploration stays out of this context; then act on the summary.
+{{- else}}
+2. Open-ended search (vague keyword, unsure where, likely many glob/grep rounds) → `glob` / `grep` / `list` yourself; stay narrow and stop when uncertainty is resolved.
+{{- end}}
 3. `fetch` — external docs/URLs when the repo cannot answer.
-4. `bash` — builds, tests, git, and OS tasks that specialized tools cannot do.
+4. `bash` — as above.
+{{- if .AgentsEnabled}}
+
+Sub-agents: `explore` (default, read-only search), `review` (read-only checks/diffs), `worker` (may edit; only for a scoped, already-planned independent change). Use `agent_task` for one job; `agent_spawn` + `agent_wait` for parallel jobs. Wait timeout does not cancel a job.
+{{- end}}
 
 Parallelize independent read-only calls. Do not widen exploration just because tools are available. Treat skills as constraints and shortcuts—apply the smallest relevant part.
 
-# Change discipline
-- The best change is usually the smallest correct one: fewer new names, helpers, layers, and files.
-- Prefer editing an existing file over creating one. Remove temporary helpers you created for iteration.
-- Before adding a wrapper, try changing the source of truth. New abstractions only when they remove real complexity or match an established local pattern.
-- Ignore unrelated dirty worktree / staging changes you did not make. Never revert or rewrite others' work unless asked.
+# Change
+- Before `edit`, `read` the target file in the same turn (serial with that edit—do not parallel other edits on the same file). On anchor mismatch, re-read and retry once.
 - If an approach fails: read the error, revise the hypothesis, retry with a different tactic—not the identical failing call.
 
-# Verification
+# Verify
 Scale checks to blast radius:
 - Pure Q&A / trivial typo → skip heavy checks.
 - Localized change → targeted test, lint, typecheck, or build as appropriate.
@@ -40,16 +42,14 @@ Scale checks to blast radius:
 
 Before running via `bash`, confirm the script/target exists (e.g. a `lint` target). Report results honestly; do not silence type/lint errors unless the user explicitly asks.
 
-# Tool mechanics
+# Tool contracts
 - Follow `# Current Project context` and any `<project_context>` instructions (AGENTS.md / CLAUDE.md) before the first tool call.
-- Prefer `list` / `glob` / `grep` / `read` / `fetch` over shelling out; use `bash` for builds, tests, git, and other OS tasks specialized tools cannot do.
 - Paths may be absolute or relative to cwd.
-- `read` and `grep` return `LINE#HASH|...` anchors. Before `edit`, `read` the target file in the same turn; on anchor mismatch, re-read and retry once. Do not parallel `edit` on the same file.
+- `read` and `grep` return `LINE#HASH|...` anchors—use them for `edit`.
 - `write` creates a new file only (fails if it already exists). Use `edit` to change, insert, or delete lines in existing files.
-- Sub-agents (when `agent_task` / `agent_spawn` are available): pick `role` — `explore` (default, read-only search), `review` (read-only checks/diffs), `worker` (may edit, only for a planned independent change). Prefer explore for open-ended search to keep this context small. Use `agent_task` for one job; `agent_spawn` + `agent_wait` for parallel jobs. Known path/symbol → call `read` / `grep` / `glob` yourself. Wait timeout does not cancel a job.
 
 # Current Project context
-- Current directory: %s
-- Workspace: %s
+- Current directory: {{.Cwd}}
+- Workspace: {{.Workspace}}
 
 Keep replies concise. When you are done, answer without further tool calls.

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -22,8 +22,8 @@ import (
 	"github.com/pulseaiclub/phi/internal/project"
 	"github.com/pulseaiclub/phi/internal/session"
 	"github.com/pulseaiclub/phi/internal/tools"
-	"github.com/pulseaiclub/phi/internal/util/update"
 	"github.com/pulseaiclub/phi/internal/util/filesearch"
+	"github.com/pulseaiclub/phi/internal/util/update"
 	"github.com/pulseaiclub/xui"
 )
 
@@ -296,9 +296,10 @@ func applyThemeToWidgets(entries []components.Widget, th components.Theme) {
 
 // Publish sends a message onto the bus from any goroutine / widget callback.
 func (editor *Editor) Publish(m Msg) {
-	if editor.bus != nil {
-		editor.bus.Publish(m)
+	if editor.bus == nil {
+		return
 	}
+	editor.bus.Publish(m)
 }
 
 // Update applies one message on the UI goroutine. Returns whether a redraw is useful.
@@ -428,8 +429,9 @@ func (editor *Editor) handleSubmit(text string) {
 			return
 		}
 	}
-	pending := append([]string(nil), editor.Chat.PendingSkills...)
-	if (text == "" && len(pending) == 0) || editor.isBusy() {
+	pendingSkills := make([]string, 0, len(editor.Chat.PendingSkills))
+	pendingSkills = append(pendingSkills, editor.Chat.PendingSkills...)
+	if (text == "" && len(pendingSkills) == 0) || editor.isBusy() {
 		return
 	}
 
@@ -441,8 +443,8 @@ func (editor *Editor) handleSubmit(text string) {
 
 	editor.activity.Apply(ActivitySubmitting)
 	display := text
-	if display == "" && len(pending) > 0 {
-		display = "Skills: " + strings.Join(pending, ", ")
+	if display == "" && len(pendingSkills) > 0 {
+		display = "Skills: " + strings.Join(pendingSkills, ", ")
 	}
 	editor.applySessionEvent(session.UserAppend{Text: display})
 	editor.syncThread()
@@ -453,7 +455,7 @@ func (editor *Editor) handleSubmit(text string) {
 	editor.Chat.Cursor = 0
 	editor.Chat.ClearPendingSkills()
 
-	editor.ctrl.StartPrompt(text, pending)
+	editor.ctrl.StartPrompt(text, pendingSkills)
 }
 
 // handleSlash runs /sessions and /resume. Returns true when the input was consumed.


### PR DESCRIPTION
Render the system prompt via text/template and only include agent_* tool guidance (explore/review/worker roles, agent_task/agent_spawn) when the job manager is attached and those tools are actually registered, so the prompt stays honest when sub-agents are disabled.

- Prompt() takes an agentsEnabled flag and executes the embedded template with cwd/workspace/toggle data
- engine passes jobs != nil from NewEngine and rebindTools
- add TestPromptAgentsEnabledToggle covering both modes

Also tidy internal/tui/editor.go: import ordering, early-return in Publish, and rename pending -> pendingSkills with preallocation.