### PR TITLE
fix(toolmanager): select compatible release assets

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -81,18 +82,49 @@ func loadRunBootstrap(ctx context.Context, sessionDirOverride string) (*runBoots
 // Failures are non-fatal: the search tools fall back to PATH at runtime
 // and report a clear error if truly unavailable.
 func EnsureSearchTools(ctx context.Context, proj *project.Project) error {
-	for _, tool := range []string{"fd", "rg"} {
+	return ensureSearchTools(ctx, proj, toolmanager.DownloadTool)
+}
+
+type searchToolDownloader func(context.Context, string) (string, error)
+
+func ensureSearchTools(ctx context.Context, proj *project.Project, download searchToolDownloader) error {
+	type downloadResult struct {
+		index int
+		err   error
+	}
+
+	tools := []string{"fd", "rg"}
+	results := make(chan downloadResult, len(tools))
+	scheduled := 0
+	installErrors := make([]error, len(tools))
+	for index, tool := range tools {
 		if !shouldBootstrap(proj, tool) {
 			continue
 		}
-		dlCtx, cancel := context.WithTimeout(ctx, bootstrapDownloadTimeout)
-		_, err := toolmanager.DownloadTool(dlCtx, tool)
-		cancel()
+		scheduled++
+		go func(index int, tool string) {
+			dlCtx, cancel := context.WithTimeout(ctx, bootstrapDownloadTimeout)
+			defer cancel()
+			_, err := download(dlCtx, tool)
+			if err != nil {
+				err = fmt.Errorf("%s: %w", tool, err)
+			}
+			results <- downloadResult{index: index, err: err}
+		}(index, tool)
+	}
+
+	for range scheduled {
+		result := <-results
+		installErrors[result.index] = result.err
+	}
+
+	joinedErrors := installErrors[:0]
+	for _, err := range installErrors {
 		if err != nil {
-			return fmt.Errorf("%s: %w", tool, err)
+			joinedErrors = append(joinedErrors, err)
 		}
 	}
-	return nil
+	return errors.Join(joinedErrors...)
 }
 
 // shouldBootstrap is true when the tool binary is missing from the phi bin

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,6 +61,40 @@ func TestShouldBootstrapWhenOnPATH(t *testing.T) {
 
 	assert.False(t, shouldBootstrap(p, "rg"))
 	assert.True(t, shouldBootstrap(p, "fd"))
+}
+
+func TestEnsureSearchToolsAttemptsAllDownloads(t *testing.T) {
+	p, _ := testProject(t)
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	download := func(_ context.Context, tool string) (string, error) {
+		started <- tool
+		<-release
+		return "", errors.New("download failed")
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- ensureSearchTools(t.Context(), p, download)
+	}()
+
+	downloaded := make([]string, 0, 2)
+	for len(downloaded) < 2 {
+		select {
+		case tool := <-started:
+			downloaded = append(downloaded, tool)
+		case <-time.After(time.Second):
+			close(release)
+			<-result
+			t.Fatal("downloads did not start concurrently")
+		}
+	}
+	close(release)
+	err := <-result
+	require.Error(t, err)
+	assert.ElementsMatch(t, []string{"fd", "rg"}, downloaded)
+	assert.ErrorContains(t, err, "fd: download failed")
+	assert.ErrorContains(t, err, "rg: download failed")
 }
 
 func TestHeadlessGateDefaultsToStrict(t *testing.T) {

--- a/internal/toolmanager/download.go
+++ b/internal/toolmanager/download.go
@@ -16,6 +16,8 @@ import (
 	"github.com/pulseaiclub/phi/internal/util/githubrelease"
 )
 
+const compatibleReleaseLookback = 10
+
 // BinDir returns the default directory for downloaded tool binaries.
 func BinDir() (string, error) {
 	home, err := os.UserHomeDir()
@@ -152,6 +154,53 @@ func findBinaryRecursively(rootDir, binaryFileName string) (string, error) {
 	return found, nil
 }
 
+func findReleaseAsset(assets []githubrelease.Asset, candidates []string) (githubrelease.Asset, bool) {
+	assetsByName := make(map[string]githubrelease.Asset, len(assets))
+	for _, asset := range assets {
+		assetsByName[asset.Name] = asset
+	}
+	for _, candidate := range candidates {
+		if asset, ok := assetsByName[candidate]; ok {
+			return asset, true
+		}
+	}
+	return githubrelease.Asset{}, false
+}
+
+func selectCompatibleAsset(
+	config ToolConfig,
+	releases []githubrelease.Release,
+	targetPlatform, targetArch string,
+	goos, goarch string,
+) (githubrelease.Asset, error) {
+	if len(config.AssetNames.getAssetNames("", targetPlatform, targetArch)) == 0 {
+		return githubrelease.Asset{}, fmt.Errorf("unsupported platform: %s/%s", goos, goarch)
+	}
+
+	checkedTags := make([]string, 0, len(releases))
+	for _, release := range releases {
+		checkedTags = append(checkedTags, release.TagName)
+		version := githubrelease.TagVersion(release.TagName)
+		candidates := config.AssetNames.getAssetNames(version, targetPlatform, targetArch)
+		asset, ok := findReleaseAsset(release.Assets, candidates)
+		if !ok {
+			continue
+		}
+		if asset.BrowserDownloadURL == "" {
+			return githubrelease.Asset{}, fmt.Errorf("%s release asset %s has no download URL", config.Name, asset.Name)
+		}
+		return asset, nil
+	}
+
+	return githubrelease.Asset{}, fmt.Errorf(
+		"%s has no compatible release asset for %s/%s (checked: %s)",
+		config.Name,
+		goos,
+		goarch,
+		strings.Join(checkedTags, ", "),
+	)
+}
+
 // DownloadTool downloads the specified tool from GitHub releases and installs
 // it to the phi bin directory (~/.phi/bin/).
 func DownloadTool(ctx context.Context, tool string) (string, error) {
@@ -164,23 +213,17 @@ func DownloadTool(ctx context.Context, tool string) (string, error) {
 		return "", fmt.Errorf("unsupported platform: %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 
-	version, err := githubrelease.GetLatestVersion(ctx, config.Repo)
+	releases, err := githubrelease.FetchRecent(ctx, config.Repo, compatibleReleaseLookback)
 	if err != nil {
 		return "", err
 	}
 
-	assetName := config.GetAssetName(version)
-	if assetName == "" {
-		return "", fmt.Errorf("unsupported platform: %s/%s", platform, arch)
+	asset, err := selectCompatibleAsset(config, releases, platform, arch, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return "", err
 	}
-
-	downloadURL := fmt.Sprintf(
-		"https://github.com/%s/releases/download/%s%s/%s",
-		config.Repo,
-		config.TagPrefix,
-		version,
-		assetName,
-	)
+	assetName := asset.Name
+	downloadURL := asset.BrowserDownloadURL
 
 	toolsDir, err := BinDir()
 	if err != nil {

--- a/internal/toolmanager/download_integration_test.go
+++ b/internal/toolmanager/download_integration_test.go
@@ -1,0 +1,79 @@
+package toolmanager
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pulseaiclub/phi/internal/util/githubrelease"
+)
+
+func TestDownloadToolsFromGitHub(t *testing.T) {
+	if os.Getenv("PHI_RUN_NETWORK_TESTS") != "1" {
+		t.Skip("set PHI_RUN_NETWORK_TESTS=1 to test real GitHub release downloads")
+	}
+
+	for _, test := range []struct {
+		tool       string
+		versionOut string
+	}{
+		{tool: "fd", versionOut: "fd"},
+		{tool: "rg", versionOut: "ripgrep"},
+	} {
+		t.Run(test.tool, func(t *testing.T) {
+			homeDir := t.TempDir()
+			t.Setenv("HOME", homeDir)
+			if runtime.GOOS == "windows" {
+				t.Setenv("USERPROFILE", homeDir)
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+			defer cancel()
+			path, err := DownloadTool(ctx, test.tool)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			commandCtx, commandCancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer commandCancel()
+			out, err := exec.CommandContext(commandCtx, path, "--version").CombinedOutput()
+			if err != nil {
+				t.Fatalf("run downloaded %s: %v: %s", test.tool, err, out)
+			}
+			if !strings.Contains(string(out), test.versionOut) {
+				t.Fatalf("unexpected %s version output: %s", test.tool, out)
+			}
+		})
+	}
+}
+
+func TestSelectCompatibleFdReleaseFromGitHub(t *testing.T) {
+	if os.Getenv("PHI_RUN_NETWORK_TESTS") != "1" {
+		t.Skip("set PHI_RUN_NETWORK_TESTS=1 to query real GitHub releases")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	releases, err := githubrelease.FetchRecent(ctx, Tools["fd"].Repo, compatibleReleaseLookback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	asset, err := selectCompatibleAsset(
+		Tools["fd"],
+		releases,
+		PlatformDarwin,
+		ArchAMD64,
+		"darwin",
+		"amd64",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(asset.Name, "x86_64-apple-darwin") {
+		t.Fatalf("unexpected Intel macOS fd asset: %s", asset.Name)
+	}
+}

--- a/internal/toolmanager/download_test.go
+++ b/internal/toolmanager/download_test.go
@@ -1,0 +1,119 @@
+package toolmanager
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pulseaiclub/phi/internal/util/githubrelease"
+)
+
+func TestFindReleaseAssetUsesCandidateOrder(t *testing.T) {
+	t.Parallel()
+	assets := []githubrelease.Asset{
+		{Name: "tool-gnu.tar.gz", BrowserDownloadURL: "https://example.com/gnu"},
+		{Name: "tool-musl.tar.gz", BrowserDownloadURL: "https://example.com/musl"},
+	}
+
+	got, ok := findReleaseAsset(assets, []string{"tool-musl.tar.gz", "tool-gnu.tar.gz"})
+	if !ok {
+		t.Fatal("findReleaseAsset() did not find a compatible asset")
+	}
+	if got.Name != "tool-musl.tar.gz" {
+		t.Fatalf("findReleaseAsset() = %q, want musl candidate", got.Name)
+	}
+}
+
+func TestFindReleaseAssetFallsBack(t *testing.T) {
+	t.Parallel()
+	assets := []githubrelease.Asset{
+		{Name: "tool-gnu.tar.gz", BrowserDownloadURL: "https://example.com/gnu"},
+	}
+
+	got, ok := findReleaseAsset(assets, []string{"tool-musl.tar.gz", "tool-gnu.tar.gz"})
+	if !ok {
+		t.Fatal("findReleaseAsset() did not use the fallback asset")
+	}
+	if got.Name != "tool-gnu.tar.gz" {
+		t.Fatalf("findReleaseAsset() = %q, want GNU fallback", got.Name)
+	}
+}
+
+func TestSelectCompatibleAssetFallsBackToOlderRelease(t *testing.T) {
+	t.Parallel()
+	releases := []githubrelease.Release{
+		{
+			TagName: "v10.4.2",
+			Assets: []githubrelease.Asset{
+				{Name: "fd-v10.4.2-aarch64-apple-darwin.tar.gz", BrowserDownloadURL: "https://example.com/v10.4.2-arm64"},
+			},
+		},
+		{
+			TagName: "v10.3.0",
+			Assets: []githubrelease.Asset{
+				{Name: "fd-v10.3.0-x86_64-apple-darwin.tar.gz", BrowserDownloadURL: "https://example.com/v10.3.0-amd64"},
+			},
+		},
+	}
+
+	asset, err := selectCompatibleAsset(
+		Tools["fd"],
+		releases,
+		PlatformDarwin,
+		ArchAMD64,
+		"darwin",
+		"amd64",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asset.Name != "fd-v10.3.0-x86_64-apple-darwin.tar.gz" {
+		t.Fatalf("selectCompatibleAsset() = %q, want v10.3.0 Intel macOS asset", asset.Name)
+	}
+}
+
+func TestSelectCompatibleAssetNoMatch(t *testing.T) {
+	t.Parallel()
+	releases := []githubrelease.Release{
+		{TagName: "v10.4.2", Assets: []githubrelease.Asset{{Name: "checksums.txt"}}},
+		{TagName: "v10.4.1", Assets: []githubrelease.Asset{{Name: "checksums.txt"}}},
+	}
+	_, err := selectCompatibleAsset(
+		Tools["fd"],
+		releases,
+		PlatformDarwin,
+		ArchAMD64,
+		"darwin",
+		"amd64",
+	)
+	if err == nil {
+		t.Fatal("selectCompatibleAsset() unexpectedly found an asset")
+	}
+	for _, want := range []string{"fd has no compatible release asset", "darwin/amd64", "v10.4.2, v10.4.1"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("selectCompatibleAsset() error = %q, want substring %q", err, want)
+		}
+	}
+}
+
+func TestSelectCompatibleAssetRequiresDownloadURL(t *testing.T) {
+	t.Parallel()
+	releases := []githubrelease.Release{
+		{
+			TagName: "15.2.0",
+			Assets: []githubrelease.Asset{
+				{Name: "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz"},
+			},
+		},
+	}
+	_, err := selectCompatibleAsset(
+		Tools["rg"],
+		releases,
+		PlatformLinux,
+		ArchAMD64,
+		"linux",
+		"amd64",
+	)
+	if err == nil || !strings.Contains(err.Error(), "has no download URL") {
+		t.Fatalf("selectCompatibleAsset() error = %v, want missing URL error", err)
+	}
+}

--- a/internal/toolmanager/tool.go
+++ b/internal/toolmanager/tool.go
@@ -44,11 +44,8 @@ type ToolConfig struct {
 	Repo string
 	// BinaryName is the name of the executable binary.
 	BinaryName string
-	// TagPrefix is the prefix used in version tags (e.g., "v" for "v1.0.0").
-	TagPrefix string
-	// GetAssetName returns the asset filename for the given version.
-	// Platform and architecture are detected automatically from current runtime.
-	GetAssetName func(version string) string
+	// AssetNames builds release asset candidates for the current platform.
+	AssetNames AssetName
 }
 
 // Tools is a registry of downloadable tool configurations.
@@ -58,29 +55,33 @@ var Tools = map[string]ToolConfig{
 		Name:       "fd",
 		Repo:       "sharkdp/fd",
 		BinaryName: "fd",
-		TagPrefix:  "v",
-		GetAssetName: AssetName{
-			toolName:      "fd",
-			versionPrefix: "v",
-			archMap:       defaultArchMap,
-			darwinSuffix:  "-apple-darwin.tar.gz",
-			linuxSuffix:   "-unknown-linux-gnu.tar.gz",
-			winSuffix:     "-pc-windows-msvc.zip",
-		}.GetAssetName,
+		AssetNames: AssetName{
+			toolName:       "fd",
+			versionPrefix:  "v",
+			archMap:        defaultArchMap,
+			darwinSuffixes: []string{"-apple-darwin.tar.gz"},
+			linuxSuffixes: []string{
+				"-unknown-linux-musl.tar.gz",
+				"-unknown-linux-gnu.tar.gz",
+			},
+			winSuffixes: []string{"-pc-windows-msvc.zip"},
+		},
 	},
 	"rg": {
 		Name:       "ripgrep",
 		Repo:       "BurntSushi/ripgrep",
 		BinaryName: "rg",
-		TagPrefix:  "",
-		GetAssetName: AssetName{
-			toolName:      "ripgrep",
-			versionPrefix: "",
-			archMap:       defaultArchMap,
-			darwinSuffix:  "-apple-darwin.tar.gz",
-			linuxSuffix:   "-unknown-linux-gnu.tar.gz",
-			winSuffix:     "-pc-windows-msvc.zip",
-		}.GetAssetName,
+		AssetNames: AssetName{
+			toolName:       "ripgrep",
+			versionPrefix:  "",
+			archMap:        defaultArchMap,
+			darwinSuffixes: []string{"-apple-darwin.tar.gz"},
+			linuxSuffixes: []string{
+				"-unknown-linux-musl.tar.gz",
+				"-unknown-linux-gnu.tar.gz",
+			},
+			winSuffixes: []string{"-pc-windows-msvc.zip"},
+		},
 	},
 }
 
@@ -89,12 +90,12 @@ type archMapping map[string]map[string]string
 
 // AssetName builds the full asset filename for a tool release.
 type AssetName struct {
-	toolName      string
-	versionPrefix string
-	archMap       archMapping
-	darwinSuffix  string
-	linuxSuffix   string
-	winSuffix     string
+	toolName       string
+	versionPrefix  string
+	archMap        archMapping
+	darwinSuffixes []string
+	linuxSuffixes  []string
+	winSuffixes    []string
 }
 
 func normalizePlatform(goos string) string {
@@ -128,20 +129,24 @@ var (
 	arch     = normalizeArch(runtime.GOARCH)
 )
 
-// GetAssetName returns the full asset filename for the given version,
-// based on the current platform and architecture.
-func (a AssetName) GetAssetName(version string) string {
-	if platform == "" || arch == "" {
-		return ""
+// GetAssetNames returns release asset candidates in preference order for the
+// current platform and architecture.
+func (a AssetName) GetAssetNames(version string) []string {
+	return a.getAssetNames(version, platform, arch)
+}
+
+func (a AssetName) getAssetNames(version, targetPlatform, targetArch string) []string {
+	if targetPlatform == "" || targetArch == "" {
+		return nil
 	}
 
-	platformArchs, ok := a.archMap[platform]
+	platformArchs, ok := a.archMap[targetPlatform]
 	if !ok {
-		return ""
+		return nil
 	}
-	archName, ok := platformArchs[arch]
+	archName, ok := platformArchs[targetArch]
 	if !ok {
-		return ""
+		return nil
 	}
 
 	fullVersion := version
@@ -149,14 +154,21 @@ func (a AssetName) GetAssetName(version string) string {
 		fullVersion = a.versionPrefix + version
 	}
 
-	switch platform {
+	var suffixes []string
+	switch targetPlatform {
 	case PlatformDarwin:
-		return fmt.Sprintf("%s-%s-%s%s", a.toolName, fullVersion, archName, a.darwinSuffix)
+		suffixes = a.darwinSuffixes
 	case PlatformLinux:
-		return fmt.Sprintf("%s-%s-%s%s", a.toolName, fullVersion, archName, a.linuxSuffix)
+		suffixes = a.linuxSuffixes
 	case PlatformWin32:
-		return fmt.Sprintf("%s-%s-%s%s", a.toolName, fullVersion, archName, a.winSuffix)
+		suffixes = a.winSuffixes
 	default:
-		return ""
+		return nil
 	}
+
+	names := make([]string, 0, len(suffixes))
+	for _, suffix := range suffixes {
+		names = append(names, fmt.Sprintf("%s-%s-%s%s", a.toolName, fullVersion, archName, suffix))
+	}
+	return names
 }

--- a/internal/toolmanager/tool_test.go
+++ b/internal/toolmanager/tool_test.go
@@ -1,0 +1,69 @@
+package toolmanager
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAssetNameCandidates(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		tool     string
+		version  string
+		platform string
+		arch     string
+		want     []string
+	}{
+		{
+			name:     "ripgrep linux prefers musl",
+			tool:     "rg",
+			version:  "15.2.0",
+			platform: PlatformLinux,
+			arch:     ArchAMD64,
+			want: []string{
+				"ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz",
+				"ripgrep-15.2.0-x86_64-unknown-linux-gnu.tar.gz",
+			},
+		},
+		{
+			name:     "fd linux prefers portable musl",
+			tool:     "fd",
+			version:  "10.4.2",
+			platform: PlatformLinux,
+			arch:     ArchAMD64,
+			want: []string{
+				"fd-v10.4.2-x86_64-unknown-linux-musl.tar.gz",
+				"fd-v10.4.2-x86_64-unknown-linux-gnu.tar.gz",
+			},
+		},
+		{
+			name:     "ripgrep darwin arm64",
+			tool:     "rg",
+			version:  "15.2.0",
+			platform: PlatformDarwin,
+			arch:     ArchARM64,
+			want: []string{
+				"ripgrep-15.2.0-aarch64-apple-darwin.tar.gz",
+			},
+		},
+		{
+			name:     "unsupported architecture",
+			tool:     "rg",
+			version:  "15.2.0",
+			platform: PlatformLinux,
+			arch:     ArchX86,
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Tools[tt.tool].AssetNames.getAssetNames(tt.version, tt.platform, tt.arch)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("getAssetNames() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/util/githubrelease/release.go
+++ b/internal/util/githubrelease/release.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -14,10 +15,21 @@ import (
 
 const apiVersion = "2022-11-28"
 
-// Release is metadata from GET /repos/{owner}/{repo}/releases/latest.
+const maxReleasesPerPage = 100
+
+// Asset is a downloadable file attached to a GitHub release.
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// Release is metadata from the GitHub Releases API.
 type Release struct {
-	TagName string
-	HTMLURL string
+	TagName    string  `json:"tag_name"`
+	HTMLURL    string  `json:"html_url"`
+	Draft      bool    `json:"draft"`
+	Prerelease bool    `json:"prerelease"`
+	Assets     []Asset `json:"assets"`
 }
 
 // FetchLatest queries the latest published release for owner/repo.
@@ -51,14 +63,79 @@ func FetchLatest(ctx context.Context, repo string) (Release, error) {
 		return Release{}, fmt.Errorf("github api %s: status %d", repo, resp.StatusCode)
 	}
 
-	var body struct {
-		TagName string `json:"tag_name"`
-		HTMLURL string `json:"html_url"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	release, err := decodeRelease(resp.Body)
+	if err != nil {
 		return Release{}, fmt.Errorf("decode release response from %q: %w", repo, err)
 	}
-	return Release{TagName: body.TagName, HTMLURL: body.HTMLURL}, nil
+	return release, nil
+}
+
+// FetchRecent returns up to limit recent published, non-prerelease releases,
+// ordered newest first by the GitHub API.
+func FetchRecent(ctx context.Context, repo string, limit int) ([]Release, error) {
+	if limit < 1 || limit > maxReleasesPerPage {
+		return nil, fmt.Errorf("release limit must be between 1 and %d", maxReleasesPerPage)
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=%d", repo, limit)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request for %q: %w", repo, err)
+	}
+	req.Header.Set("accept", "application/vnd.github+json")
+	req.Header.Set("x-github-api-version", apiVersion)
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
+	resp, err := util.DefaultHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch recent releases from %q: %w", repo, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("no published release for %s", repo)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github api %s: status %d", repo, resp.StatusCode)
+	}
+
+	releases, err := decodeReleases(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("decode releases response from %q: %w", repo, err)
+	}
+	releases = stableReleases(releases)
+	if len(releases) == 0 {
+		return nil, fmt.Errorf("no published stable release for %s", repo)
+	}
+	return releases, nil
+}
+
+func decodeRelease(r io.Reader) (Release, error) {
+	var release Release
+	if err := json.NewDecoder(r).Decode(&release); err != nil {
+		return Release{}, err
+	}
+	return release, nil
+}
+
+func decodeReleases(r io.Reader) ([]Release, error) {
+	var releases []Release
+	if err := json.NewDecoder(r).Decode(&releases); err != nil {
+		return nil, err
+	}
+	return releases, nil
+}
+
+func stableReleases(releases []Release) []Release {
+	stable := make([]Release, 0, len(releases))
+	for _, release := range releases {
+		if release.Draft || release.Prerelease {
+			continue
+		}
+		stable = append(stable, release)
+	}
+	return stable
 }
 
 // TagVersion returns the tag without a leading v/V prefix (for tool asset names).
@@ -67,15 +144,6 @@ func TagVersion(tag string) string {
 		return tag[1:]
 	}
 	return tag
-}
-
-// GetLatestVersion is like FetchLatest but returns the version string without a v prefix.
-func GetLatestVersion(ctx context.Context, repo string) (string, error) {
-	rel, err := FetchLatest(ctx, repo)
-	if err != nil {
-		return "", err
-	}
-	return TagVersion(rel.TagName), nil
 }
 
 // DownloadBaseURL converts a release tag page URL to the release download root.

--- a/internal/util/githubrelease/release_test.go
+++ b/internal/util/githubrelease/release_test.go
@@ -1,6 +1,9 @@
 package githubrelease
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTagVersion(t *testing.T) {
 	t.Parallel()
@@ -25,5 +28,62 @@ func TestDownloadBaseURL(t *testing.T) {
 	want := "https://github.com/pulseaiclub/phi/releases/download/v0.1.0"
 	if got := DownloadBaseURL(in); got != want {
 		t.Fatalf("DownloadBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestDecodeReleaseIncludesAssets(t *testing.T) {
+	t.Parallel()
+	response := `{
+		"tag_name": "15.2.0",
+		"html_url": "https://github.com/BurntSushi/ripgrep/releases/tag/15.2.0",
+		"assets": [{
+			"name": "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz",
+			"browser_download_url": "https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz"
+		}]
+	}`
+
+	release, err := decodeRelease(strings.NewReader(response))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.TagName != "15.2.0" {
+		t.Fatalf("TagName = %q, want 15.2.0", release.TagName)
+	}
+	if len(release.Assets) != 1 {
+		t.Fatalf("len(Assets) = %d, want 1", len(release.Assets))
+	}
+	asset := release.Assets[0]
+	if asset.Name != "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz" {
+		t.Fatalf("asset Name = %q", asset.Name)
+	}
+	if asset.BrowserDownloadURL == "" {
+		t.Fatal("asset BrowserDownloadURL is empty")
+	}
+}
+
+func TestStableReleasesFiltersDraftsAndPrereleases(t *testing.T) {
+	t.Parallel()
+	response := `[
+		{"tag_name": "v3.0.0-rc.1", "prerelease": true},
+		{"tag_name": "v2.0.0", "draft": true},
+		{"tag_name": "v1.0.0", "assets": [{"name": "tool.tar.gz"}]}
+	]`
+
+	releases, err := decodeReleases(strings.NewReader(response))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stable := stableReleases(releases)
+	if len(stable) != 1 || stable[0].TagName != "v1.0.0" {
+		t.Fatalf("stableReleases() = %#v, want only v1.0.0", stable)
+	}
+}
+
+func TestFetchRecentRejectsInvalidLimit(t *testing.T) {
+	t.Parallel()
+	for _, limit := range []int{0, maxReleasesPerPage + 1} {
+		if _, err := FetchRecent(t.Context(), "owner/repo", limit); err == nil {
+			t.Fatalf("FetchRecent(limit=%d) unexpectedly succeeded", limit)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

I updated the fd/ripgrep bootstrap flow to resolve compatible files from the GitHub Releases API instead of constructing a download URL for the latest release.

- I added ordered asset candidates for each supported OS and architecture.
- I prefer portable musl binaries on Linux and retain GNU binaries as a fallback.
- I fall back through recent stable releases when the newest release does not publish an asset for the current platform.
- I made fd and ripgrep bootstrap concurrently so one failed or slow download does not prevent the other or double the headless startup timeout.

## Why

The previous implementation assumed every latest release published a predictable GNU asset. That assumption no longer holds: for example, recent ripgrep releases may publish a musl Linux binary without the corresponding GNU binary, causing the generated URL to return 404. A similar gap can occur when a project stops publishing a platform-specific asset in its newest release while an older compatible release is still available.

This change selects from the assets GitHub actually reports and produces a clearer error listing the releases checked when no compatible asset exists.

## Impact

Users on glibc and musl Linux systems can bootstrap runnable fd and ripgrep binaries. Intel macOS users can also receive the newest compatible release still available within the lookback window. Download failures remain non-fatal, and both tools are attempted independently.

## Validation

- `go test ./...`
- `go test -race ./cmd ./internal/toolmanager`
- `go vet ./...`
- `PHI_RUN_NETWORK_TESTS=1 go test ./internal/toolmanager -run 'TestDownloadToolsFromGitHub|TestSelectCompatibleFdReleaseFromGitHub' -count=1 -v`
- Real fd and ripgrep downloads followed by `--version` execution
