### PR TITLE
fix(agent): enforce max-rounds as a tool-round cap

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -237,19 +237,27 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 			return
 		}
 
-		for round := 0; ; round++ {
-			if round > engine.maxRounds {
-				yield(nil, fmt.Errorf("agent: %w (%d)", ErrMaxRounds, engine.maxRounds))
-				return
-			}
+		toolRounds := 0
+		for {
 			if ctx.Err() != nil {
 				return
 			}
 
 			msgs := engine.session.BuildContext()
 
-			msg, ok := engine.streamTurn(ctx, yield, msgs)
+			msg, complete, ok := engine.streamTurn(ctx, yield, msgs)
 			if !ok {
+				return
+			}
+
+			// Defer publishing and persisting the terminal assistant update until
+			// the tool budget is checked. An over-budget tool request must not
+			// leave an unexecuted tool call in the session or UI.
+			if len(msg.ToolCalls) > 0 && toolRounds >= engine.maxRounds {
+				yield(nil, fmt.Errorf("agent: %w (%d)", ErrMaxRounds, engine.maxRounds))
+				return
+			}
+			if !yield(complete, nil) {
 				return
 			}
 
@@ -266,6 +274,7 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 				return
 			}
 
+			toolRounds++
 			toolMsgs := engine.executor.Run(ctx, msg.ToolCalls, func(td session.ToolData) bool {
 				return yield(td, nil)
 			})
@@ -339,7 +348,7 @@ func (engine *Engine) streamTurn(
 	ctx context.Context,
 	yield func(session.Event, error) bool,
 	messages []llm.Message,
-) (llm.Message, bool) {
+) (llm.Message, session.Event, bool) {
 	id := fmt.Sprintf("assistant-%d", time.Now().UnixNano())
 	var thinking, text string
 	var final llm.Message
@@ -351,7 +360,7 @@ func (engine *Engine) streamTurn(
 				_ = yield(emitMessage(id, session.StateError, session.StopNone, thinking, text, nil, llm.Usage{}), nil)
 			}
 			yield(nil, err)
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 		}
 
 		switch event.Type {
@@ -361,7 +370,7 @@ func (engine *Engine) streamTurn(
 				errText = "stream error"
 			}
 			yield(nil, fmt.Errorf("%s", errText))
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 
 		case llm.StreamEventTypeDelta:
 			if event.Delta.ReasoningContent != "" {
@@ -371,13 +380,13 @@ func (engine *Engine) streamTurn(
 				text += event.Delta.Content
 			}
 			if !yield(emitMessage(id, session.StateStreaming, session.StopNone, thinking, text, nil, llm.Usage{}), nil) {
-				return llm.Message{}, false
+				return llm.Message{}, nil, false
 			}
 
 		case llm.StreamEventTypeDone:
 			if len(event.Partial.Choices) == 0 {
 				yield(nil, errors.New("agent: stream finished with no assistant choice"))
-				return llm.Message{}, false
+				return llm.Message{}, nil, false
 			}
 			final = event.Partial.Choices[0].Message
 			final.Usage = event.Partial.Usage
@@ -395,10 +404,10 @@ func (engine *Engine) streamTurn(
 	if !gotDone {
 		if ctx.Err() != nil {
 			_ = yield(emitMessage(id, session.StateCancelled, session.StopNone, thinking, text, nil, llm.Usage{}), nil)
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 		}
 		yield(nil, fmt.Errorf("agent: stream closed without assistant output"))
-		return llm.Message{}, false
+		return llm.Message{}, nil, false
 	}
 
 	blocks := engine.toolCallsToBlocks(final.ToolCalls)
@@ -406,10 +415,8 @@ func (engine *Engine) streamTurn(
 	if len(blocks) > 0 {
 		reason = session.StopToolUse
 	}
-	if !yield(emitMessage(id, session.StateComplete, reason, thinking, text, blocks, final.Usage), nil) {
-		return llm.Message{}, false
-	}
-	return final, true
+	complete := emitMessage(id, session.StateComplete, reason, thinking, text, blocks, final.Usage)
+	return final, complete, true
 }
 
 func (engine *Engine) toolCallsToBlocks(calls []llm.ToolCall) []session.ContentBlock {

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/permission"
+	"github.com/pulseaiclub/phi/internal/session"
+	"github.com/pulseaiclub/phi/internal/tools"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,26 +39,95 @@ func sseToolCallChunk(id, name, args string) string {
 	return "data: " + string(payload) + "\n\n"
 }
 
-// fakeToolLoopServer always asks the model to run `echo hi` so a Loop never
-// ends on its own; used to prove the max-rounds budget fires.
-func fakeToolLoopServer() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = fmt.Fprint(w, sseToolCallChunk("call_1", "bash", `{"command":"echo hi"}`))
-		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
-	}))
+func sseTextChunk(text string) string {
+	payload, err := json.Marshal(map[string]any{
+		"choices": []any{map[string]any{
+			"delta": map[string]any{
+				"role":    "assistant",
+				"content": text,
+			},
+		}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return "data: " + string(payload) + "\n\n"
 }
 
-func TestLoopExceedsMaxRounds(t *testing.T) {
-	server := fakeToolLoopServer()
-	defer server.Close()
+// fakeToolSequenceServer returns tool calls for finalAfter tool requests, then
+// returns a final text response. A negative finalAfter means tool calls forever.
+func fakeToolSequenceServer(finalAfter int) (*httptest.Server, *atomic.Int32) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		request := requests.Add(1)
+		if finalAfter < 0 || int(request) <= finalAfter {
+			_, _ = fmt.Fprint(w, sseToolCallChunk(fmt.Sprintf("call_%d", request), "count", `{}`))
+		} else {
+			_, _ = fmt.Fprint(w, sseTextChunk("done"))
+		}
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	return server, &requests
+}
 
+func countingTool(runs *atomic.Int32) tools.Tool {
+	return tools.Tool{
+		Definition: llm.ToolDefinition{
+			Name:        "count",
+			Description: "count tool executions",
+			Params:      &llm.FunctionParameters{Type: "object"},
+		},
+		Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+			runs.Add(1)
+			return tools.Result{Content: "ok"}, nil
+		},
+	}
+}
+
+func newRoundTestEngine(t *testing.T, serverURL string, runs *atomic.Int32) *Engine {
+	t.Helper()
 	engine, err := NewEngine(EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
+		Model:       llm.ModelConfig{Name: "fake", BaseURL: serverURL, APIKey: "x"},
 		SessionOpts: SessionOpts{Cwd: t.TempDir()},
 		Gate:        permission.AllowAll{},
+		Tools:       []tools.Tool{countingTool(runs)},
 	})
 	require.NoError(t, err)
+	return engine
+}
+
+func TestLoopMaxRoundsAllowsFinalAnswerAfterLastToolRound(t *testing.T) {
+	server, requests := fakeToolSequenceServer(2)
+	defer server.Close()
+
+	var runs atomic.Int32
+	engine := newRoundTestEngine(t, server.URL, &runs)
+	require.NoError(t, engine.SetMaxRounds(2))
+
+	var lastErr error
+	var finalText string
+	for ev, err := range engine.Loop(context.Background(), "go", LoopOpts{}) {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		if update, ok := ev.(session.AssistantMessageUpdate); ok && update.Message.State == session.StateComplete {
+			finalText = update.Message.FlatText()
+		}
+	}
+	require.NoError(t, lastErr)
+	require.Equal(t, int32(2), runs.Load())
+	require.Equal(t, int32(3), requests.Load())
+	require.Equal(t, "done", finalText)
+}
+
+func TestLoopMaxRoundsDoesNotExecuteExtraToolRound(t *testing.T) {
+	server, requests := fakeToolSequenceServer(-1)
+	defer server.Close()
+
+	var runs atomic.Int32
+	engine := newRoundTestEngine(t, server.URL, &runs)
 	require.NoError(t, engine.SetMaxRounds(2))
 
 	var lastErr error
@@ -66,10 +138,20 @@ func TestLoopExceedsMaxRounds(t *testing.T) {
 			break
 		}
 	}
-	require.Error(t, lastErr, "loop should stop with an error once rounds are exhausted")
+	require.Error(t, lastErr, "loop should stop when the model requests a third tool round")
 	if !errors.Is(lastErr, ErrMaxRounds) {
 		t.Fatalf("expected ErrMaxRounds to be wrapped, got %v", lastErr)
 	}
+	require.Equal(t, int32(2), runs.Load())
+	require.Equal(t, int32(3), requests.Load())
+
+	assistantToolRounds := 0
+	for _, msg := range engine.session.BuildContext() {
+		if msg.Role == llm.RoleAssistant && len(msg.ToolCalls) > 0 {
+			assistantToolRounds++
+		}
+	}
+	require.Equal(t, 2, assistantToolRounds)
 }
 
 func TestSetMaxRoundsRejectsNonPositive(t *testing.T) {


### PR DESCRIPTION
## Summary

- Count completed tool-execution rounds against the configured `max-rounds` budget.
- Allow the model to return a final answer after the last permitted tool round.
- Reject the next over-budget tool request before publishing, persisting, or executing it.

## Why

The previous loop counted assistant turns rather than tool rounds. It could stop before the model produced its final answer and could expose an unexecuted terminal tool request in session or UI state.

## Impact

`max-rounds` now matches its documented meaning: exactly that many tool rounds may run, followed by one final answer turn. Requests for an additional tool round fail with `ErrMaxRounds` without mutating the session.

## Validation

- `go test ./internal/agent`
