### PR TITLE
ci: add cross-platform tests and golangci-lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,17 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            test-command: make test
+          - os: macos-latest
+            test-command: make test
+          - os: windows-latest
+            test-command: go test ./...
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -25,4 +35,27 @@ jobs:
           go-version: stable
 
       - name: Run tests
-        run: make test
+        run: ${{ matrix.test-command }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: stable
+
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          install-only: true
+
+      - name: Lint
+        run: golangci-lint run ./...
+
+      - name: Check formatting
+        run: golangci-lint fmt --diff

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,204 @@
+version: "2"
+run:
+  issues-exit-code: 1
+  tests: true
+linters:
+  default: none
+  enable:
+    - asasalint
+    - bodyclose
+    - depguard
+    - errcheck
+    - errorlint
+    - gocritic
+    - godot
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - modernize
+    - noctx
+    - perfsprint
+    - revive
+    - staticcheck
+    - testifylint
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - usetesting
+  settings:
+    depguard:
+      rules:
+        non-tests:
+          files:
+            - '!$test'
+          deny:
+            - pkg: testing
+              desc: Use testing only in test files.
+            - pkg: github.com/stretchr/testify
+              desc: Use testify only in test files.
+            - pkg: crypto/md5
+            - pkg: crypto/sha1
+            - pkg: crypto/**/pkix
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - commentedOutCode
+        - dupArg
+        - hugeParam
+        - importShadow
+        - preferDecodeRune
+        - rangeValCopy
+        - unnamedResult
+        - whyNoLint
+      enable-all: true
+    godot:
+      exclude:
+        # Exclude links.
+        - '^ *\[[^]]+\]:'
+        # Exclude sentence fragments for lists.
+        - ^[ ]*[-•]
+        # Exclude sentences prefixing a list.
+        - :$
+    misspell:
+      locale: US
+      ignore-rules:
+        - cancelled
+    modernize:
+      disable:
+        - omitzero
+    perfsprint:
+      int-conversion: true
+      err-error: true
+      errorf: true
+      sprintf1: true
+      strconcat: true
+    revive:
+      confidence: 0.01
+      enable-all-rules: false
+      enable-default-rules: true
+      max-open-files: 2048
+      rules:
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: constant-logical-expr
+        - name: context-as-argument
+          arguments:
+            - allow-types-before: '*testing.T'
+          disabled: true
+        - name: context-keys-type
+        - name: deep-exit
+        - name: defer
+          arguments:
+            - - call-chain
+              - loop
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+          arguments:
+            - preserve-scope
+        - name: empty-block
+        - name: empty-lines
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+          arguments:
+            - say-repetitive-instead-of-stutters
+        - name: flag-parameter
+        - name: identical-branches
+        - name: if-return
+        - name: import-shadowing
+        - name: increment-decrement
+        - name: indent-error-flow
+          arguments:
+            - preserve-scope
+        - name: package-comments
+        - name: range
+        - name: range-val-in-closure
+        - name: range-val-address
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: string-format
+          arguments:
+            - - panic
+              - /^[^\n]*$/
+              - must not contain line breaks
+        - name: struct-tag
+        - name: superfluous-else
+          arguments:
+            - preserve-scope
+        - name: time-equal
+        - name: unconditional-recursion
+        - name: unexported-return
+        - name: unhandled-error
+          arguments:
+            - fmt.Fprint
+            - fmt.Fprintf
+            - fmt.Fprintln
+            - fmt.Print
+            - fmt.Printf
+            - fmt.Println
+        - name: unused-parameter
+        - name: unused-receiver
+        - name: unnecessary-stmt
+        - name: use-any
+        - name: useless-break
+        - name: var-declaration
+        - name: var-naming
+          arguments:
+            - ["ID"] # AllowList
+            - ["Otel", "Aws", "Gcp"] # DenyList
+            - - skip-package-name-collision-with-go-std: true
+        - name: waitgroup-by-value
+    testifylint:
+      enable-all: true
+      disable:
+        - float-compare
+        - go-require
+        - require-error
+    usetesting:
+      context-background: true
+      context-todo: true
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # It's okay to not run gosec and perfsprint in a test.
+      - linters:
+          - gosec
+          - perfsprint
+        path: _test\.go
+      # Ignoring gosec G404: Use of weak random number generator (math/rand instead of crypto/rand)
+      # as we commonly use it in tests and examples.
+      - linters:
+          - gosec
+        text: 'G404:'
+      # Ignoring gosec G402: TLS MinVersion too low
+      # as the https://pkg.go.dev/crypto/tls#Config handles MinVersion default well.
+      - linters:
+          - gosec
+        text: 'G402: TLS MinVersion too low.'
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+    - golines
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/pulseaiclub/phi
+    golines:
+      max-len: 120
+  exclusions:
+    generated: lax

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -19,7 +19,9 @@ func testProject(t *testing.T) (*project.Project, string) {
 	t.Helper()
 	home := t.TempDir()
 	pathDir := t.TempDir()
+	// os.UserHomeDir uses HOME on Unix and USERPROFILE on Windows.
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("PATH", pathDir)
 
 	p, err := project.Discover("")

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -73,7 +73,9 @@ func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	// The app must be able to load the written file with the same results.
+	// os.UserHomeDir uses HOME on Unix and USERPROFILE on Windows.
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	p, err := project.Discover("")
 	require.NoError(t, err)
 	require.NoError(t, p.LoadConfig())

--- a/internal/job/manager_test.go
+++ b/internal/job/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -215,14 +216,15 @@ func TestRecoverStaleJobsOnNew(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "job_zombie")
 	require.NoError(t, os.MkdirAll(dir, 0o755))
+	// strconv.Quote so Windows paths with backslashes remain valid JSON.
 	meta := `{
   "id": "job_zombie",
   "prompt": "left over",
   "status": "running",
   "created_at": "2026-01-01T00:00:00Z",
-  "dir": "` + dir + `",
-  "result_path": "` + filepath.Join(dir, "result.md") + `",
-  "events_path": "` + filepath.Join(dir, "events.jsonl") + `"
+  "dir": ` + strconv.Quote(dir) + `,
+  "result_path": ` + strconv.Quote(filepath.Join(dir, "result.md")) + `,
+  "events_path": ` + strconv.Quote(filepath.Join(dir, "events.jsonl")) + `
 }`
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "events.jsonl"), nil, 0o644))
@@ -250,7 +252,7 @@ func TestRecoverIgnoreLeavesStale(t *testing.T) {
   "prompt": "left over",
   "status": "running",
   "created_at": "2026-01-01T00:00:00Z",
-  "dir": "` + dir + `"
+  "dir": ` + strconv.Quote(dir) + `
 }`
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644))
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -13,7 +13,10 @@ import (
 // tests never touch the real ~/.phi.
 func discoverInTempHome(t *testing.T) *Project {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	// os.UserHomeDir uses HOME on Unix and USERPROFILE on Windows.
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	p, err := Discover("")
 	require.NoError(t, err)
 	return p

--- a/internal/tools/bashtool/shellconfig_test.go
+++ b/internal/tools/bashtool/shellconfig_test.go
@@ -2,6 +2,7 @@ package bashtool
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -54,14 +55,17 @@ func TestResolveShellConfig(t *testing.T) {
 }
 
 func TestPrependPathEntry(t *testing.T) {
-	got := prependPathEntry([]string{"PATH=/usr/bin:/bin"}, "/x/bin")
-	if got[0] != "PATH=/x/bin:/usr/bin:/bin" {
-		t.Fatalf("got %q", got[0])
+	sep := string(os.PathListSeparator)
+	got := prependPathEntry([]string{"PATH=/usr/bin" + sep + "/bin"}, "/x/bin")
+	want := "PATH=/x/bin" + sep + "/usr/bin" + sep + "/bin"
+	if got[0] != want {
+		t.Fatalf("got %q, want %q", got[0], want)
 	}
 
 	// Already present → unchanged.
-	got = prependPathEntry([]string{"PATH=/usr/bin:/x/bin"}, "/x/bin")
-	if len(got) != 1 || got[0] != "PATH=/usr/bin:/x/bin" {
+	existing := "PATH=/usr/bin" + sep + "/x/bin"
+	got = prependPathEntry([]string{existing}, "/x/bin")
+	if len(got) != 1 || got[0] != existing {
 		t.Fatalf("expected unchanged, got %v", got)
 	}
 


### PR DESCRIPTION
Run tests on ubuntu, macos and windows via a build matrix, and enable golangci-lint in CI:

- add .golangci.yml (golangci-lint v2) 
- add lint job on ubuntu-latest running golangci-lint run ./... and golangci-lint fmt --diff
- windows runner uses go test ./... directly (no make available)

Note: ~1047 pre-existing lint issues remain, so the lint job is red until the baseline is cleared (tracked separately).