### PR TITLE
feat(tui): prompt Continue/Stop when tool rounds are exhausted

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ Flags:
 Exit codes: `0` success · `1` runtime/LLM error · `2` max rounds reached ·
 `3` config/usage error.
 
+In the interactive TUI, exhausting the tool-round budget prompts Continue /
+Stop. Headless `phi run` has no confirmation UI, so it exits with code 2.
+
 In headless mode, permission `ask` decisions are denied (there is no approval
 UI), so `readonly`-style safety applies without extra flags.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -239,6 +239,9 @@ phi run -p "fix the failing test in internal/tools"
 退出码：`0` 成功 · `1` 运行时/LLM 错误 · `2` 达到最大轮数 ·
 `3` 配置/用法错误。
 
+交互式 TUI 在工具轮数耗尽时会询问 Continue / Stop。
+无头 `phi run` 没有确认界面，因此直接以退出码 2 结束。
+
 无头模式下，权限 `ask` 的决策会被拒绝（没有审批界面），因此无需额外参数
 即可获得 `readonly` 级别的安全性。
 

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -24,9 +24,15 @@ import (
 // and yields session.Event for the TUI reducer. Context compaction is owned
 // here so Session stays a thin message store.
 // ErrMaxRounds is returned (wrapped) by Loop when the model exceeds the
-// configured tool-round budget. Callers can distinguish it from other
-// runtime errors with errors.Is, e.g. for a dedicated exit code.
+// configured tool-round budget and continuation is declined or unavailable.
+// Callers can distinguish it from other runtime errors with errors.Is,
+// e.g. for a dedicated exit code.
 var ErrMaxRounds = errors.New("exceeded maximum tool rounds")
+
+// ContinueFunc asks whether to grant another maxRounds budget after the
+// current budget is exhausted. Nil means hard-fail with ErrMaxRounds
+// (headless / sub-agent default). True continues the loop with a fresh budget.
+type ContinueFunc func(ctx context.Context, maxRounds int) (bool, error)
 
 type Engine struct {
 	client        *llmclient.Client
@@ -37,6 +43,7 @@ type Engine struct {
 	modelCfg      llm.ModelConfig
 	gate          permission.Gate
 	ask           permission.AskFunc
+	continueAsk   ContinueFunc
 	jobs          *job.Manager
 	hooks         *hooks.Manager
 
@@ -49,10 +56,11 @@ type EngineOpts struct {
 	SessionOpts SessionOpts
 	Gate        permission.Gate    // nil = allow all
 	Ask         permission.AskFunc // nil = deny on Ask
+	ContinueAsk ContinueFunc       // nil = ErrMaxRounds on budget exhaust
 	Tools       []tools.Tool       // nil = tools.DefaultTools(); sub-agents use ChildTools()
 	MaxRounds   int                // 0 = package default
 	Jobs        *job.Manager       // if set, register agent_* tools on this engine
-	Hooks       *hooks.Manager // nil = no hooks; child engines inherit parent Manager (S9)
+	Hooks       *hooks.Manager     // nil = no hooks; child engines inherit parent Manager (S9)
 }
 
 // NewEngine wires an LLM client, tool executor, and session store.
@@ -70,6 +78,7 @@ func NewEngine(opts EngineOpts) (*Engine, error) {
 		session:       sess,
 		gate:          opts.Gate,
 		ask:           opts.Ask,
+		continueAsk:   opts.ContinueAsk,
 		jobs:          opts.Jobs,
 		hooks:         opts.Hooks,
 	}
@@ -175,6 +184,15 @@ func (engine *Engine) SetPermission(gate permission.Gate, ask permission.AskFunc
 	}
 }
 
+// SetContinueAsk sets the handler invoked when the tool-round budget is exhausted.
+// Pass nil to hard-fail with ErrMaxRounds (default for headless runs).
+func (engine *Engine) SetContinueAsk(fn ContinueFunc) {
+	if engine == nil {
+		return
+	}
+	engine.continueAsk = fn
+}
+
 // SetHooks replaces the hooks manager. Pass nil to disable hooks.
 // Does not drop Gate/Ask; rebindTools also preserves hooks.
 func (engine *Engine) SetHooks(mgr *hooks.Manager) {
@@ -264,6 +282,18 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 
 		for round := 0; ; round++ {
 			if round > engine.maxRounds {
+				if engine.continueAsk != nil {
+					ok, err := engine.continueAsk(ctx, engine.maxRounds)
+					if err != nil {
+						yield(nil, err)
+						return
+					}
+					if ok {
+						// Fresh budget: for-loop round++ then yields 0.
+						round = -1
+						continue
+					}
+				}
 				yield(nil, fmt.Errorf("agent: %w (%d)", ErrMaxRounds, engine.maxRounds))
 				return
 			}

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -237,19 +237,27 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 			return
 		}
 
-		for round := 0; ; round++ {
-			if round > engine.maxRounds {
-				yield(nil, fmt.Errorf("agent: %w (%d)", ErrMaxRounds, engine.maxRounds))
-				return
-			}
+		toolRounds := 0
+		for {
 			if ctx.Err() != nil {
 				return
 			}
 
 			msgs := engine.session.BuildContext()
 
-			msg, ok := engine.streamTurn(ctx, yield, msgs)
+			msg, complete, ok := engine.streamTurn(ctx, yield, msgs)
 			if !ok {
+				return
+			}
+
+			// Defer publishing and persisting the terminal assistant update until
+			// the tool budget is checked. An over-budget tool request must not
+			// leave an unexecuted tool call in the session or UI.
+			if len(msg.ToolCalls) > 0 && toolRounds >= engine.maxRounds {
+				yield(nil, fmt.Errorf("agent: %w (%d)", ErrMaxRounds, engine.maxRounds))
+				return
+			}
+			if !yield(complete, nil) {
 				return
 			}
 
@@ -266,6 +274,7 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 				return
 			}
 
+			toolRounds++
 			toolMsgs := engine.executor.Run(ctx, msg.ToolCalls, func(td session.ToolData) bool {
 				return yield(td, nil)
 			})
@@ -339,7 +348,7 @@ func (engine *Engine) streamTurn(
 	ctx context.Context,
 	yield func(session.Event, error) bool,
 	messages []llm.Message,
-) (llm.Message, bool) {
+) (llm.Message, session.Event, bool) {
 	id := fmt.Sprintf("assistant-%d", time.Now().UnixNano())
 	var thinking, text string
 	var final llm.Message
@@ -351,7 +360,7 @@ func (engine *Engine) streamTurn(
 				_ = yield(emitMessage(id, session.StateError, session.StopNone, thinking, text, nil, llm.Usage{}), nil)
 			}
 			yield(nil, err)
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 		}
 
 		switch event.Type {
@@ -361,7 +370,7 @@ func (engine *Engine) streamTurn(
 				errText = "stream error"
 			}
 			yield(nil, fmt.Errorf("%s", errText))
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 
 		case llm.StreamEventTypeDelta:
 			if event.Delta.ReasoningContent != "" {
@@ -371,13 +380,13 @@ func (engine *Engine) streamTurn(
 				text += event.Delta.Content
 			}
 			if !yield(emitMessage(id, session.StateStreaming, session.StopNone, thinking, text, nil, llm.Usage{}), nil) {
-				return llm.Message{}, false
+				return llm.Message{}, nil, false
 			}
 
 		case llm.StreamEventTypeDone:
 			if len(event.Partial.Choices) == 0 {
 				yield(nil, errors.New("agent: stream finished with no assistant choice"))
-				return llm.Message{}, false
+				return llm.Message{}, nil, false
 			}
 			final = event.Partial.Choices[0].Message
 			final.Usage = event.Partial.Usage
@@ -395,10 +404,10 @@ func (engine *Engine) streamTurn(
 	if !gotDone {
 		if ctx.Err() != nil {
 			_ = yield(emitMessage(id, session.StateCancelled, session.StopNone, thinking, text, nil, llm.Usage{}), nil)
-			return llm.Message{}, false
+			return llm.Message{}, nil, false
 		}
 		yield(nil, fmt.Errorf("agent: stream closed without assistant output"))
-		return llm.Message{}, false
+		return llm.Message{}, nil, false
 	}
 
 	blocks := engine.toolCallsToBlocks(final.ToolCalls)
@@ -406,10 +415,8 @@ func (engine *Engine) streamTurn(
 	if len(blocks) > 0 {
 		reason = session.StopToolUse
 	}
-	if !yield(emitMessage(id, session.StateComplete, reason, thinking, text, blocks, final.Usage), nil) {
-		return llm.Message{}, false
-	}
-	return final, true
+	complete := emitMessage(id, session.StateComplete, reason, thinking, text, blocks, final.Usage)
+	return final, complete, true
 }
 
 func (engine *Engine) toolCallsToBlocks(calls []llm.ToolCall) []session.ContentBlock {

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/permission"
+	"github.com/pulseaiclub/phi/internal/session"
+	"github.com/pulseaiclub/phi/internal/tools"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,26 +39,95 @@ func sseToolCallChunk(id, name, args string) string {
 	return "data: " + string(payload) + "\n\n"
 }
 
-// fakeToolLoopServer always asks the model to run `echo hi` so a Loop never
-// ends on its own; used to prove the max-rounds budget fires.
-func fakeToolLoopServer() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = fmt.Fprint(w, sseToolCallChunk("call_1", "bash", `{"command":"echo hi"}`))
-		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
-	}))
+func sseTextChunk(text string) string {
+	payload, err := json.Marshal(map[string]any{
+		"choices": []any{map[string]any{
+			"delta": map[string]any{
+				"role":    "assistant",
+				"content": text,
+			},
+		}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return "data: " + string(payload) + "\n\n"
 }
 
-func TestLoopExceedsMaxRounds(t *testing.T) {
-	server := fakeToolLoopServer()
-	defer server.Close()
+// fakeToolSequenceServer returns tool calls for finalAfter tool requests, then
+// returns a final text response. A negative finalAfter means tool calls forever.
+func fakeToolSequenceServer(finalAfter int) (*httptest.Server, *atomic.Int32) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		request := requests.Add(1)
+		if finalAfter < 0 || int(request) <= finalAfter {
+			_, _ = fmt.Fprint(w, sseToolCallChunk(fmt.Sprintf("call_%d", request), "count", `{}`))
+		} else {
+			_, _ = fmt.Fprint(w, sseTextChunk("done"))
+		}
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	return server, &requests
+}
 
+func countingTool(runs *atomic.Int32) tools.Tool {
+	return tools.Tool{
+		Definition: llm.ToolDefinition{
+			Name:        "count",
+			Description: "count tool executions",
+			Params:      &llm.FunctionParameters{Type: "object"},
+		},
+		Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+			runs.Add(1)
+			return tools.Result{Content: "ok"}, nil
+		},
+	}
+}
+
+func newRoundTestEngine(t *testing.T, serverURL string, runs *atomic.Int32) *Engine {
+	t.Helper()
 	engine, err := NewEngine(EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
+		Model:       llm.ModelConfig{Name: "fake", BaseURL: serverURL, APIKey: "x"},
 		SessionOpts: SessionOpts{Cwd: t.TempDir()},
 		Gate:        permission.AllowAll{},
+		Tools:       []tools.Tool{countingTool(runs)},
 	})
 	require.NoError(t, err)
+	return engine
+}
+
+func TestLoopMaxRoundsAllowsFinalAnswerAfterLastToolRound(t *testing.T) {
+	server, requests := fakeToolSequenceServer(2)
+	defer server.Close()
+
+	var runs atomic.Int32
+	engine := newRoundTestEngine(t, server.URL, &runs)
+	require.NoError(t, engine.SetMaxRounds(2))
+
+	var lastErr error
+	var finalText string
+	for ev, err := range engine.Loop(context.Background(), "go", LoopOpts{}) {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		if update, ok := ev.(session.AssistantMessageUpdate); ok && update.Message.State == session.StateComplete {
+			finalText = update.Message.FlatText()
+		}
+	}
+	require.NoError(t, lastErr)
+	require.Equal(t, int32(2), runs.Load())
+	require.Equal(t, int32(3), requests.Load())
+	require.Equal(t, "done", finalText)
+}
+
+func TestLoopMaxRoundsDoesNotExecuteExtraToolRound(t *testing.T) {
+	server, requests := fakeToolSequenceServer(-1)
+	defer server.Close()
+
+	var runs atomic.Int32
+	engine := newRoundTestEngine(t, server.URL, &runs)
 	require.NoError(t, engine.SetMaxRounds(2))
 
 	var lastErr error
@@ -66,10 +138,20 @@ func TestLoopExceedsMaxRounds(t *testing.T) {
 			break
 		}
 	}
-	require.Error(t, lastErr, "loop should stop with an error once rounds are exhausted")
+	require.Error(t, lastErr, "loop should stop when the model requests a third tool round")
 	if !errors.Is(lastErr, ErrMaxRounds) {
 		t.Fatalf("expected ErrMaxRounds to be wrapped, got %v", lastErr)
 	}
+	require.Equal(t, int32(2), runs.Load())
+	require.Equal(t, int32(3), requests.Load())
+
+	assistantToolRounds := 0
+	for _, msg := range engine.session.BuildContext() {
+		if msg.Role == llm.RoleAssistant && len(msg.ToolCalls) > 0 {
+			assistantToolRounds++
+		}
+	}
+	require.Equal(t, 2, assistantToolRounds)
 }
 
 func TestSetMaxRoundsRejectsNonPositive(t *testing.T) {

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pulseaiclub/phi/internal/llm"
@@ -70,6 +71,62 @@ func TestLoopExceedsMaxRounds(t *testing.T) {
 	if !errors.Is(lastErr, ErrMaxRounds) {
 		t.Fatalf("expected ErrMaxRounds to be wrapped, got %v", lastErr)
 	}
+}
+
+func TestLoopContinueAskGrantsAnotherBudget(t *testing.T) {
+	server := fakeToolLoopServer()
+	defer server.Close()
+
+	var asks atomic.Int32
+	engine, err := NewEngine(EngineOpts{
+		Model:       llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
+		SessionOpts: SessionOpts{Cwd: t.TempDir()},
+		Gate:        permission.AllowAll{},
+		ContinueAsk: func(context.Context, int) (bool, error) {
+			// Approve once so the loop can start a second budget window, then stop.
+			return asks.Add(1) == 1, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, engine.SetMaxRounds(1))
+
+	var lastErr error
+	for ev, err := range engine.Loop(context.Background(), "go", LoopOpts{}) {
+		_ = ev
+		if err != nil {
+			lastErr = err
+			break
+		}
+	}
+	require.Error(t, lastErr)
+	require.True(t, errors.Is(lastErr, ErrMaxRounds))
+	require.Equal(t, int32(2), asks.Load(), "should ask once per exhausted budget")
+}
+
+func TestLoopContinueAskDeclineReturnsErrMaxRounds(t *testing.T) {
+	server := fakeToolLoopServer()
+	defer server.Close()
+
+	engine, err := NewEngine(EngineOpts{
+		Model:       llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
+		SessionOpts: SessionOpts{Cwd: t.TempDir()},
+		Gate:        permission.AllowAll{},
+		ContinueAsk: func(context.Context, int) (bool, error) {
+			return false, nil
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, engine.SetMaxRounds(1))
+
+	var lastErr error
+	for ev, err := range engine.Loop(context.Background(), "go", LoopOpts{}) {
+		_ = ev
+		if err != nil {
+			lastErr = err
+			break
+		}
+	}
+	require.True(t, errors.Is(lastErr, ErrMaxRounds))
 }
 
 func TestSetMaxRoundsRejectsNonPositive(t *testing.T) {

--- a/internal/tui/continue_ask.go
+++ b/internal/tui/continue_ask.go
@@ -1,0 +1,214 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/layout"
+	"github.com/pulseaiclub/xui"
+)
+
+// ContinueReply is the user's response when the tool-round budget is exhausted.
+type ContinueReply struct {
+	Continue bool
+}
+
+var continueOptionLabels = []string{
+	"Continue",
+	"Stop",
+}
+
+// continueAskState holds the max-rounds continuation UI in the composer slot.
+type continueAskState struct {
+	maxRounds int
+	reply     chan ContinueReply
+	selected  int
+}
+
+func newContinueAskState(maxRounds int, reply chan ContinueReply) *continueAskState {
+	return &continueAskState{
+		maxRounds: maxRounds,
+		reply:     reply,
+		selected:  0,
+	}
+}
+
+func (editor *Editor) beginContinueAsk(msg ContinueAskMsg) {
+	if editor.continueAsk != nil {
+		editor.resolveContinue(ContinueReply{})
+	}
+	if editor.permAsk != nil {
+		editor.resolvePermission(AskReply{})
+	}
+	editor.hideCompleters()
+	if editor.palette.Open {
+		editor.palette.Hide()
+	}
+	editor.continueAsk = newContinueAskState(msg.MaxRounds, msg.Reply)
+	editor.activity.Apply(ActivityAwaitingApproval)
+	if editor.App != nil {
+		editor.App.RequestFocus(editor)
+	}
+}
+
+func (editor *Editor) resolveContinue(r ContinueReply) {
+	st := editor.continueAsk
+	if st == nil {
+		return
+	}
+	editor.continueAsk = nil
+	if editor.activity.Current == ActivityAwaitingApproval {
+		editor.activity.Apply(ActivityTools)
+	}
+	if editor.App != nil {
+		editor.App.RequestFocus(&editor.Chat)
+	}
+	if st.reply != nil {
+		select {
+		case st.reply <- r:
+		default:
+		}
+	}
+}
+
+func (editor *Editor) handleContinueKey(ctx *components.EventContext, e xui.KeyEvent) bool {
+	st := editor.continueAsk
+	if st == nil || !e.Press {
+		return false
+	}
+
+	if e.Mods.Has(xui.ModAlt) && e.Code == xui.KeyRune && e.Rune >= '1' && e.Rune <= '2' {
+		idx := int(e.Rune - '1')
+		editor.acceptContinueOption(idx)
+		ctx.ConsumeAndRedraw()
+		return true
+	}
+
+	switch e.Code {
+	case xui.KeyEscape:
+		editor.resolveContinue(ContinueReply{})
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyUp:
+		if st.selected > 0 {
+			st.selected--
+		} else {
+			st.selected = len(continueOptionLabels) - 1
+		}
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyDown, xui.KeyTab:
+		st.selected = (st.selected + 1) % len(continueOptionLabels)
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyEnter:
+		editor.acceptContinueOption(st.selected)
+		ctx.ConsumeAndRedraw()
+		return true
+	case xui.KeyRune:
+		if e.Mods.Has(xui.ModCtrl) || e.Mods.Has(xui.ModAlt) {
+			ctx.ConsumeAndRedraw()
+			return true
+		}
+		switch e.Rune {
+		case 'k', 'K':
+			if st.selected > 0 {
+				st.selected--
+			}
+			ctx.ConsumeAndRedraw()
+			return true
+		case 'j', 'J':
+			st.selected = (st.selected + 1) % len(continueOptionLabels)
+			ctx.ConsumeAndRedraw()
+			return true
+		}
+	}
+	ctx.ConsumeAndRedraw()
+	return true
+}
+
+func (editor *Editor) acceptContinueOption(idx int) {
+	switch idx {
+	case 0:
+		editor.resolveContinue(ContinueReply{Continue: true})
+	default:
+		editor.resolveContinue(ContinueReply{})
+	}
+}
+
+func (st *continueAskState) preferredAskHeight() int {
+	h := 2 + 1 + 1 + len(continueOptionLabels) + 1 + 1
+	if h < 8 {
+		h = 8
+	}
+	return h
+}
+
+func (editor *Editor) drawContinueAsk(ctx components.DrawContext, width, height int) components.Surface {
+	st := editor.continueAsk
+	if st == nil {
+		return components.NewSurface(width, height, nil)
+	}
+	th := editor.theme
+	if width <= 0 {
+		width = 80
+	}
+	if height <= 0 {
+		height = st.preferredAskHeight()
+	}
+	innerW := width - 4
+	if innerW < 10 {
+		innerW = width
+	}
+
+	warn := th.Warning
+	primary := th.Success
+	if th.ToolName.Fg.Kind != 0 {
+		primary = th.ToolName
+	}
+
+	var body []components.RichLine
+	body = append(body, components.WrapSpans([]components.Span{
+		{
+			Text:  fmt.Sprintf("Reached max tool rounds (%d). Continue for another %d?", st.maxRounds, st.maxRounds),
+			Style: th.Foreground,
+		},
+	}, innerW, ctx.Method)...)
+	body = append(body, components.RichLine{})
+
+	for i, label := range continueOptionLabels {
+		sel := i == st.selected
+		arrow := " "
+		dot := "○"
+		labelSt := th.Foreground
+		dotSt := th.Muted
+		if sel {
+			arrow = "▸"
+			dot = "●"
+			labelSt = xui.Style{Bold: true, Fg: primary.Fg}
+			dotSt = primary
+		}
+		shortcut := fmt.Sprintf(" [Alt+%d]", i+1)
+		body = append(body, components.WrapSpans([]components.Span{
+			{Text: arrow, Style: primary},
+			{Text: dot, Style: dotSt},
+			{Text: " " + label, Style: labelSt},
+			{Text: shortcut, Style: th.Muted},
+		}, innerW, ctx.Method)...)
+	}
+	body = append(body, components.WrapSpans([]components.Span{
+		{Text: "↑↓ navigate • Enter select • Esc stop", Style: th.Muted},
+	}, innerW, ctx.Method)...)
+
+	panel := components.NewSurface(width, height, nil)
+	layout.DrawRoundedBorder(&panel, layout.BorderRounded, warn, nil, nil, nil, nil, ctx.Method)
+	y := 1
+	for _, line := range body {
+		if y >= height-1 {
+			break
+		}
+		components.PaintSpans(&panel, 2, y, line, ctx.Method)
+		y++
+	}
+	return panel
+}

--- a/internal/tui/continue_ask_test.go
+++ b/internal/tui/continue_ask_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/xui"
+)
+
+func TestContinueAskResolveContinue(t *testing.T) {
+	editor := &Editor{theme: components.DefaultTheme(), activity: NewActivityHandler(nil)}
+	reply := make(chan ContinueReply, 1)
+	editor.beginContinueAsk(ContinueAskMsg{MaxRounds: 64, Reply: reply})
+	if editor.continueAsk == nil {
+		t.Fatal("expected continueAsk")
+	}
+	if editor.continueAsk.maxRounds != 64 {
+		t.Fatalf("maxRounds=%d", editor.continueAsk.maxRounds)
+	}
+	if editor.activity.Current != ActivityAwaitingApproval {
+		t.Fatalf("activity=%v", editor.activity.Current)
+	}
+	editor.resolveContinue(ContinueReply{Continue: true})
+	if editor.continueAsk != nil {
+		t.Fatal("expected continueAsk cleared")
+	}
+	select {
+	case r := <-reply:
+		if !r.Continue {
+			t.Fatal("expected Continue=true")
+		}
+	default:
+		t.Fatal("expected reply")
+	}
+}
+
+func TestContinueAskEscapeStops(t *testing.T) {
+	editor := &Editor{theme: components.DefaultTheme(), activity: NewActivityHandler(nil)}
+	reply := make(chan ContinueReply, 1)
+	editor.beginContinueAsk(ContinueAskMsg{MaxRounds: 2, Reply: reply})
+	ctx := &components.EventContext{}
+	_ = editor.handleContinueKey(ctx, xui.KeyEvent{Press: true, Code: xui.KeyEscape})
+	select {
+	case r := <-reply:
+		if r.Continue {
+			t.Fatal("escape should stop")
+		}
+	default:
+		t.Fatal("expected reply on escape")
+	}
+}
+
+func TestContinueDismissClearsOverlay(t *testing.T) {
+	editor := &Editor{theme: components.DefaultTheme(), activity: NewActivityHandler(nil)}
+	reply := make(chan ContinueReply, 1)
+	editor.beginContinueAsk(ContinueAskMsg{MaxRounds: 2, Reply: reply})
+	editor.Update(ContinueDismissMsg{})
+	if editor.continueAsk != nil {
+		t.Fatal("overlay should clear without consuming reply")
+	}
+	select {
+	case <-reply:
+		t.Fatal("dismiss must not send on reply")
+	default:
+	}
+}

--- a/internal/tui/controller.go
+++ b/internal/tui/controller.go
@@ -82,10 +82,11 @@ func NewController(bus *Bus) *Controller {
 			SessionDir: c.sessionDir,
 			Persist:    true,
 		},
-		Gate:  c.gate,
-		Ask:   c.askPermission,
-		Jobs:  c.engineJobs(),
-		Hooks: hooksMgr,
+		Gate:        c.gate,
+		Ask:         c.askPermission,
+		ContinueAsk: c.askContinue,
+		Jobs:        c.engineJobs(),
+		Hooks:       hooksMgr,
 	})
 	if err != nil {
 		c.engineErr = err
@@ -283,6 +284,30 @@ func (c *Controller) askPermission(ctx context.Context, req permission.Request, 
 	}
 }
 
+// askContinue blocks until the user chooses to continue or stop after max rounds.
+func (c *Controller) askContinue(ctx context.Context, maxRounds int) (bool, error) {
+	reply := make(chan ContinueReply, 1)
+	c.publish(ContinueAskMsg{MaxRounds: maxRounds, Reply: reply})
+
+	timeout := time.Duration(c.askTimeoutSec) * time.Second
+	if timeout <= 0 {
+		timeout = 120 * time.Second
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case r := <-reply:
+		return r.Continue, nil
+	case <-ctx.Done():
+		c.publish(ContinueDismissMsg{})
+		return false, ctx.Err()
+	case <-timer.C:
+		c.publish(ContinueDismissMsg{})
+		return false, nil
+	}
+}
+
 // SetModel replaces the LLM client while keeping the same session tree.
 func (c *Controller) SetModel(name string) error {
 	name = strings.TrimSpace(name)
@@ -312,10 +337,11 @@ func (c *Controller) SetModel(name string) error {
 				SessionDir: c.sessionDir,
 				Persist:    true,
 			},
-			Gate:  c.gate,
-			Ask:   c.askPermission,
-			Jobs:  c.engineJobs(),
-			Hooks: mgr,
+			Gate:        c.gate,
+			Ask:         c.askPermission,
+			ContinueAsk: c.askContinue,
+			Jobs:        c.engineJobs(),
+			Hooks:       mgr,
 		})
 		if err != nil {
 			return err
@@ -326,6 +352,7 @@ func (c *Controller) SetModel(name string) error {
 		return nil
 	}
 	c.engine.SetPermission(c.gate, c.askPermission)
+	c.engine.SetContinueAsk(c.askContinue)
 	c.engine.SetJobs(c.engineJobs())
 	if _, _, err := c.ReloadHooks(); err != nil {
 		debuglog.Logf("hooks: reload on SetModel: %v", err)
@@ -394,10 +421,11 @@ func (c *Controller) Resume(id string) (cwdWarning string, err error) {
 			Persist:    true,
 			ResumeID:   id,
 		},
-		Gate:  c.gate,
-		Ask:   c.askPermission,
-		Jobs:  c.engineJobs(),
-		Hooks: mgr,
+		Gate:        c.gate,
+		Ask:         c.askPermission,
+		ContinueAsk: c.askContinue,
+		Jobs:        c.engineJobs(),
+		Hooks:       mgr,
 	})
 	if err != nil {
 		return "", err

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -70,7 +70,8 @@ type Editor struct {
 
 	updateHint string // footer right: "vX.Y.Z available · phi update"
 
-	permAsk *permAskState
+	permAsk     *permAskState
+	continueAsk *continueAskState
 
 	// User "!cmd" local bash (separate from agent tool runs).
 	bashRunning atomic.Bool
@@ -350,6 +351,19 @@ func (editor *Editor) Update(m Msg) {
 				editor.App.RequestFocus(&editor.Chat)
 			}
 		}
+	case ContinueAskMsg:
+		editor.beginContinueAsk(msg)
+	case ContinueDismissMsg:
+		wasAsk := editor.continueAsk != nil
+		editor.continueAsk = nil
+		if wasAsk {
+			if editor.activity.Current == ActivityAwaitingApproval {
+				editor.activity.Apply(ActivityTools)
+			}
+			if editor.App != nil {
+				editor.App.RequestFocus(&editor.Chat)
+			}
+		}
 	case UpdateAvailableMsg:
 		latest := strings.TrimPrefix(msg.Latest, "v")
 		editor.updateHint = latest + " available · phi update"
@@ -574,6 +588,9 @@ func (editor *Editor) handleCancel() {
 	if editor.permAsk != nil {
 		editor.resolvePermission(AskReply{})
 	}
+	if editor.continueAsk != nil {
+		editor.resolveContinue(ContinueReply{})
+	}
 	if editor.cancelBash() {
 		return
 	}
@@ -589,7 +606,7 @@ func (editor *Editor) handleCancel() {
 func (editor *Editor) Handle(ctx *components.EventContext, ev xui.Event) {
 	switch e := ev.(type) {
 	case xui.FocusEvent:
-		if editor.permAsk != nil {
+		if editor.permAsk != nil || editor.continueAsk != nil {
 			ctx.RequestFocus(editor)
 		} else if editor.palette.Open {
 			ctx.RequestFocus(&editor.palette)
@@ -605,6 +622,9 @@ func (editor *Editor) Handle(ctx *components.EventContext, ev xui.Event) {
 			return
 		}
 		if editor.handlePermissionKey(ctx, e) {
+			return
+		}
+		if editor.handleContinueKey(ctx, e) {
 			return
 		}
 		if editor.handleCopyKey(ctx, e) {
@@ -850,6 +870,15 @@ func (editor *Editor) Draw(ctx components.DrawContext) components.Surface {
 		if chatH < 8 {
 			chatH = 8
 		}
+	} else if editor.continueAsk != nil {
+		chatH = editor.continueAsk.preferredAskHeight()
+		maxChatH := maxSize.Height - footerH - 3
+		if chatH > maxChatH {
+			chatH = maxChatH
+		}
+		if chatH < 8 {
+			chatH = 8
+		}
 	} else {
 		chatH = editor.Chat.PreferredHeight(maxSize.Width, ctx.Method)
 		minChatH := 5
@@ -895,6 +924,8 @@ func (editor *Editor) Draw(ctx components.DrawContext) components.Surface {
 	if editor.permAsk != nil {
 		// Permission confirmation replaces the chat composer.
 		chatSurf = editor.drawPermissionAsk(ctx, maxSize.Width, chatH)
+	} else if editor.continueAsk != nil {
+		chatSurf = editor.drawContinueAsk(ctx, maxSize.Width, chatH)
 	} else {
 		chatSurf = editor.Chat.Draw(ctx.WithConstraints(components.Size{}, components.Size{Width: maxSize.Width, Height: chatH}))
 	}
@@ -905,7 +936,7 @@ func (editor *Editor) Draw(ctx components.DrawContext) components.Surface {
 		{Origin: components.Point{X: 0, Y: listH}, Surface: chatSurf, Z: 1},
 		{Origin: components.Point{X: 0, Y: maxSize.Height - footerH}, Surface: footer, Z: 2},
 	}
-	if editor.permAsk == nil {
+	if editor.permAsk == nil && editor.continueAsk == nil {
 		if editor.slash.Open {
 			editor.slash.AnchorBottomY = listH
 			editor.slash.AnchorX = 0

--- a/internal/tui/msg.go
+++ b/internal/tui/msg.go
@@ -68,6 +68,20 @@ type PermissionDismissMsg struct{}
 
 func (PermissionDismissMsg) isMsg() {}
 
+// ContinueAskMsg asks the UI whether to grant another max-rounds budget.
+// Reply must be buffered(1); the UI sends ContinueReply once.
+type ContinueAskMsg struct {
+	MaxRounds int
+	Reply     chan ContinueReply
+}
+
+func (ContinueAskMsg) isMsg() {}
+
+// ContinueDismissMsg clears a pending continue overlay (timeout/cancel).
+type ContinueDismissMsg struct{}
+
+func (ContinueDismissMsg) isMsg() {}
+
 // UpdateAvailableMsg delivers a startup version-check result to the UI.
 type UpdateAvailableMsg struct {
 	Latest  string

--- a/internal/tui/permission_ask.go
+++ b/internal/tui/permission_ask.go
@@ -92,6 +92,9 @@ func (editor *Editor) beginPermissionAsk(msg PermissionAskMsg) {
 	if editor.permAsk != nil {
 		editor.resolvePermission(AskReply{})
 	}
+	if editor.continueAsk != nil {
+		editor.resolveContinue(ContinueReply{})
+	}
 	editor.hideCompleters()
 	if editor.palette.Open {
 		editor.palette.Hide()


### PR DESCRIPTION
When the tool-round budget is exhausted, the interactive TUI now asks the user whether to grant another max-rounds budget instead of exiting. Headless `phi run` has no confirmation UI, so it keeps the previous behavior: fail with ErrMaxRounds and exit code 2.

- agent: add ContinueFunc (via EngineOpts / SetContinueAsk); nil keeps the hard-fail default, true resumes Loop with a fresh budget
- tui: add ContinueAskMsg/ContinueDismissMsg and a composer-slot overlay with Continue/Stop keys (Enter/1 = continue, Esc/2 = stop), sharing focus/activity handling with the permission ask
- test: cover grant (asks once per exhausted budget), decline, and overlay dismiss
- docs: note TUI vs headless behavior in README (en/zh-CN)