### PR TITLE
fix(bash): bound and safely stream command output

### DIFF
--- a/internal/components/block/bash_block.go
+++ b/internal/components/block/bash_block.go
@@ -24,10 +24,10 @@ const (
 //	$ ls
 //	  parser.go
 //	  ...
-//	  [Showing lines 10-100 of 100. Full output: /tmp/phi-bash-….log]
+//	  [Showing lines 10-100 of 100. Full/retained output: /tmp/phi-bash-….log]
 //
-// Long output is truncated at the source (tools.FormatBashOutput) with a
-// /tmp dump — this widget does not invent a useless "Show more" chrome.
+// Long output is truncated by the bash tool with a /tmp dump — this widget
+// does not invent a useless "Show more" chrome.
 type BashBlock struct {
 	Command  string
 	Output   string

--- a/internal/tools/bashtool/bash.go
+++ b/internal/tools/bashtool/bash.go
@@ -1,7 +1,6 @@
 package bashtool
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,7 +18,7 @@ const (
 var bashDescription = `Run a shell command and return combined stdout/stderr.
 
 Use for one-off build, test, git, or inspection commands. Large output is
-truncated with the full log written to a temp file.`
+truncated with the retained output written to a temp file.`
 
 // BashTool returns the bash tool definition + handler.
 func BashTool() tooldef.Tool {
@@ -80,12 +79,14 @@ func runBash(ctx context.Context, input json.RawMessage) (tooldef.Result, error)
 	if err != nil {
 		return tooldef.Result{}, err
 	}
-	var buf bytes.Buffer
-	c.Stdout = &buf
-	c.Stderr = &buf
+	// Bound the shared stdout/stderr collector so runaway output cannot be
+	// buffered unboundedly.
+	cb := newCappedBuffer(BashMaxCollectBytes)
+	c.Stdout = cb
+	c.Stderr = cb
 	err = c.Run()
 
-	out := FormatBashOutput(buf.String())
+	out := formatBashOutput(cb.String(), cb.Truncated())
 	if strings.TrimSpace(out) == "" {
 		out = "(no output)"
 	}

--- a/internal/tools/bashtool/bash_output.go
+++ b/internal/tools/bashtool/bash_output.go
@@ -14,23 +14,29 @@ const (
 	BashMaxOutputLines = 1000
 	// BashMaxOutputBytes is the maximum bytes kept in displayed bash output (50KB).
 	BashMaxOutputBytes = 50 * 1024
+	// BashMaxCollectBytes caps how much of a command's output is buffered in
+	// memory (and retained in the temp-file dump) before display truncation.
+	// Guards against runaway output (`cat /dev/urandom | base64`, `yes`):
+	// the newest 8 MB is kept, the rest is dropped at the source.
+	BashMaxCollectBytes = 8 * 1024 * 1024
 )
 
-// FormatBashOutput keeps the last BashMaxOutputLines / BashMaxOutputBytes of
-// output (tail). When truncated, the full output is written to a temp file and
-// a panda-style notice with the path is appended — no in-UI "Show more".
-func FormatBashOutput(output string) string {
-	display, path := truncateBashTail(output, BashMaxOutputLines, BashMaxOutputBytes)
-	if path == "" {
-		return display
+// formatBashOutput keeps the last BashMaxOutputLines / BashMaxOutputBytes of
+// real output. Collection metadata is appended afterward so it does not alter
+// the display budget or reported line range.
+func formatBashOutput(output string, collectionTruncated bool) string {
+	label := "Full output"
+	if collectionTruncated {
+		label = "Retained output"
 	}
-	if !strings.Contains(display, path) {
-		display += fmt.Sprintf("\n\n[Full output: %s]", path)
+	display, _ := truncateBashTail(output, BashMaxOutputLines, BashMaxOutputBytes, label)
+	if collectionTruncated {
+		display += collectTruncationNote
 	}
 	return display
 }
 
-func truncateBashTail(output string, maxLines, maxBytes int) (display, fullPath string) {
+func truncateBashTail(output string, maxLines, maxBytes int, outputLabel string) (display, fullPath string) {
 	if maxLines <= 0 {
 		maxLines = BashMaxOutputLines
 	}
@@ -38,12 +44,14 @@ func truncateBashTail(output string, maxLines, maxBytes int) (display, fullPath 
 		maxBytes = BashMaxOutputBytes
 	}
 	totalBytes := len(output)
-	lines := strings.Split(output, "\n")
-	// Trailing empty from final newline shouldn't inflate the line count for limits.
-	totalLines := len(lines)
-	if totalLines > 0 && lines[totalLines-1] == "" {
-		totalLines--
-		lines = lines[:totalLines]
+	totalLines := strings.Count(output, "\n")
+	bodyEnd := len(output)
+	if bodyEnd > 0 && output[bodyEnd-1] == '\n' {
+		// A final newline terminates the last line; exclude only the empty
+		// element that strings.Split would otherwise produce after it.
+		bodyEnd--
+	} else if bodyEnd > 0 {
+		totalLines++
 	}
 
 	if totalLines <= maxLines && totalBytes <= maxBytes {
@@ -55,40 +63,47 @@ func truncateBashTail(output string, maxLines, maxBytes int) (display, fullPath 
 		path = ""
 	}
 
-	// Keep a tail that respects both limits.
-	start := 0
+	// Locate the display tail without splitting every retained line. Dense
+	// output can contain millions of newlines even within the collection cap.
+	tailStart := 0
 	if totalLines > maxLines {
-		start = totalLines - maxLines
-	}
-	tail := lines[start:]
-	for len(tail) > 1 && joinedBytes(tail) > maxBytes {
-		tail = tail[1:]
-	}
-	if len(tail) == 1 && len(tail[0]) > maxBytes {
-		s := tail[0]
-		tail = []string{s[len(s)-maxBytes:]}
+		cursor := bodyEnd
+		for range maxLines {
+			newline := strings.LastIndexByte(output[:cursor], '\n')
+			if newline < 0 {
+				cursor = 0
+				break
+			}
+			cursor = newline
+		}
+		tailStart = cursor + 1
 	}
 
-	display = strings.Join(tail, "\n")
-	startLine := totalLines - len(tail) + 1
-	endLine := totalLines
-	if path != "" {
-		display += fmt.Sprintf("\n\n[Showing lines %d-%d of %d. Full output: %s]", startLine, endLine, totalLines, path)
-	} else {
-		display += fmt.Sprintf("\n\n[Showing lines %d-%d of %d. Full output unavailable]", startLine, endLine, totalLines)
-	}
-	return display, path
-}
-
-func joinedBytes(lines []string) int {
-	n := 0
-	for i, line := range lines {
-		n += len(line)
-		if i > 0 {
-			n++ // newline
+	if bodyEnd-tailStart > maxBytes {
+		minStart := bodyEnd - maxBytes
+		searchStart := minStart - 1
+		if searchStart < tailStart {
+			searchStart = tailStart
+		}
+		if newline := strings.IndexByte(output[searchStart:bodyEnd], '\n'); newline >= 0 {
+			// Prefer a line boundary, even when that keeps fewer than maxBytes.
+			tailStart = searchStart + newline + 1
+		} else {
+			// The final line alone exceeds maxBytes; keep its byte tail.
+			tailStart = minStart
 		}
 	}
-	return n
+
+	display = output[tailStart:bodyEnd]
+	displayLines := strings.Count(display, "\n") + 1
+	startLine := totalLines - displayLines + 1
+	endLine := totalLines
+	if path != "" {
+		display += fmt.Sprintf("\n\n[Showing lines %d-%d of %d. %s: %s]", startLine, endLine, totalLines, outputLabel, path)
+	} else {
+		display += fmt.Sprintf("\n\n[Showing lines %d-%d of %d. %s unavailable]", startLine, endLine, totalLines, outputLabel)
+	}
+	return display, path
 }
 
 func writeBashTempFile(content string) (string, error) {

--- a/internal/tools/bashtool/bash_output_test.go
+++ b/internal/tools/bashtool/bash_output_test.go
@@ -6,21 +6,21 @@ import (
 	"testing"
 )
 
-func TestFormatBashOutputShort(t *testing.T) {
+func TestBashOutputFormattingPreservesShortOutput(t *testing.T) {
 	in := "a\nb\nc\n"
-	got := FormatBashOutput(in)
+	got := formatBashOutput(in, false)
 	if got != in {
 		t.Fatalf("short output changed: %q", got)
 	}
 }
 
-func TestFormatBashOutputWritesTemp(t *testing.T) {
+func TestBashOutputFormattingWritesTemp(t *testing.T) {
 	var b strings.Builder
 	for i := 0; i < BashMaxOutputLines+20; i++ {
 		b.WriteString("line\n")
 	}
 	full := b.String()
-	got := FormatBashOutput(full)
+	got := formatBashOutput(full, false)
 	if !strings.Contains(got, "Full output:") {
 		t.Fatalf("missing full-output notice: %q", got)
 	}
@@ -31,6 +31,7 @@ func TestFormatBashOutputWritesTemp(t *testing.T) {
 	idx := strings.Index(got, "Full output: ")
 	rest := got[idx+len("Full output: "):]
 	path := strings.TrimSpace(strings.Split(rest, "]")[0])
+	t.Cleanup(func() { _ = os.Remove(path) })
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
@@ -38,5 +39,110 @@ func TestFormatBashOutputWritesTemp(t *testing.T) {
 	if string(data) != full {
 		t.Fatalf("temp file content mismatch: got %d bytes want %d", len(data), len(full))
 	}
-	_ = os.Remove(path)
+}
+
+func TestFormatCollectedBashOutputLabelsRetainedFile(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < BashMaxOutputLines+20; i++ {
+		b.WriteString("line\n")
+	}
+	retained := b.String()
+
+	got := formatBashOutput(retained, true)
+	if !strings.Contains(got, "Retained output:") {
+		t.Fatalf("missing retained-output notice: %q", got)
+	}
+	if strings.Contains(got, "Full output:") {
+		t.Fatalf("collection-truncated output mislabeled as full: %q", got)
+	}
+	if !strings.Contains(got, "Showing lines 21-1020 of 1020") {
+		t.Fatalf("collection notice changed real line range: %q", got)
+	}
+	if !strings.HasSuffix(got, collectTruncationNote) {
+		t.Fatalf("missing collection truncation note: %q", got)
+	}
+	idx := strings.Index(got, "Retained output: ")
+	path := strings.TrimSpace(strings.Split(got[idx+len("Retained output: "):], "]")[0])
+	if path == "" {
+		t.Fatal("missing retained output path")
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != retained {
+		t.Fatalf("retained file contains display metadata: got %d bytes want %d", len(data), len(retained))
+	}
+}
+
+func TestCollectionNoticeDoesNotConsumeDisplayBudget(t *testing.T) {
+	output := strings.Repeat("x", BashMaxOutputBytes)
+	got := formatBashOutput(output, true)
+	if got != output+collectTruncationNote {
+		t.Fatalf("collection notice altered output at display limit: got %d bytes want %d", len(got), len(output)+len(collectTruncationNote))
+	}
+	if strings.Contains(got, "Retained output:") || strings.Contains(got, "Showing lines") {
+		t.Fatalf("collection notice caused an unnecessary temp dump: %q", got[len(output):])
+	}
+}
+
+func TestTruncateBashTailPreservesTailSemantics(t *testing.T) {
+	tests := []struct {
+		name      string
+		output    string
+		maxLines  int
+		maxBytes  int
+		wantTail  string
+		wantRange string
+	}{
+		{
+			name:      "line limit with trailing newline",
+			output:    "one\ntwo\nthree\nfour\n",
+			maxLines:  3,
+			maxBytes:  64,
+			wantTail:  "two\nthree\nfour",
+			wantRange: "Showing lines 2-4 of 4",
+		},
+		{
+			name:      "byte limit prefers complete lines",
+			output:    "aaaa\nbbbb\ncccc",
+			maxLines:  100,
+			maxBytes:  8,
+			wantTail:  "cccc",
+			wantRange: "Showing lines 3-3 of 3",
+		},
+		{
+			name:      "single long line keeps byte tail",
+			output:    "0123456789ABC",
+			maxLines:  100,
+			maxBytes:  10,
+			wantTail:  "3456789ABC",
+			wantRange: "Showing lines 1-1 of 1",
+		},
+		{
+			name:      "final empty line",
+			output:    "one\n\n",
+			maxLines:  1,
+			maxBytes:  64,
+			wantTail:  "",
+			wantRange: "Showing lines 2-2 of 2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			display, path := truncateBashTail(tc.output, tc.maxLines, tc.maxBytes, "Full output")
+			if path == "" {
+				t.Fatal("missing temp output path")
+			}
+			t.Cleanup(func() { _ = os.Remove(path) })
+			if !strings.HasPrefix(display, tc.wantTail+"\n\n[") {
+				t.Fatalf("display tail=%q, want prefix %q", display, tc.wantTail)
+			}
+			if !strings.Contains(display, tc.wantRange) {
+				t.Fatalf("display=%q, want range %q", display, tc.wantRange)
+			}
+		})
+	}
 }

--- a/internal/tools/bashtool/collect.go
+++ b/internal/tools/bashtool/collect.go
@@ -1,0 +1,145 @@
+package bashtool
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+)
+
+// cappedBuffer collects command output into a bounded rolling tail.
+//
+// Once the cap is reached, the oldest bytes are dropped so memory stays
+// bounded while the newest output is retained — the same "keep the tail"
+// philosophy as the bash display limits. The truncation is
+// reported via Truncated so callers can tell the user the output was cut
+// at the source, not just at display time.
+//
+// Write is safe for concurrent use even though the current os/exec callers
+// assign the same comparable writer to stdout and stderr, which os/exec
+// coalesces onto one copy path.
+type cappedBuffer struct {
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+// BashOutputTail keeps a small, display-sized tail for live UI updates.
+// Unlike cappedBuffer, it also limits the number of lines so rendering the
+// live view cannot allocate a surface proportional to a runaway log.
+type BashOutputTail struct {
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	maxBytes  int
+	maxLines  int
+	truncated bool
+}
+
+// NewBashOutputTail creates a bounded tail using the bash display limits.
+func NewBashOutputTail(maxLines, maxBytes int) *BashOutputTail {
+	if maxLines <= 0 {
+		maxLines = BashMaxOutputLines
+	}
+	if maxBytes <= 0 {
+		maxBytes = BashMaxOutputBytes
+	}
+	return &BashOutputTail{maxLines: maxLines, maxBytes: maxBytes}
+}
+
+// Write implements io.Writer while retaining only the newest display-sized
+// tail. It is safe for concurrent use.
+func (t *BashOutputTail) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf.Write(p)
+	t.trimLocked()
+	return len(p), nil
+}
+
+// WriteString appends s to the bounded tail without an intermediate byte
+// slice.
+func (t *BashOutputTail) WriteString(s string) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf.WriteString(s)
+	t.trimLocked()
+	return len(s), nil
+}
+
+// Snapshot returns the current display tail and whether older output was
+// discarded.
+func (t *BashOutputTail) Snapshot() (string, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.buf.String(), t.truncated
+}
+
+func (t *BashOutputTail) trimLocked() {
+	if t.maxBytes > 0 && t.buf.Len() > t.maxBytes {
+		t.buf.Next(t.buf.Len() - t.maxBytes)
+		t.truncated = true
+	}
+	data := t.buf.Bytes()
+	if len(data) == 0 || t.maxLines <= 0 {
+		return
+	}
+
+	// A trailing newline terminates the last line; it should not create an
+	// extra empty line in the same way truncateBashTail treats it.
+	lineCount := 1
+	if data[len(data)-1] == '\n' {
+		lineCount = 0
+	}
+	for i := len(data) - 1; i >= 0; i-- {
+		if data[i] != '\n' {
+			continue
+		}
+		lineCount++
+		if lineCount > t.maxLines {
+			t.buf.Next(i + 1)
+			t.truncated = true
+			return
+		}
+	}
+}
+
+func newCappedBuffer(limit int) *cappedBuffer {
+	return &cappedBuffer{limit: limit}
+}
+
+// Write implements io.Writer. It never reports a short write even when bytes
+// are dropped, so os/exec's copy machinery treats it as a plain sink.
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buf.Write(p)
+	if c.buf.Len() > c.limit {
+		// Drop the oldest bytes to keep a bounded rolling tail.
+		c.buf.Next(c.buf.Len() - c.limit)
+		c.truncated = true
+	}
+	return len(p), nil
+}
+
+// String returns the retained output (never more than limit bytes).
+func (c *cappedBuffer) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+// Truncated reports whether the cap was hit and bytes were dropped.
+func (c *cappedBuffer) Truncated() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.truncated
+}
+
+const collectTruncationMarker = "[output truncated:"
+
+// collectTruncationNote is appended after display truncation so it does not
+// consume the real output's line or byte budget.
+var collectTruncationNote = fmt.Sprintf(
+	"\n\n%s only the last %d MB was kept]",
+	collectTruncationMarker,
+	BashMaxCollectBytes/(1024*1024))

--- a/internal/tools/bashtool/collect_test.go
+++ b/internal/tools/bashtool/collect_test.go
@@ -1,0 +1,86 @@
+package bashtool
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestCappedBufferKeepsNewestTail(t *testing.T) {
+	cb := newCappedBuffer(32)
+	full := strings.Repeat("0123456789", 100)
+	for range 100 {
+		if _, err := cb.Write([]byte("0123456789")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := cb.String()
+	if want := full[len(full)-32:]; got != want {
+		t.Fatalf("want the newest 32 bytes %q, got %q", want, got)
+	}
+	if !cb.Truncated() {
+		t.Fatal("want truncated")
+	}
+}
+
+func TestBashOutputTailKeepsNewestLinesAndBytes(t *testing.T) {
+	tail := NewBashOutputTail(3, 64)
+	if _, err := tail.WriteString("one\ntwo\nthree\nfour\n"); err != nil {
+		t.Fatal(err)
+	}
+	got, truncated := tail.Snapshot()
+	if want := "two\nthree\nfour\n"; got != want || !truncated {
+		t.Fatalf("got %q truncated=%v, want %q and truncation", got, truncated, want)
+	}
+
+	tail = NewBashOutputTail(100, 10)
+	if _, err := tail.WriteString("0123456789ABC"); err != nil {
+		t.Fatal(err)
+	}
+	got, truncated = tail.Snapshot()
+	if got != "3456789ABC" || !truncated {
+		t.Fatalf("got %q truncated=%v, want newest 10 bytes", got, truncated)
+	}
+}
+
+func TestCappedBufferNoTruncationUnderLimit(t *testing.T) {
+	cb := newCappedBuffer(64)
+	data := "hello world"
+	if _, err := cb.Write([]byte(data)); err != nil {
+		t.Fatal(err)
+	}
+	if cb.String() != data || cb.Truncated() {
+		t.Fatalf("got %q truncated=%v", cb.String(), cb.Truncated())
+	}
+}
+
+func TestCappedBufferExactLimit(t *testing.T) {
+	cb := newCappedBuffer(10)
+	data := "0123456789"
+	if _, err := cb.Write([]byte(data)); err != nil {
+		t.Fatal(err)
+	}
+	if cb.String() != data || cb.Truncated() {
+		t.Fatalf("got %q truncated=%v", cb.String(), cb.Truncated())
+	}
+}
+
+func TestCappedBufferConcurrentWrites(t *testing.T) {
+	// Preserve the collector's defensive concurrency contract even though the
+	// current os/exec setup coalesces stdout and stderr onto one writer path.
+	cb := newCappedBuffer(1024)
+	var wg sync.WaitGroup
+	for _, g := range []string{"a", "b"} {
+		wg.Add(1)
+		go func(g string) {
+			defer wg.Done()
+			for range 5000 {
+				_, _ = cb.Write([]byte(g))
+			}
+		}(g)
+	}
+	wg.Wait()
+	if len(cb.String()) != 1024 || !cb.Truncated() {
+		t.Fatalf("len=%d truncated=%v", len(cb.String()), cb.Truncated())
+	}
+}

--- a/internal/tools/bashtool/shell_exec.go
+++ b/internal/tools/bashtool/shell_exec.go
@@ -1,14 +1,11 @@
 package bashtool
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
-	"sync"
 )
 
 // ShellExecResult is the outcome of a streaming shell run.
@@ -23,6 +20,34 @@ type ShellExecOptions struct {
 	OnChunk func(chunk string)
 }
 
+// shellOutputWriter combines stdout and stderr while preserving the streaming
+// callback. Using it as Cmd.Stdout and Cmd.Stderr lets os/exec own the copy
+// machinery, so Cmd.Run waits for all output before closing the pipes.
+// Collection is bounded independently of streaming callbacks, whose consumers
+// are responsible for applying their own retention limits.
+type shellOutputWriter struct {
+	cb      *cappedBuffer
+	onChunk func(chunk string)
+}
+
+func (w *shellOutputWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if _, err := w.cb.Write(p); err != nil {
+		return 0, err
+	}
+	if w.onChunk != nil {
+		w.onChunk(string(p))
+	}
+	return len(p), nil
+}
+
+// Collected returns the retained command output without display metadata.
+func (w *shellOutputWriter) Collected() string {
+	return w.cb.String()
+}
+
 // ExecShell runs command via bash -c, streaming combined stdout+stderr.
 func ExecShell(ctx context.Context, command string, opts ShellExecOptions) (ShellExecResult, error) {
 	command = strings.TrimSpace(command)
@@ -34,50 +59,12 @@ func ExecShell(ctx context.Context, command string, opts ShellExecOptions) (Shel
 	if err != nil {
 		return ShellExecResult{}, err
 	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return ShellExecResult{}, err
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return ShellExecResult{}, err
-	}
-	if err := cmd.Start(); err != nil {
-		return ShellExecResult{}, err
-	}
+	output := &shellOutputWriter{cb: newCappedBuffer(BashMaxCollectBytes), onChunk: opts.OnChunk}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	waitErr := cmd.Run()
 
-	var (
-		mu  sync.Mutex
-		buf bytes.Buffer
-		wg  sync.WaitGroup
-	)
-	stream := func(r io.Reader) {
-		defer wg.Done()
-		chunk := make([]byte, 4096)
-		for {
-			n, readErr := r.Read(chunk)
-			if n > 0 {
-				s := string(chunk[:n])
-				mu.Lock()
-				buf.WriteString(s)
-				mu.Unlock()
-				if opts.OnChunk != nil {
-					opts.OnChunk(s)
-				}
-			}
-			if readErr != nil {
-				return
-			}
-		}
-	}
-	wg.Add(2)
-	go stream(stdout)
-	go stream(stderr)
-
-	waitErr := cmd.Wait()
-	wg.Wait()
-
-	out := FormatBashOutput(buf.String())
+	out := formatBashOutput(output.Collected(), output.cb.Truncated())
 
 	res := ShellExecResult{Output: out}
 	if errors.Is(ctx.Err(), context.Canceled) {

--- a/internal/tools/bashtool/shell_exec_test.go
+++ b/internal/tools/bashtool/shell_exec_test.go
@@ -2,6 +2,7 @@ package bashtool
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,125 @@ func TestExecShellEcho(t *testing.T) {
 	if !strings.Contains(res.Output, "hello") {
 		t.Fatalf("output=%q", res.Output)
 	}
+}
+
+func TestExecShellCapturesBothStreams(t *testing.T) {
+	res, err := ExecShell(context.Background(), "printf stdout; printf stderr >&2", ShellExecOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ExitCode != 0 || res.Canceled {
+		t.Fatalf("result: %+v", res)
+	}
+	if !strings.Contains(res.Output, "stdout") || !strings.Contains(res.Output, "stderr") {
+		t.Fatalf("combined output=%q", res.Output)
+	}
+}
+
+func TestShellOutputWriterStreamsAfterCollectionCap(t *testing.T) {
+	var streamed strings.Builder
+	output := &shellOutputWriter{
+		cb:      newCappedBuffer(4),
+		onChunk: func(chunk string) { streamed.WriteString(chunk) },
+	}
+	if _, err := output.Write([]byte("1234")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := output.Write([]byte("5678")); err != nil {
+		t.Fatal(err)
+	}
+	if got := streamed.String(); got != "12345678" {
+		t.Fatalf("streamed output=%q, want all chunks", got)
+	}
+	if got := output.cb.String(); got != "5678" || !output.cb.Truncated() {
+		t.Fatalf("collected output=%q truncated=%v, want bounded tail", got, output.cb.Truncated())
+	}
+}
+
+func TestExecShellCapturesOutputBeforeProcessExit(t *testing.T) {
+	const outputSize = 32 * 1024
+	const command = "printf '%*s' 32768 '' | tr ' ' x"
+
+	for range 8 {
+		res, err := ExecShell(context.Background(), command, ShellExecOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.ExitCode != 0 || res.Canceled {
+			t.Fatalf("result: %+v", res)
+		}
+		if len(res.Output) != outputSize || strings.Trim(res.Output, "x") != "" {
+			t.Fatalf("captured %d bytes, want %d x bytes", len(res.Output), outputSize)
+		}
+	}
+}
+
+func TestExecShellKeepsOutputTail(t *testing.T) {
+	// Regression: output still buffered in the kernel pipe at process exit
+	// must not be dropped (writer-mode copying drains to EOF before Run returns).
+	command := "seq 1 100000" // ~590KB, under the collection cap
+	res, err := ExecShell(context.Background(), command, ShellExecOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupBashOutputFile(t, res.Output)
+	if res.ExitCode != 0 || res.Canceled {
+		t.Fatalf("result: %+v", res)
+	}
+	// The display notice's own line range proves line 100000 was collected.
+	if !strings.Contains(res.Output, "Showing lines 99001-100000 of 100000") {
+		t.Fatalf("output tail lost, ends with %q", tailLines(res.Output, 3))
+	}
+	if !strings.Contains(res.Output, "Full output:") || strings.Contains(res.Output, "Retained output:") {
+		t.Fatalf("under-cap output mislabeled, ends with %q", tailLines(res.Output, 3))
+	}
+	if strings.Contains(res.Output, "[output truncated:") {
+		t.Fatalf("unexpected collection truncation, ends with %q", tailLines(res.Output, 3))
+	}
+}
+
+func TestExecShellBoundsCollection(t *testing.T) {
+	// Runaway output must not be buffered unboundedly: the newest
+	// BashMaxCollectBytes are kept and the collection truncation is reported.
+	command := "yes x | head -c 20971520" // 20MB
+	res, err := ExecShell(context.Background(), command, ShellExecOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupBashOutputFile(t, res.Output)
+	if res.ExitCode != 0 || res.Canceled {
+		t.Fatalf("result: %+v", res)
+	}
+	if !strings.Contains(res.Output, "[output truncated: only the last 8 MB was kept]") {
+		t.Fatalf("want collection truncation notice, ends with %q", tailLines(res.Output, 3))
+	}
+	if !strings.Contains(res.Output, "Retained output:") || strings.Contains(res.Output, "Full output:") {
+		t.Fatalf("collection-truncated output mislabeled, ends with %q", tailLines(res.Output, 3))
+	}
+}
+
+func cleanupBashOutputFile(t *testing.T, output string) {
+	t.Helper()
+	for _, marker := range []string{"Full output: ", "Retained output: "} {
+		idx := strings.Index(output, marker)
+		if idx < 0 {
+			continue
+		}
+		path := strings.TrimSpace(strings.Split(output[idx+len(marker):], "]")[0])
+		if path == "" {
+			return
+		}
+		t.Cleanup(func() { _ = os.Remove(path) })
+		return
+	}
+}
+
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
 }
 
 func TestExecShellCancel(t *testing.T) {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -31,9 +31,18 @@ var (
 type (
 	ShellExecResult  = bashtool.ShellExecResult
 	ShellExecOptions = bashtool.ShellExecOptions
+	BashOutputTail   = bashtool.BashOutputTail
 )
 
-var ExecShell = bashtool.ExecShell
+const (
+	BashMaxOutputLines = bashtool.BashMaxOutputLines
+	BashMaxOutputBytes = bashtool.BashMaxOutputBytes
+)
+
+var (
+	ExecShell         = bashtool.ExecShell
+	NewBashOutputTail = bashtool.NewBashOutputTail
+)
 
 // Agent helpers used by the TUI / mapper.
 type (

--- a/internal/tui/bash.go
+++ b/internal/tui/bash.go
@@ -58,14 +58,12 @@ func (editor *Editor) runBash(id, command string) {
 		editor.bashMu.Unlock()
 	}()
 
-	var (
-		outMu sync.Mutex
-		out   strings.Builder
-	)
-	publishOutput := func() {
-		outMu.Lock()
-		cur := out.String()
-		outMu.Unlock()
+	// Live updates publish at most this often and carry only a display-sized
+	// tail. This keeps both the event payload and BashBlock layout bounded while
+	// the final event still carries the formatted command result.
+	const bashPublishInterval = 100 * time.Millisecond
+
+	liveOutput := newBashLiveOutput(bashPublishInterval, func(cur string) {
 		editor.Publish(SessionEventMsg{Event: session.ToolData{Run: session.ToolRun{
 			ToolUseID: id,
 			Name:      "bash",
@@ -74,16 +72,15 @@ func (editor *Editor) runBash(id, command string) {
 			Output:    cur,
 			Local:     true,
 		}}})
-	}
+	})
 
 	result, err := tools.ExecShell(ctx, command, tools.ShellExecOptions{
-		OnChunk: func(chunk string) {
-			outMu.Lock()
-			out.WriteString(chunk)
-			outMu.Unlock()
-			publishOutput()
-		},
+		OnChunk: liveOutput.Append,
 	})
+	// Cmd.Run waits for all writer callbacks, so no Append can race with Close.
+	// Closing before the final event prevents a trailing in-progress update from
+	// replacing the completed state.
+	liveOutput.Close()
 	if err != nil {
 		editor.Publish(SessionEventMsg{Event: session.ToolData{Run: session.ToolRun{
 			ToolUseID: id,
@@ -115,6 +112,76 @@ func (editor *Editor) runBash(id, command string) {
 		ExitCode:  result.ExitCode,
 		Local:     true,
 	}}})
+}
+
+// bashLiveOutput publishes a bounded live tail immediately, then at most once
+// per interval. A skipped update always schedules one trailing publication.
+type bashLiveOutput struct {
+	mu          sync.Mutex
+	tail        *tools.BashOutputTail
+	interval    time.Duration
+	lastPublish time.Time
+	timer       *time.Timer
+	stopped     bool
+	publish     func(output string)
+}
+
+func newBashLiveOutput(interval time.Duration, publish func(output string)) *bashLiveOutput {
+	return &bashLiveOutput{
+		tail:     tools.NewBashOutputTail(tools.BashMaxOutputLines, tools.BashMaxOutputBytes),
+		interval: interval,
+		publish:  publish,
+	}
+}
+
+func (o *bashLiveOutput) Append(chunk string) {
+	_, _ = o.tail.WriteString(chunk)
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.stopped || o.timer != nil {
+		return
+	}
+	now := time.Now()
+	if o.lastPublish.IsZero() || now.Sub(o.lastPublish) >= o.interval {
+		o.publishLocked(now)
+		return
+	}
+	delay := o.interval - now.Sub(o.lastPublish)
+	o.timer = time.AfterFunc(delay, o.publishTrailing)
+}
+
+func (o *bashLiveOutput) publishTrailing() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.timer = nil
+	if o.stopped {
+		return
+	}
+	o.publishLocked(time.Now())
+}
+
+func (o *bashLiveOutput) publishLocked(now time.Time) {
+	cur, truncated := o.tail.Snapshot()
+	if truncated {
+		cur = "[live output truncated; showing latest output]\n" + cur
+	}
+	o.lastPublish = now
+	if o.publish != nil {
+		o.publish(cur)
+	}
+}
+
+// Close synchronizes with any active timer callback and prevents future
+// in-progress publications.
+func (o *bashLiveOutput) Close() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.stopped = true
+	if o.timer != nil {
+		o.timer.Stop()
+		o.timer = nil
+	}
 }
 
 // cancelBash aborts a running user "!cmd". Returns true if one was cancelled.

--- a/internal/tui/bash_test.go
+++ b/internal/tui/bash_test.go
@@ -1,0 +1,47 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBashLiveOutputPublishesTrailingUpdate(t *testing.T) {
+	updates := make(chan string, 2)
+	live := newBashLiveOutput(50*time.Millisecond, func(output string) {
+		updates <- output
+	})
+	t.Cleanup(live.Close)
+
+	live.Append("first")
+	if got := <-updates; got != "first" {
+		t.Fatalf("first update=%q", got)
+	}
+	live.Append("-second")
+
+	select {
+	case got := <-updates:
+		if got != "first-second" {
+			t.Fatalf("trailing update=%q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for trailing update")
+	}
+}
+
+func TestBashLiveOutputCloseCancelsTrailingUpdate(t *testing.T) {
+	updates := make(chan string, 2)
+	live := newBashLiveOutput(time.Hour, func(output string) {
+		updates <- output
+	})
+
+	live.Append("first")
+	<-updates
+	live.Append("-second")
+	live.Close()
+
+	live.mu.Lock()
+	defer live.mu.Unlock()
+	if !live.stopped || live.timer != nil {
+		t.Fatalf("closed live output: stopped=%v timer=%v", live.stopped, live.timer)
+	}
+}


### PR DESCRIPTION
## Summary

- Cap retained stdout/stderr at a rolling 8 MiB tail and keep display output within 50 KiB and 1,000 lines.
- Throttle bounded TUI updates while preserving a trailing live update and preventing delayed updates after completion.
- Replace manual `StdoutPipe`/`StderrPipe` readers with `os/exec` writer mode so `Cmd.Run` waits for output copying before returning.
- Distinguish complete output logs from collection-truncated retained logs.

## Why

The previous implementation buffered all command output before applying display limits, and the TUI copied and published the full accumulated string for every chunk. `ExecShell` also called `Wait` before its pipe readers finished, risking loss of output at process exit.

## Impact

High-volume commands now have bounded collection and UI memory use, live output remains responsive, and trailing stdout/stderr is drained before process completion is reported.

## Validation

- `go test ./internal/tools/bashtool ./internal/tui`
- `go test -race ./internal/tools/bashtool ./internal/tui`
