### PR TITLE
Harden agent and command execution limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Flags:
 | `-p, --prompt STRING`| Prompt to run (required)                       |
 | `--jsonl`            | Emit JSONL events to stdout                    |
 | `--max-rounds N`     | Cap tool rounds (default 64)                   |
+| `--timeout DURATION` | Limit the agent run wall-clock time (e.g. `10m`; disabled by default) |
 | `--session ID`       | Resume a persisted session by id or unique prefix |
 | `--continue-last`    | Resume the newest persisted session for this directory |
 | `--session-dir DIR`  | Override the session storage directory         |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,6 +230,7 @@ phi run -p "fix the failing test in internal/tools"
 | `-p, --prompt STRING` | 要运行的提示词（必填） |
 | `--jsonl` | 向 stdout 输出 JSONL 事件 |
 | `--max-rounds N` | 限制工具轮数（默认 64） |
+| `--timeout DURATION` | 限制 Agent 运行总时长（例如 `10m`，默认不限制） |
 | `--session ID` | 按 id 或唯一前缀恢复已持久化的会话 |
 | `--continue-last` | 恢复当前目录最新的持久化会话 |
 | `--session-dir DIR` | 覆盖会话存储目录 |

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pulseaiclub/phi/internal/agent"
 	"github.com/pulseaiclub/phi/internal/session"
@@ -20,6 +21,7 @@ type runOptions struct {
 	prompt       string
 	jsonl        bool
 	maxRounds    int
+	timeout      time.Duration
 	session      string
 	continueLast bool
 	sessionDir   string
@@ -114,7 +116,14 @@ func runCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "file: %s\n", f)
 	}
 
-	return runLoop(ctx, engine, opts)
+	runCtx := ctx
+	if opts.timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, opts.timeout)
+		defer cancel()
+	}
+
+	return runLoop(runCtx, engine, opts)
 }
 
 // runLoop consumes the same engine.Loop the TUI uses — no second loop is
@@ -152,8 +161,12 @@ func runLoop(ctx context.Context, engine *agent.Engine, opts runOptions) int {
 		}
 	}
 
-	if ctx.Err() != nil && exit == ExitOK {
-		exit = ExitError // interrupted (Ctrl-C) is not success
+	if ctxErr := ctx.Err(); ctxErr != nil && exit == ExitOK {
+		exit = ExitError // context cancellation is not success
+		if errors.Is(ctxErr, context.DeadlineExceeded) {
+			enc.errorEvent(ctxErr.Error())
+			fmt.Fprintln(os.Stderr, "error:", ctxErr)
+		}
 	}
 
 	if !opts.jsonl && exit == ExitOK && strings.TrimSpace(finalText) != "" {
@@ -212,6 +225,23 @@ func parseRunArgs(args []string) (runOptions, error) {
 				return o, fmt.Errorf("--max-rounds must be a positive integer, got %q", v)
 			}
 			o.maxRounds = n
+		case arg == "--timeout":
+			v, err := next(arg)
+			if err != nil {
+				return o, err
+			}
+			d, err := time.ParseDuration(v)
+			if err != nil || d <= 0 {
+				return o, fmt.Errorf("--timeout must be a positive duration, got %q", v)
+			}
+			o.timeout = d
+		case strings.HasPrefix(arg, "--timeout="):
+			v := strings.TrimPrefix(arg, "--timeout=")
+			d, err := time.ParseDuration(v)
+			if err != nil || d <= 0 {
+				return o, fmt.Errorf("--timeout must be a positive duration, got %q", v)
+			}
+			o.timeout = d
 		case arg == "--session":
 			v, err := next(arg)
 			if err != nil {
@@ -245,6 +275,7 @@ flags:
   -p, --prompt STRING   prompt to run (required)
       --jsonl           emit JSONL events to stdout
       --max-rounds N    cap tool rounds (default 64)
+      --timeout DURATION stop after a wall-clock duration (e.g. 10m; default unlimited)
       --session ID      resume a persisted session by id or unique prefix
       --continue-last   resume the newest persisted session for this directory
       --session-dir DIR override the session storage directory

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -2,13 +2,19 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pulseaiclub/phi/internal/agent"
+	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/pulseaiclub/phi/internal/permission"
 	"github.com/pulseaiclub/phi/internal/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,12 +25,14 @@ func TestParseRunArgs(t *testing.T) {
 		"-p", "do the thing",
 		"--jsonl",
 		"--max-rounds", "10",
+		"--timeout", "10m",
 		"--session", "abc123",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "do the thing", opts.prompt)
 	assert.True(t, opts.jsonl)
 	assert.Equal(t, 10, opts.maxRounds)
+	assert.Equal(t, 10*time.Minute, opts.timeout)
 	assert.Equal(t, "abc123", opts.session)
 	assert.False(t, opts.continueLast)
 }
@@ -33,12 +41,14 @@ func TestParseRunArgsEqualsForms(t *testing.T) {
 	opts, err := parseRunArgs([]string{
 		"--prompt=hi",
 		"--max-rounds=5",
+		"--timeout=1500ms",
 		"--session-dir=/tmp/sess",
 		"--continue-last",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "hi", opts.prompt)
 	assert.Equal(t, 5, opts.maxRounds)
+	assert.Equal(t, 1500*time.Millisecond, opts.timeout)
 	assert.Equal(t, "/tmp/sess", opts.sessionDir)
 	assert.True(t, opts.continueLast)
 }
@@ -48,12 +58,45 @@ func TestParseRunArgsErrors(t *testing.T) {
 		{"--prompt"},            // missing value
 		{"--max-rounds", "abc"}, // non-integer
 		{"--max-rounds", "0"},   // non-positive
+		{"--timeout"},           // missing value
+		{"--timeout", "abc"},    // invalid duration
+		{"--timeout", "0"},      // non-positive
+		{"--timeout", "-1s"},    // non-positive
 		{"--bogus", "x"},        // unknown flag
 	}
 	for _, args := range cases {
 		_, err := parseRunArgs(args)
 		assert.Error(t, err, "args %v should error", args)
 	}
+}
+
+func TestRunLoopTimeoutCancelsLLMRequest(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer server.Close()
+	defer close(block)
+
+	engine, err := agent.NewEngine(agent.EngineOpts{
+		Model: llm.ModelConfig{
+			Name:    "fake",
+			BaseURL: server.URL,
+			APIKey:  "test",
+		},
+		SessionOpts: agent.SessionOpts{Cwd: t.TempDir()},
+		Gate:        permission.AllowAll{},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	exit := runLoop(ctx, engine, runOptions{prompt: "wait"})
+
+	assert.Equal(t, ExitError, exit)
+	assert.Less(t, time.Since(start), time.Second)
 }
 
 func TestClassifyRunError(t *testing.T) {

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -237,19 +237,27 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 			return
 		}
 
-		for round := 0; ; round++ {
-			if round > engine.maxRounds {
-				yield(nil, fmt.Errorf("agent: %w (%d)", ErrMaxRounds, engine.maxRounds))
-				return
-			}
+		toolRounds := 0
+		for {
 			if ctx.Err() != nil {
 				return
 			}
 
 			msgs := engine.session.BuildContext()
 
-			msg, ok := engine.streamTurn(ctx, yield, msgs)
+			msg, complete, ok := engine.streamTurn(ctx, yield, msgs)
 			if !ok {
+				return
+			}
+
+			// Defer publishing and persisting the terminal assistant update until
+			// the tool budget is checked. An over-budget tool request must not
+			// leave an unexecuted tool call in the session or UI.
+			if len(msg.ToolCalls) > 0 && toolRounds >= engine.maxRounds {
+				yield(nil, fmt.Errorf("agent: %w (%d)", ErrMaxRounds, engine.maxRounds))
+				return
+			}
+			if !yield(complete, nil) {
 				return
 			}
 
@@ -266,6 +274,7 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 				return
 			}
 
+			toolRounds++
 			toolMsgs := engine.executor.Run(ctx, msg.ToolCalls, func(td session.ToolData) bool {
 				return yield(td, nil)
 			})
@@ -339,7 +348,7 @@ func (engine *Engine) streamTurn(
 	ctx context.Context,
 	yield func(session.Event, error) bool,
 	messages []llm.Message,
-) (llm.Message, bool) {
+) (llm.Message, session.Event, bool) {
 	id := fmt.Sprintf("assistant-%d", time.Now().UnixNano())
 	var thinking, text string
 	var final llm.Message
@@ -351,7 +360,7 @@ func (engine *Engine) streamTurn(
 				_ = yield(emitMessage(id, session.StateError, session.StopNone, thinking, text, nil, llm.Usage{}), nil)
 			}
 			yield(nil, err)
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 		}
 
 		switch event.Type {
@@ -361,7 +370,7 @@ func (engine *Engine) streamTurn(
 				errText = "stream error"
 			}
 			yield(nil, fmt.Errorf("%s", errText))
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 
 		case llm.StreamEventTypeDelta:
 			if event.Delta.ReasoningContent != "" {
@@ -371,13 +380,13 @@ func (engine *Engine) streamTurn(
 				text += event.Delta.Content
 			}
 			if !yield(emitMessage(id, session.StateStreaming, session.StopNone, thinking, text, nil, llm.Usage{}), nil) {
-				return llm.Message{}, false
+				return llm.Message{}, nil, false
 			}
 
 		case llm.StreamEventTypeDone:
 			if len(event.Partial.Choices) == 0 {
 				yield(nil, errors.New("agent: stream finished with no assistant choice"))
-				return llm.Message{}, false
+				return llm.Message{}, nil, false
 			}
 			final = event.Partial.Choices[0].Message
 			final.Usage = event.Partial.Usage
@@ -395,10 +404,10 @@ func (engine *Engine) streamTurn(
 	if !gotDone {
 		if ctx.Err() != nil {
 			_ = yield(emitMessage(id, session.StateCancelled, session.StopNone, thinking, text, nil, llm.Usage{}), nil)
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 		}
 		yield(nil, fmt.Errorf("agent: stream closed without assistant output"))
-		return llm.Message{}, false
+		return llm.Message{}, nil, false
 	}
 
 	blocks := engine.toolCallsToBlocks(final.ToolCalls)
@@ -406,10 +415,8 @@ func (engine *Engine) streamTurn(
 	if len(blocks) > 0 {
 		reason = session.StopToolUse
 	}
-	if !yield(emitMessage(id, session.StateComplete, reason, thinking, text, blocks, final.Usage), nil) {
-		return llm.Message{}, false
-	}
-	return final, true
+	complete := emitMessage(id, session.StateComplete, reason, thinking, text, blocks, final.Usage)
+	return final, complete, true
 }
 
 func (engine *Engine) toolCallsToBlocks(calls []llm.ToolCall) []session.ContentBlock {

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/permission"
+	"github.com/pulseaiclub/phi/internal/session"
+	"github.com/pulseaiclub/phi/internal/tools"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,26 +39,95 @@ func sseToolCallChunk(id, name, args string) string {
 	return "data: " + string(payload) + "\n\n"
 }
 
-// fakeToolLoopServer always asks the model to run `echo hi` so a Loop never
-// ends on its own; used to prove the max-rounds budget fires.
-func fakeToolLoopServer() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = fmt.Fprint(w, sseToolCallChunk("call_1", "bash", `{"command":"echo hi"}`))
-		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
-	}))
+func sseTextChunk(text string) string {
+	payload, err := json.Marshal(map[string]any{
+		"choices": []any{map[string]any{
+			"delta": map[string]any{
+				"role":    "assistant",
+				"content": text,
+			},
+		}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return "data: " + string(payload) + "\n\n"
 }
 
-func TestLoopExceedsMaxRounds(t *testing.T) {
-	server := fakeToolLoopServer()
-	defer server.Close()
+// fakeToolSequenceServer returns tool calls for finalAfter tool requests, then
+// returns a final text response. A negative finalAfter means tool calls forever.
+func fakeToolSequenceServer(finalAfter int) (*httptest.Server, *atomic.Int32) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		request := requests.Add(1)
+		if finalAfter < 0 || int(request) <= finalAfter {
+			_, _ = fmt.Fprint(w, sseToolCallChunk(fmt.Sprintf("call_%d", request), "count", `{}`))
+		} else {
+			_, _ = fmt.Fprint(w, sseTextChunk("done"))
+		}
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	return server, &requests
+}
 
+func countingTool(runs *atomic.Int32) tools.Tool {
+	return tools.Tool{
+		Definition: llm.ToolDefinition{
+			Name:        "count",
+			Description: "count tool executions",
+			Params:      &llm.FunctionParameters{Type: "object"},
+		},
+		Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+			runs.Add(1)
+			return tools.Result{Content: "ok"}, nil
+		},
+	}
+}
+
+func newRoundTestEngine(t *testing.T, serverURL string, runs *atomic.Int32) *Engine {
+	t.Helper()
 	engine, err := NewEngine(EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
+		Model:       llm.ModelConfig{Name: "fake", BaseURL: serverURL, APIKey: "x"},
 		SessionOpts: SessionOpts{Cwd: t.TempDir()},
 		Gate:        permission.AllowAll{},
+		Tools:       []tools.Tool{countingTool(runs)},
 	})
 	require.NoError(t, err)
+	return engine
+}
+
+func TestLoopMaxRoundsAllowsFinalAnswerAfterLastToolRound(t *testing.T) {
+	server, requests := fakeToolSequenceServer(2)
+	defer server.Close()
+
+	var runs atomic.Int32
+	engine := newRoundTestEngine(t, server.URL, &runs)
+	require.NoError(t, engine.SetMaxRounds(2))
+
+	var lastErr error
+	var finalText string
+	for ev, err := range engine.Loop(context.Background(), "go", LoopOpts{}) {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		if update, ok := ev.(session.AssistantMessageUpdate); ok && update.Message.State == session.StateComplete {
+			finalText = update.Message.FlatText()
+		}
+	}
+	require.NoError(t, lastErr)
+	require.Equal(t, int32(2), runs.Load())
+	require.Equal(t, int32(3), requests.Load())
+	require.Equal(t, "done", finalText)
+}
+
+func TestLoopMaxRoundsDoesNotExecuteExtraToolRound(t *testing.T) {
+	server, requests := fakeToolSequenceServer(-1)
+	defer server.Close()
+
+	var runs atomic.Int32
+	engine := newRoundTestEngine(t, server.URL, &runs)
 	require.NoError(t, engine.SetMaxRounds(2))
 
 	var lastErr error
@@ -66,10 +138,20 @@ func TestLoopExceedsMaxRounds(t *testing.T) {
 			break
 		}
 	}
-	require.Error(t, lastErr, "loop should stop with an error once rounds are exhausted")
+	require.Error(t, lastErr, "loop should stop when the model requests a third tool round")
 	if !errors.Is(lastErr, ErrMaxRounds) {
 		t.Fatalf("expected ErrMaxRounds to be wrapped, got %v", lastErr)
 	}
+	require.Equal(t, int32(2), runs.Load())
+	require.Equal(t, int32(3), requests.Load())
+
+	assistantToolRounds := 0
+	for _, msg := range engine.session.BuildContext() {
+		if msg.Role == llm.RoleAssistant && len(msg.ToolCalls) > 0 {
+			assistantToolRounds++
+		}
+	}
+	require.Equal(t, 2, assistantToolRounds)
 }
 
 func TestSetMaxRoundsRejectsNonPositive(t *testing.T) {

--- a/internal/components/block/bash_block.go
+++ b/internal/components/block/bash_block.go
@@ -24,10 +24,10 @@ const (
 //	$ ls
 //	  parser.go
 //	  ...
-//	  [Showing lines 10-100 of 100. Full output: /tmp/phi-bash-….log]
+//	  [Showing lines 10-100 of 100. Full/retained output: /tmp/phi-bash-….log]
 //
-// Long output is truncated at the source (tools.FormatBashOutput) with a
-// /tmp dump — this widget does not invent a useless "Show more" chrome.
+// Long output is truncated by the bash tool with a /tmp dump — this widget
+// does not invent a useless "Show more" chrome.
 type BashBlock struct {
 	Command  string
 	Output   string

--- a/internal/tools/bashtool/bash.go
+++ b/internal/tools/bashtool/bash.go
@@ -1,7 +1,6 @@
 package bashtool
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,7 +18,7 @@ const (
 var bashDescription = `Run a shell command and return combined stdout/stderr.
 
 Use for one-off build, test, git, or inspection commands. Large output is
-truncated with the full log written to a temp file.`
+truncated with the retained output written to a temp file.`
 
 // BashTool returns the bash tool definition + handler.
 func BashTool() tooldef.Tool {
@@ -80,12 +79,14 @@ func runBash(ctx context.Context, input json.RawMessage) (tooldef.Result, error)
 	if err != nil {
 		return tooldef.Result{}, err
 	}
-	var buf bytes.Buffer
-	c.Stdout = &buf
-	c.Stderr = &buf
+	// Bound the shared stdout/stderr collector so runaway output cannot be
+	// buffered unboundedly.
+	cb := newCappedBuffer(BashMaxCollectBytes)
+	c.Stdout = cb
+	c.Stderr = cb
 	err = c.Run()
 
-	out := FormatBashOutput(buf.String())
+	out := formatBashOutput(cb.String(), cb.Truncated())
 	if strings.TrimSpace(out) == "" {
 		out = "(no output)"
 	}

--- a/internal/tools/bashtool/bash_output.go
+++ b/internal/tools/bashtool/bash_output.go
@@ -14,23 +14,29 @@ const (
 	BashMaxOutputLines = 1000
 	// BashMaxOutputBytes is the maximum bytes kept in displayed bash output (50KB).
 	BashMaxOutputBytes = 50 * 1024
+	// BashMaxCollectBytes caps how much of a command's output is buffered in
+	// memory (and retained in the temp-file dump) before display truncation.
+	// Guards against runaway output (`cat /dev/urandom | base64`, `yes`):
+	// the newest 8 MB is kept, the rest is dropped at the source.
+	BashMaxCollectBytes = 8 * 1024 * 1024
 )
 
-// FormatBashOutput keeps the last BashMaxOutputLines / BashMaxOutputBytes of
-// output (tail). When truncated, the full output is written to a temp file and
-// a panda-style notice with the path is appended — no in-UI "Show more".
-func FormatBashOutput(output string) string {
-	display, path := truncateBashTail(output, BashMaxOutputLines, BashMaxOutputBytes)
-	if path == "" {
-		return display
+// formatBashOutput keeps the last BashMaxOutputLines / BashMaxOutputBytes of
+// real output. Collection metadata is appended afterward so it does not alter
+// the display budget or reported line range.
+func formatBashOutput(output string, collectionTruncated bool) string {
+	label := "Full output"
+	if collectionTruncated {
+		label = "Retained output"
 	}
-	if !strings.Contains(display, path) {
-		display += fmt.Sprintf("\n\n[Full output: %s]", path)
+	display, _ := truncateBashTail(output, BashMaxOutputLines, BashMaxOutputBytes, label)
+	if collectionTruncated {
+		display += collectTruncationNote
 	}
 	return display
 }
 
-func truncateBashTail(output string, maxLines, maxBytes int) (display, fullPath string) {
+func truncateBashTail(output string, maxLines, maxBytes int, outputLabel string) (display, fullPath string) {
 	if maxLines <= 0 {
 		maxLines = BashMaxOutputLines
 	}
@@ -38,12 +44,14 @@ func truncateBashTail(output string, maxLines, maxBytes int) (display, fullPath 
 		maxBytes = BashMaxOutputBytes
 	}
 	totalBytes := len(output)
-	lines := strings.Split(output, "\n")
-	// Trailing empty from final newline shouldn't inflate the line count for limits.
-	totalLines := len(lines)
-	if totalLines > 0 && lines[totalLines-1] == "" {
-		totalLines--
-		lines = lines[:totalLines]
+	totalLines := strings.Count(output, "\n")
+	bodyEnd := len(output)
+	if bodyEnd > 0 && output[bodyEnd-1] == '\n' {
+		// A final newline terminates the last line; exclude only the empty
+		// element that strings.Split would otherwise produce after it.
+		bodyEnd--
+	} else if bodyEnd > 0 {
+		totalLines++
 	}
 
 	if totalLines <= maxLines && totalBytes <= maxBytes {
@@ -55,40 +63,47 @@ func truncateBashTail(output string, maxLines, maxBytes int) (display, fullPath 
 		path = ""
 	}
 
-	// Keep a tail that respects both limits.
-	start := 0
+	// Locate the display tail without splitting every retained line. Dense
+	// output can contain millions of newlines even within the collection cap.
+	tailStart := 0
 	if totalLines > maxLines {
-		start = totalLines - maxLines
-	}
-	tail := lines[start:]
-	for len(tail) > 1 && joinedBytes(tail) > maxBytes {
-		tail = tail[1:]
-	}
-	if len(tail) == 1 && len(tail[0]) > maxBytes {
-		s := tail[0]
-		tail = []string{s[len(s)-maxBytes:]}
+		cursor := bodyEnd
+		for range maxLines {
+			newline := strings.LastIndexByte(output[:cursor], '\n')
+			if newline < 0 {
+				cursor = 0
+				break
+			}
+			cursor = newline
+		}
+		tailStart = cursor + 1
 	}
 
-	display = strings.Join(tail, "\n")
-	startLine := totalLines - len(tail) + 1
-	endLine := totalLines
-	if path != "" {
-		display += fmt.Sprintf("\n\n[Showing lines %d-%d of %d. Full output: %s]", startLine, endLine, totalLines, path)
-	} else {
-		display += fmt.Sprintf("\n\n[Showing lines %d-%d of %d. Full output unavailable]", startLine, endLine, totalLines)
-	}
-	return display, path
-}
-
-func joinedBytes(lines []string) int {
-	n := 0
-	for i, line := range lines {
-		n += len(line)
-		if i > 0 {
-			n++ // newline
+	if bodyEnd-tailStart > maxBytes {
+		minStart := bodyEnd - maxBytes
+		searchStart := minStart - 1
+		if searchStart < tailStart {
+			searchStart = tailStart
+		}
+		if newline := strings.IndexByte(output[searchStart:bodyEnd], '\n'); newline >= 0 {
+			// Prefer a line boundary, even when that keeps fewer than maxBytes.
+			tailStart = searchStart + newline + 1
+		} else {
+			// The final line alone exceeds maxBytes; keep its byte tail.
+			tailStart = minStart
 		}
 	}
-	return n
+
+	display = output[tailStart:bodyEnd]
+	displayLines := strings.Count(display, "\n") + 1
+	startLine := totalLines - displayLines + 1
+	endLine := totalLines
+	if path != "" {
+		display += fmt.Sprintf("\n\n[Showing lines %d-%d of %d. %s: %s]", startLine, endLine, totalLines, outputLabel, path)
+	} else {
+		display += fmt.Sprintf("\n\n[Showing lines %d-%d of %d. %s unavailable]", startLine, endLine, totalLines, outputLabel)
+	}
+	return display, path
 }
 
 func writeBashTempFile(content string) (string, error) {

--- a/internal/tools/bashtool/bash_output_test.go
+++ b/internal/tools/bashtool/bash_output_test.go
@@ -6,21 +6,21 @@ import (
 	"testing"
 )
 
-func TestFormatBashOutputShort(t *testing.T) {
+func TestBashOutputFormattingPreservesShortOutput(t *testing.T) {
 	in := "a\nb\nc\n"
-	got := FormatBashOutput(in)
+	got := formatBashOutput(in, false)
 	if got != in {
 		t.Fatalf("short output changed: %q", got)
 	}
 }
 
-func TestFormatBashOutputWritesTemp(t *testing.T) {
+func TestBashOutputFormattingWritesTemp(t *testing.T) {
 	var b strings.Builder
 	for i := 0; i < BashMaxOutputLines+20; i++ {
 		b.WriteString("line\n")
 	}
 	full := b.String()
-	got := FormatBashOutput(full)
+	got := formatBashOutput(full, false)
 	if !strings.Contains(got, "Full output:") {
 		t.Fatalf("missing full-output notice: %q", got)
 	}
@@ -31,6 +31,7 @@ func TestFormatBashOutputWritesTemp(t *testing.T) {
 	idx := strings.Index(got, "Full output: ")
 	rest := got[idx+len("Full output: "):]
 	path := strings.TrimSpace(strings.Split(rest, "]")[0])
+	t.Cleanup(func() { _ = os.Remove(path) })
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
@@ -38,5 +39,110 @@ func TestFormatBashOutputWritesTemp(t *testing.T) {
 	if string(data) != full {
 		t.Fatalf("temp file content mismatch: got %d bytes want %d", len(data), len(full))
 	}
-	_ = os.Remove(path)
+}
+
+func TestFormatCollectedBashOutputLabelsRetainedFile(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < BashMaxOutputLines+20; i++ {
+		b.WriteString("line\n")
+	}
+	retained := b.String()
+
+	got := formatBashOutput(retained, true)
+	if !strings.Contains(got, "Retained output:") {
+		t.Fatalf("missing retained-output notice: %q", got)
+	}
+	if strings.Contains(got, "Full output:") {
+		t.Fatalf("collection-truncated output mislabeled as full: %q", got)
+	}
+	if !strings.Contains(got, "Showing lines 21-1020 of 1020") {
+		t.Fatalf("collection notice changed real line range: %q", got)
+	}
+	if !strings.HasSuffix(got, collectTruncationNote) {
+		t.Fatalf("missing collection truncation note: %q", got)
+	}
+	idx := strings.Index(got, "Retained output: ")
+	path := strings.TrimSpace(strings.Split(got[idx+len("Retained output: "):], "]")[0])
+	if path == "" {
+		t.Fatal("missing retained output path")
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != retained {
+		t.Fatalf("retained file contains display metadata: got %d bytes want %d", len(data), len(retained))
+	}
+}
+
+func TestCollectionNoticeDoesNotConsumeDisplayBudget(t *testing.T) {
+	output := strings.Repeat("x", BashMaxOutputBytes)
+	got := formatBashOutput(output, true)
+	if got != output+collectTruncationNote {
+		t.Fatalf("collection notice altered output at display limit: got %d bytes want %d", len(got), len(output)+len(collectTruncationNote))
+	}
+	if strings.Contains(got, "Retained output:") || strings.Contains(got, "Showing lines") {
+		t.Fatalf("collection notice caused an unnecessary temp dump: %q", got[len(output):])
+	}
+}
+
+func TestTruncateBashTailPreservesTailSemantics(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		maxLines  int
+		maxBytes  int
+		wantTail  string
+		wantRange string
+	}{
+		{
+			name:      "line limit with trailing newline",
+			output:    "one\ntwo\nthree\nfour\n",
+			maxLines:  3,
+			maxBytes:  64,
+			wantTail:  "two\nthree\nfour",
+			wantRange: "Showing lines 2-4 of 4",
+		},
+		{
+			name:      "byte limit prefers complete lines",
+			output:    "aaaa\nbbbb\ncccc",
+			maxLines:  100,
+			maxBytes:  8,
+			wantTail:  "cccc",
+			wantRange: "Showing lines 3-3 of 3",
+		},
+		{
+			name:      "single long line keeps byte tail",
+			output:    "0123456789ABC",
+			maxLines:  100,
+			maxBytes:  10,
+			wantTail:  "3456789ABC",
+			wantRange: "Showing lines 1-1 of 1",
+		},
+		{
+			name:      "final empty line",
+			output:    "one\n\n",
+			maxLines:  1,
+			maxBytes:  64,
+			wantTail:  "",
+			wantRange: "Showing lines 2-2 of 2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			display, path := truncateBashTail(tc.output, tc.maxLines, tc.maxBytes, "Full output")
+			if path == "" {
+				t.Fatal("missing temp output path")
+			}
+			t.Cleanup(func() { _ = os.Remove(path) })
+			if !strings.HasPrefix(display, tc.wantTail+"\n\n[") {
+				t.Fatalf("display tail=%q, want prefix %q", display, tc.wantTail)
+			}
+			if !strings.Contains(display, tc.wantRange) {
+				t.Fatalf("display=%q, want range %q", display, tc.wantRange)
+			}
+		})
+	}
 }

--- a/internal/tools/bashtool/collect.go
+++ b/internal/tools/bashtool/collect.go
@@ -1,0 +1,145 @@
+package bashtool
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+)
+
+// cappedBuffer collects command output into a bounded rolling tail.
+//
+// Once the cap is reached, the oldest bytes are dropped so memory stays
+// bounded while the newest output is retained — the same "keep the tail"
+// philosophy as the bash display limits. The truncation is
+// reported via Truncated so callers can tell the user the output was cut
+// at the source, not just at display time.
+//
+// Write is safe for concurrent use even though the current os/exec callers
+// assign the same comparable writer to stdout and stderr, which os/exec
+// coalesces onto one copy path.
+type cappedBuffer struct {
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+// BashOutputTail keeps a small, display-sized tail for live UI updates.
+// Unlike cappedBuffer, it also limits the number of lines so rendering the
+// live view cannot allocate a surface proportional to a runaway log.
+type BashOutputTail struct {
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	maxBytes  int
+	maxLines  int
+	truncated bool
+}
+
+// NewBashOutputTail creates a bounded tail using the bash display limits.
+func NewBashOutputTail(maxLines, maxBytes int) *BashOutputTail {
+	if maxLines <= 0 {
+		maxLines = BashMaxOutputLines
+	}
+	if maxBytes <= 0 {
+		maxBytes = BashMaxOutputBytes
+	}
+	return &BashOutputTail{maxLines: maxLines, maxBytes: maxBytes}
+}
+
+// Write implements io.Writer while retaining only the newest display-sized
+// tail. It is safe for concurrent use.
+func (t *BashOutputTail) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf.Write(p)
+	t.trimLocked()
+	return len(p), nil
+}
+
+// WriteString appends s to the bounded tail without an intermediate byte
+// slice.
+func (t *BashOutputTail) WriteString(s string) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf.WriteString(s)
+	t.trimLocked()
+	return len(s), nil
+}
+
+// Snapshot returns the current display tail and whether older output was
+// discarded.
+func (t *BashOutputTail) Snapshot() (string, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.buf.String(), t.truncated
+}
+
+func (t *BashOutputTail) trimLocked() {
+	if t.maxBytes > 0 && t.buf.Len() > t.maxBytes {
+		t.buf.Next(t.buf.Len() - t.maxBytes)
+		t.truncated = true
+	}
+	data := t.buf.Bytes()
+	if len(data) == 0 || t.maxLines <= 0 {
+		return
+	}
+
+	// A trailing newline terminates the last line; it should not create an
+	// extra empty line in the same way truncateBashTail treats it.
+	lineCount := 1
+	if data[len(data)-1] == '\n' {
+		lineCount = 0
+	}
+	for i := len(data) - 1; i >= 0; i-- {
+		if data[i] != '\n' {
+			continue
+		}
+		lineCount++
+		if lineCount > t.maxLines {
+			t.buf.Next(i + 1)
+			t.truncated = true
+			return
+		}
+	}
+}
+
+func newCappedBuffer(limit int) *cappedBuffer {
+	return &cappedBuffer{limit: limit}
+}
+
+// Write implements io.Writer. It never reports a short write even when bytes
+// are dropped, so os/exec's copy machinery treats it as a plain sink.
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buf.Write(p)
+	if c.buf.Len() > c.limit {
+		// Drop the oldest bytes to keep a bounded rolling tail.
+		c.buf.Next(c.buf.Len() - c.limit)
+		c.truncated = true
+	}
+	return len(p), nil
+}
+
+// String returns the retained output (never more than limit bytes).
+func (c *cappedBuffer) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+// Truncated reports whether the cap was hit and bytes were dropped.
+func (c *cappedBuffer) Truncated() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.truncated
+}
+
+const collectTruncationMarker = "[output truncated:"
+
+// collectTruncationNote is appended after display truncation so it does not
+// consume the real output's line or byte budget.
+var collectTruncationNote = fmt.Sprintf(
+	"\n\n%s only the last %d MB was kept]",
+	collectTruncationMarker,
+	BashMaxCollectBytes/(1024*1024))

--- a/internal/tools/bashtool/collect_test.go
+++ b/internal/tools/bashtool/collect_test.go
@@ -1,0 +1,86 @@
+package bashtool
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestCappedBufferKeepsNewestTail(t *testing.T) {
+	cb := newCappedBuffer(32)
+	full := strings.Repeat("0123456789", 100)
+	for range 100 {
+		if _, err := cb.Write([]byte("0123456789")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := cb.String()
+	if want := full[len(full)-32:]; got != want {
+		t.Fatalf("want the newest 32 bytes %q, got %q", want, got)
+	}
+	if !cb.Truncated() {
+		t.Fatal("want truncated")
+	}
+}
+
+func TestBashOutputTailKeepsNewestLinesAndBytes(t *testing.T) {
+	tail := NewBashOutputTail(3, 64)
+	if _, err := tail.WriteString("one\ntwo\nthree\nfour\n"); err != nil {
+		t.Fatal(err)
+	}
+	got, truncated := tail.Snapshot()
+	if want := "two\nthree\nfour\n"; got != want || !truncated {
+		t.Fatalf("got %q truncated=%v, want %q and truncation", got, truncated, want)
+	}
+
+	tail = NewBashOutputTail(100, 10)
+	if _, err := tail.WriteString("0123456789ABC"); err != nil {
+		t.Fatal(err)
+	}
+	got, truncated = tail.Snapshot()
+	if got != "3456789ABC" || !truncated {
+		t.Fatalf("got %q truncated=%v, want newest 10 bytes", got, truncated)
+	}
+}
+
+func TestCappedBufferNoTruncationUnderLimit(t *testing.T) {
+	cb := newCappedBuffer(64)
+	data := "hello world"
+	if _, err := cb.Write([]byte(data)); err != nil {
+		t.Fatal(err)
+	}
+	if cb.String() != data || cb.Truncated() {
+		t.Fatalf("got %q truncated=%v", cb.String(), cb.Truncated())
+	}
+}
+
+func TestCappedBufferExactLimit(t *testing.T) {
+	cb := newCappedBuffer(10)
+	data := "0123456789"
+	if _, err := cb.Write([]byte(data)); err != nil {
+		t.Fatal(err)
+	}
+	if cb.String() != data || cb.Truncated() {
+		t.Fatalf("got %q truncated=%v", cb.String(), cb.Truncated())
+	}
+}
+
+func TestCappedBufferConcurrentWrites(t *testing.T) {
+	// Preserve the collector's defensive concurrency contract even though the
+	// current os/exec setup coalesces stdout and stderr onto one writer path.
+	cb := newCappedBuffer(1024)
+	var wg sync.WaitGroup
+	for _, g := range []string{"a", "b"} {
+		wg.Add(1)
+		go func(g string) {
+			defer wg.Done()
+			for range 5000 {
+				_, _ = cb.Write([]byte(g))
+			}
+		}(g)
+	}
+	wg.Wait()
+	if len(cb.String()) != 1024 || !cb.Truncated() {
+		t.Fatalf("len=%d truncated=%v", len(cb.String()), cb.Truncated())
+	}
+}

--- a/internal/tools/bashtool/shell_exec.go
+++ b/internal/tools/bashtool/shell_exec.go
@@ -1,14 +1,11 @@
 package bashtool
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
-	"sync"
 )
 
 // ShellExecResult is the outcome of a streaming shell run.
@@ -23,6 +20,34 @@ type ShellExecOptions struct {
 	OnChunk func(chunk string)
 }
 
+// shellOutputWriter combines stdout and stderr while preserving the streaming
+// callback. Using it as Cmd.Stdout and Cmd.Stderr lets os/exec own the copy
+// machinery, so Cmd.Run waits for all output before closing the pipes.
+// Collection is bounded independently of streaming callbacks, whose consumers
+// are responsible for applying their own retention limits.
+type shellOutputWriter struct {
+	cb      *cappedBuffer
+	onChunk func(chunk string)
+}
+
+func (w *shellOutputWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if _, err := w.cb.Write(p); err != nil {
+		return 0, err
+	}
+	if w.onChunk != nil {
+		w.onChunk(string(p))
+	}
+	return len(p), nil
+}
+
+// Collected returns the retained command output without display metadata.
+func (w *shellOutputWriter) Collected() string {
+	return w.cb.String()
+}
+
 // ExecShell runs command via bash -c, streaming combined stdout+stderr.
 func ExecShell(ctx context.Context, command string, opts ShellExecOptions) (ShellExecResult, error) {
 	command = strings.TrimSpace(command)
@@ -34,50 +59,12 @@ func ExecShell(ctx context.Context, command string, opts ShellExecOptions) (Shel
 	if err != nil {
 		return ShellExecResult{}, err
 	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return ShellExecResult{}, err
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return ShellExecResult{}, err
-	}
-	if err := cmd.Start(); err != nil {
-		return ShellExecResult{}, err
-	}
+	output := &shellOutputWriter{cb: newCappedBuffer(BashMaxCollectBytes), onChunk: opts.OnChunk}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	waitErr := cmd.Run()
 
-	var (
-		mu  sync.Mutex
-		buf bytes.Buffer
-		wg  sync.WaitGroup
-	)
-	stream := func(r io.Reader) {
-		defer wg.Done()
-		chunk := make([]byte, 4096)
-		for {
-			n, readErr := r.Read(chunk)
-			if n > 0 {
-				s := string(chunk[:n])
-				mu.Lock()
-				buf.WriteString(s)
-				mu.Unlock()
-				if opts.OnChunk != nil {
-					opts.OnChunk(s)
-				}
-			}
-			if readErr != nil {
-				return
-			}
-		}
-	}
-	wg.Add(2)
-	go stream(stdout)
-	go stream(stderr)
-
-	waitErr := cmd.Wait()
-	wg.Wait()
-
-	out := FormatBashOutput(buf.String())
+	out := formatBashOutput(output.Collected(), output.cb.Truncated())
 
 	res := ShellExecResult{Output: out}
 	if errors.Is(ctx.Err(), context.Canceled) {

--- a/internal/tools/bashtool/shell_exec_test.go
+++ b/internal/tools/bashtool/shell_exec_test.go
@@ -2,6 +2,7 @@ package bashtool
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,125 @@ func TestExecShellEcho(t *testing.T) {
 	if !strings.Contains(res.Output, "hello") {
 		t.Fatalf("output=%q", res.Output)
 	}
+}
+
+func TestExecShellCapturesBothStreams(t *testing.T) {
+	res, err := ExecShell(context.Background(), "printf stdout; printf stderr >&2", ShellExecOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ExitCode != 0 || res.Canceled {
+		t.Fatalf("result: %+v", res)
+	}
+	if !strings.Contains(res.Output, "stdout") || !strings.Contains(res.Output, "stderr") {
+		t.Fatalf("combined output=%q", res.Output)
+	}
+}
+
+func TestShellOutputWriterStreamsAfterCollectionCap(t *testing.T) {
+	var streamed strings.Builder
+	output := &shellOutputWriter{
+		cb:      newCappedBuffer(4),
+		onChunk: func(chunk string) { streamed.WriteString(chunk) },
+	}
+	if _, err := output.Write([]byte("1234")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := output.Write([]byte("5678")); err != nil {
+		t.Fatal(err)
+	}
+	if got := streamed.String(); got != "12345678" {
+		t.Fatalf("streamed output=%q, want all chunks", got)
+	}
+	if got := output.cb.String(); got != "5678" || !output.cb.Truncated() {
+		t.Fatalf("collected output=%q truncated=%v, want bounded tail", got, output.cb.Truncated())
+	}
+}
+
+func TestExecShellCapturesOutputBeforeProcessExit(t *testing.T) {
+	const outputSize = 32 * 1024
+	const command = "printf '%*s' 32768 '' | tr ' ' x"
+
+	for range 8 {
+		res, err := ExecShell(context.Background(), command, ShellExecOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.ExitCode != 0 || res.Canceled {
+			t.Fatalf("result: %+v", res)
+		}
+		if len(res.Output) != outputSize || strings.Trim(res.Output, "x") != "" {
+			t.Fatalf("captured %d bytes, want %d x bytes", len(res.Output), outputSize)
+		}
+	}
+}
+
+func TestExecShellKeepsOutputTail(t *testing.T) {
+	// Regression: output still buffered in the kernel pipe at process exit
+	// must not be dropped (writer-mode copying drains to EOF before Run returns).
+	command := "seq 1 100000" // ~590KB, under the collection cap
+	res, err := ExecShell(context.Background(), command, ShellExecOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupBashOutputFile(t, res.Output)
+	if res.ExitCode != 0 || res.Canceled {
+		t.Fatalf("result: %+v", res)
+	}
+	// The display notice's own line range proves line 100000 was collected.
+	if !strings.Contains(res.Output, "Showing lines 99001-100000 of 100000") {
+		t.Fatalf("output tail lost, ends with %q", tailLines(res.Output, 3))
+	}
+	if !strings.Contains(res.Output, "Full output:") || strings.Contains(res.Output, "Retained output:") {
+		t.Fatalf("under-cap output mislabeled, ends with %q", tailLines(res.Output, 3))
+	}
+	if strings.Contains(res.Output, "[output truncated:") {
+		t.Fatalf("unexpected collection truncation, ends with %q", tailLines(res.Output, 3))
+	}
+}
+
+func TestExecShellBoundsCollection(t *testing.T) {
+	// Runaway output must not be buffered unboundedly: the newest
+	// BashMaxCollectBytes are kept and the collection truncation is reported.
+	command := "yes x | head -c 20971520" // 20MB
+	res, err := ExecShell(context.Background(), command, ShellExecOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupBashOutputFile(t, res.Output)
+	if res.ExitCode != 0 || res.Canceled {
+		t.Fatalf("result: %+v", res)
+	}
+	if !strings.Contains(res.Output, "[output truncated: only the last 8 MB was kept]") {
+		t.Fatalf("want collection truncation notice, ends with %q", tailLines(res.Output, 3))
+	}
+	if !strings.Contains(res.Output, "Retained output:") || strings.Contains(res.Output, "Full output:") {
+		t.Fatalf("collection-truncated output mislabeled, ends with %q", tailLines(res.Output, 3))
+	}
+}
+
+func cleanupBashOutputFile(t *testing.T, output string) {
+	t.Helper()
+	for _, marker := range []string{"Full output: ", "Retained output: "} {
+		idx := strings.Index(output, marker)
+		if idx < 0 {
+			continue
+		}
+		path := strings.TrimSpace(strings.Split(output[idx+len(marker):], "]")[0])
+		if path == "" {
+			return
+		}
+		t.Cleanup(func() { _ = os.Remove(path) })
+		return
+	}
+}
+
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
 }
 
 func TestExecShellCancel(t *testing.T) {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -31,9 +31,18 @@ var (
 type (
 	ShellExecResult  = bashtool.ShellExecResult
 	ShellExecOptions = bashtool.ShellExecOptions
+	BashOutputTail   = bashtool.BashOutputTail
 )
 
-var ExecShell = bashtool.ExecShell
+const (
+	BashMaxOutputLines = bashtool.BashMaxOutputLines
+	BashMaxOutputBytes = bashtool.BashMaxOutputBytes
+)
+
+var (
+	ExecShell         = bashtool.ExecShell
+	NewBashOutputTail = bashtool.NewBashOutputTail
+)
 
 // Agent helpers used by the TUI / mapper.
 type (

--- a/internal/tui/bash.go
+++ b/internal/tui/bash.go
@@ -58,14 +58,12 @@ func (editor *Editor) runBash(id, command string) {
 		editor.bashMu.Unlock()
 	}()
 
-	var (
-		outMu sync.Mutex
-		out   strings.Builder
-	)
-	publishOutput := func() {
-		outMu.Lock()
-		cur := out.String()
-		outMu.Unlock()
+	// Live updates publish at most this often and carry only a display-sized
+	// tail. This keeps both the event payload and BashBlock layout bounded while
+	// the final event still carries the formatted command result.
+	const bashPublishInterval = 100 * time.Millisecond
+
+	liveOutput := newBashLiveOutput(bashPublishInterval, func(cur string) {
 		editor.Publish(SessionEventMsg{Event: session.ToolData{Run: session.ToolRun{
 			ToolUseID: id,
 			Name:      "bash",
@@ -74,16 +72,15 @@ func (editor *Editor) runBash(id, command string) {
 			Output:    cur,
 			Local:     true,
 		}}})
-	}
+	})
 
 	result, err := tools.ExecShell(ctx, command, tools.ShellExecOptions{
-		OnChunk: func(chunk string) {
-			outMu.Lock()
-			out.WriteString(chunk)
-			outMu.Unlock()
-			publishOutput()
-		},
+		OnChunk: liveOutput.Append,
 	})
+	// Cmd.Run waits for all writer callbacks, so no Append can race with Close.
+	// Closing before the final event prevents a trailing in-progress update from
+	// replacing the completed state.
+	liveOutput.Close()
 	if err != nil {
 		editor.Publish(SessionEventMsg{Event: session.ToolData{Run: session.ToolRun{
 			ToolUseID: id,
@@ -115,6 +112,76 @@ func (editor *Editor) runBash(id, command string) {
 		ExitCode:  result.ExitCode,
 		Local:     true,
 	}}})
+}
+
+// bashLiveOutput publishes a bounded live tail immediately, then at most once
+// per interval. A skipped update always schedules one trailing publication.
+type bashLiveOutput struct {
+	mu          sync.Mutex
+	tail        *tools.BashOutputTail
+	interval    time.Duration
+	lastPublish time.Time
+	timer       *time.Timer
+	stopped     bool
+	publish     func(output string)
+}
+
+func newBashLiveOutput(interval time.Duration, publish func(output string)) *bashLiveOutput {
+	return &bashLiveOutput{
+		tail:     tools.NewBashOutputTail(tools.BashMaxOutputLines, tools.BashMaxOutputBytes),
+		interval: interval,
+		publish:  publish,
+	}
+}
+
+func (o *bashLiveOutput) Append(chunk string) {
+	_, _ = o.tail.WriteString(chunk)
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.stopped || o.timer != nil {
+		return
+	}
+	now := time.Now()
+	if o.lastPublish.IsZero() || now.Sub(o.lastPublish) >= o.interval {
+		o.publishLocked(now)
+		return
+	}
+	delay := o.interval - now.Sub(o.lastPublish)
+	o.timer = time.AfterFunc(delay, o.publishTrailing)
+}
+
+func (o *bashLiveOutput) publishTrailing() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.timer = nil
+	if o.stopped {
+		return
+	}
+	o.publishLocked(time.Now())
+}
+
+func (o *bashLiveOutput) publishLocked(now time.Time) {
+	cur, truncated := o.tail.Snapshot()
+	if truncated {
+		cur = "[live output truncated; showing latest output]\n" + cur
+	}
+	o.lastPublish = now
+	if o.publish != nil {
+		o.publish(cur)
+	}
+}
+
+// Close synchronizes with any active timer callback and prevents future
+// in-progress publications.
+func (o *bashLiveOutput) Close() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.stopped = true
+	if o.timer != nil {
+		o.timer.Stop()
+		o.timer = nil
+	}
 }
 
 // cancelBash aborts a running user "!cmd". Returns true if one was cancelled.

--- a/internal/tui/bash_test.go
+++ b/internal/tui/bash_test.go
@@ -1,0 +1,47 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBashLiveOutputPublishesTrailingUpdate(t *testing.T) {
+	updates := make(chan string, 2)
+	live := newBashLiveOutput(50*time.Millisecond, func(output string) {
+		updates <- output
+	})
+	t.Cleanup(live.Close)
+
+	live.Append("first")
+	if got := <-updates; got != "first" {
+		t.Fatalf("first update=%q", got)
+	}
+	live.Append("-second")
+
+	select {
+	case got := <-updates:
+		if got != "first-second" {
+			t.Fatalf("trailing update=%q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for trailing update")
+	}
+}
+
+func TestBashLiveOutputCloseCancelsTrailingUpdate(t *testing.T) {
+	updates := make(chan string, 2)
+	live := newBashLiveOutput(time.Hour, func(output string) {
+		updates <- output
+	})
+
+	live.Append("first")
+	<-updates
+	live.Append("-second")
+	live.Close()
+
+	live.mu.Lock()
+	defer live.mu.Unlock()
+	if !live.stopped || live.timer != nil {
+		t.Fatalf("closed live output: stopped=%v timer=%v", live.stopped, live.timer)
+	}
+}


### PR DESCRIPTION
## Summary

- Treat `--max-rounds` as a tool-execution budget, allowing the model to return a final answer after the last permitted tool round while rejecting the next tool request before execution.
- Add an optional `phi run --timeout DURATION` wall-clock limit with documented CLI behavior and timeout error reporting.
- Bound collected bash output, preserve the newest retained tail, throttle bounded TUI updates, and use `os/exec` writer mode so process completion cannot drop trailing stdout or stderr.

## Why

The previous round counter could stop before a final answer or persist an over-budget tool request. Non-interactive runs had no overall wall-clock deadline. Bash output was only truncated for final display, leaving collection and live TUI updates vulnerable to runaway memory use, and `ExecShell` waited before its pipe readers had finished.

## Impact

Agent limits now match their documented tool-round semantics, scripted runs can enforce a total deadline, and high-volume shell commands keep memory and UI work bounded without losing process-exit output. Collection truncation is reported separately from display truncation, with retained output available in a temporary log.

## Validation

- `go test ./...`
- `go test -race ./internal/tools/bashtool ./internal/tui`
- `go vet ./...`
- `git diff --check upstream/main...HEAD`
- Windows cross-compilation of the bashtool and TUI test packages
