### PR TITLE
feat(cmd): add phi run wall-clock timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Flags:
 | `-p, --prompt STRING`| Prompt to run (required)                       |
 | `--jsonl`            | Emit JSONL events to stdout                    |
 | `--max-rounds N`     | Cap tool rounds (default 64)                   |
+| `--timeout DURATION` | Limit the agent run wall-clock time (e.g. `10m`; disabled by default) |
 | `--session ID`       | Resume a persisted session by id or unique prefix |
 | `--continue-last`    | Resume the newest persisted session for this directory |
 | `--session-dir DIR`  | Override the session storage directory         |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,6 +230,7 @@ phi run -p "fix the failing test in internal/tools"
 | `-p, --prompt STRING` | 要运行的提示词（必填） |
 | `--jsonl` | 向 stdout 输出 JSONL 事件 |
 | `--max-rounds N` | 限制工具轮数（默认 64） |
+| `--timeout DURATION` | 限制 Agent 运行总时长（例如 `10m`，默认不限制） |
 | `--session ID` | 按 id 或唯一前缀恢复已持久化的会话 |
 | `--continue-last` | 恢复当前目录最新的持久化会话 |
 | `--session-dir DIR` | 覆盖会话存储目录 |

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pulseaiclub/phi/internal/agent"
 	"github.com/pulseaiclub/phi/internal/session"
@@ -20,6 +21,7 @@ type runOptions struct {
 	prompt       string
 	jsonl        bool
 	maxRounds    int
+	timeout      time.Duration
 	session      string
 	continueLast bool
 	sessionDir   string
@@ -114,7 +116,14 @@ func runCmd(args []string) int {
 		fmt.Fprintf(os.Stderr, "file: %s\n", f)
 	}
 
-	return runLoop(ctx, engine, opts)
+	runCtx := ctx
+	if opts.timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, opts.timeout)
+		defer cancel()
+	}
+
+	return runLoop(runCtx, engine, opts)
 }
 
 // runLoop consumes the same engine.Loop the TUI uses — no second loop is
@@ -152,8 +161,12 @@ func runLoop(ctx context.Context, engine *agent.Engine, opts runOptions) int {
 		}
 	}
 
-	if ctx.Err() != nil && exit == ExitOK {
-		exit = ExitError // interrupted (Ctrl-C) is not success
+	if ctxErr := ctx.Err(); ctxErr != nil && exit == ExitOK {
+		exit = ExitError // context cancellation is not success
+		if errors.Is(ctxErr, context.DeadlineExceeded) {
+			enc.errorEvent(ctxErr.Error())
+			fmt.Fprintln(os.Stderr, "error:", ctxErr)
+		}
 	}
 
 	if !opts.jsonl && exit == ExitOK && strings.TrimSpace(finalText) != "" {
@@ -212,6 +225,23 @@ func parseRunArgs(args []string) (runOptions, error) {
 				return o, fmt.Errorf("--max-rounds must be a positive integer, got %q", v)
 			}
 			o.maxRounds = n
+		case arg == "--timeout":
+			v, err := next(arg)
+			if err != nil {
+				return o, err
+			}
+			d, err := time.ParseDuration(v)
+			if err != nil || d <= 0 {
+				return o, fmt.Errorf("--timeout must be a positive duration, got %q", v)
+			}
+			o.timeout = d
+		case strings.HasPrefix(arg, "--timeout="):
+			v := strings.TrimPrefix(arg, "--timeout=")
+			d, err := time.ParseDuration(v)
+			if err != nil || d <= 0 {
+				return o, fmt.Errorf("--timeout must be a positive duration, got %q", v)
+			}
+			o.timeout = d
 		case arg == "--session":
 			v, err := next(arg)
 			if err != nil {
@@ -245,6 +275,7 @@ flags:
   -p, --prompt STRING   prompt to run (required)
       --jsonl           emit JSONL events to stdout
       --max-rounds N    cap tool rounds (default 64)
+      --timeout DURATION stop after a wall-clock duration (e.g. 10m; default unlimited)
       --session ID      resume a persisted session by id or unique prefix
       --continue-last   resume the newest persisted session for this directory
       --session-dir DIR override the session storage directory

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -2,13 +2,19 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pulseaiclub/phi/internal/agent"
+	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/pulseaiclub/phi/internal/permission"
 	"github.com/pulseaiclub/phi/internal/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,12 +25,14 @@ func TestParseRunArgs(t *testing.T) {
 		"-p", "do the thing",
 		"--jsonl",
 		"--max-rounds", "10",
+		"--timeout", "10m",
 		"--session", "abc123",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "do the thing", opts.prompt)
 	assert.True(t, opts.jsonl)
 	assert.Equal(t, 10, opts.maxRounds)
+	assert.Equal(t, 10*time.Minute, opts.timeout)
 	assert.Equal(t, "abc123", opts.session)
 	assert.False(t, opts.continueLast)
 }
@@ -33,12 +41,14 @@ func TestParseRunArgsEqualsForms(t *testing.T) {
 	opts, err := parseRunArgs([]string{
 		"--prompt=hi",
 		"--max-rounds=5",
+		"--timeout=1500ms",
 		"--session-dir=/tmp/sess",
 		"--continue-last",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "hi", opts.prompt)
 	assert.Equal(t, 5, opts.maxRounds)
+	assert.Equal(t, 1500*time.Millisecond, opts.timeout)
 	assert.Equal(t, "/tmp/sess", opts.sessionDir)
 	assert.True(t, opts.continueLast)
 }
@@ -48,12 +58,45 @@ func TestParseRunArgsErrors(t *testing.T) {
 		{"--prompt"},            // missing value
 		{"--max-rounds", "abc"}, // non-integer
 		{"--max-rounds", "0"},   // non-positive
+		{"--timeout"},           // missing value
+		{"--timeout", "abc"},    // invalid duration
+		{"--timeout", "0"},      // non-positive
+		{"--timeout", "-1s"},    // non-positive
 		{"--bogus", "x"},        // unknown flag
 	}
 	for _, args := range cases {
 		_, err := parseRunArgs(args)
 		assert.Error(t, err, "args %v should error", args)
 	}
+}
+
+func TestRunLoopTimeoutCancelsLLMRequest(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer server.Close()
+	defer close(block)
+
+	engine, err := agent.NewEngine(agent.EngineOpts{
+		Model: llm.ModelConfig{
+			Name:    "fake",
+			BaseURL: server.URL,
+			APIKey:  "test",
+		},
+		SessionOpts: agent.SessionOpts{Cwd: t.TempDir()},
+		Gate:        permission.AllowAll{},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	exit := runLoop(ctx, engine, runOptions{prompt: "wait"})
+
+	assert.Equal(t, ExitError, exit)
+	assert.Less(t, time.Since(start), time.Second)
 }
 
 func TestClassifyRunError(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `phi run --timeout DURATION` and `--timeout=DURATION` parsing.
- Apply the timeout to the complete agent run through `context.WithTimeout`.
- Report deadline expiration as an error and document the flag in both READMEs.

## Why

Non-interactive runs previously had no overall wall-clock deadline, so a stalled model request or long-running agent loop could continue indefinitely unless interrupted externally.

## Impact

Scripts and automation can now enforce a total run deadline using standard Go duration syntax, while existing invocations remain unlimited by default.

## Validation

- `go test ./cmd`
