### PR TITLE
refactor: resolve MCP config and hooks from the project root

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pulseaiclub/phi/internal/mcp"
+	"github.com/pulseaiclub/phi/internal/project"
 )
 
 func mcpCmd(args []string) int {
@@ -50,8 +51,7 @@ See doc/mcp.md.
 }
 
 func mcpList() int {
-	cwd, _ := os.Getwd()
-	servers, err := mcp.Load(cwd)
+	servers, err := mcp.Load(project.GetDefaultProject().MCPConfigFile())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "phi mcp list:", err)
 		return ExitError
@@ -137,8 +137,7 @@ func mcpCall(args []string) int {
 			return ExitUsage
 		}
 	}
-	cwd, _ := os.Getwd()
-	pool, err := mcp.LoadPool(cwd)
+	pool, err := mcp.LoadPool(project.GetDefaultProject().MCPConfigFile())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "phi mcp call:", err)
 		return ExitError
@@ -161,12 +160,11 @@ func mcpCall(args []string) int {
 }
 
 func mcpDoctor() int {
-	cwd, _ := os.Getwd()
 	if mcp.Disabled() {
 		fmt.Println("PHI_MCP=off — MCP disabled")
 		return ExitOK
 	}
-	pool, err := mcp.LoadPool(cwd)
+	pool, err := mcp.LoadPool(project.GetDefaultProject().MCPConfigFile())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "phi mcp doctor:", err)
 		return ExitError

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -92,7 +92,7 @@ func runCmd(args []string) int {
 		Ask:   nil,
 		Hooks: loadRunHooks(bs),
 	}
-	if pool, err := mcp.LoadPool(bs.Cwd); err != nil {
+	if pool, err := mcp.LoadPool(bs.Proj.MCPConfigFile()); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: mcp:", err)
 	} else if pool != nil {
 		engineOpts.MCP = pool
@@ -144,7 +144,7 @@ func loadRunHooks(bs *runBootstrap) *hooks.Manager {
 	if bs == nil || bs.Proj == nil {
 		return nil
 	}
-	mgr, warns, err := hooks.LoadForCwd(bs.Proj.Global().HooksDir(), bs.Cwd)
+	mgr, warns, err := hooks.Load(bs.Proj.Global().HooksDir(), bs.Proj.HooksDir())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "warning: hooks:", err)
 		return nil

--- a/internal/hooks/discover.go
+++ b/internal/hooks/discover.go
@@ -39,14 +39,6 @@ type Discovered struct {
 	Source   string // SourceUser or SourceProject
 }
 
-// ProjectHooksDir returns <cwd>/.phi/hooks (first-cut: cwd only, no walk-up).
-func ProjectHooksDir(cwd string) string {
-	if cwd == "" {
-		return ""
-	}
-	return filepath.Join(cwd, ".phi", "hooks")
-}
-
 // HooksDisabled reports whether PHI_HOOKS=off.
 func HooksDisabled() bool {
 	v := strings.TrimSpace(os.Getenv(EnvHooks))
@@ -100,11 +92,6 @@ func Discover(userDir, projectDir string) ([]Discovered, []Warning, error) {
 		return out[i].Source < out[j].Source
 	})
 	return out, warnings, nil
-}
-
-// DiscoverForCwd discovers from a user hooks dir and <cwd>/.phi/hooks.
-func DiscoverForCwd(userDir, cwd string) ([]Discovered, []Warning, error) {
-	return Discover(userDir, ProjectHooksDir(cwd))
 }
 
 func scanHooksDir(dir, source string) ([]Discovered, []Warning, error) {

--- a/internal/hooks/discover_test.go
+++ b/internal/hooks/discover_test.go
@@ -20,16 +20,11 @@ func writeHookTree(t *testing.T, root, name, body string) string {
 	return dir
 }
 
-func TestProjectHooksDir(t *testing.T) {
-	assert.Equal(t, filepath.Join("/tmp/proj", ".phi", "hooks"), ProjectHooksDir("/tmp/proj"))
-	assert.Empty(t, ProjectHooksDir(""))
-}
-
 func TestDiscoverUserAndProjectShadow(t *testing.T) {
 	home := t.TempDir()
 	cwd := t.TempDir()
 	userDir := filepath.Join(home, "hooks")
-	projDir := ProjectHooksDir(cwd)
+	projDir := filepath.Join(cwd, ".phi", "hooks")
 
 	writeHookTree(t, userDir, "guard-bash", `{
   "name": "guard-bash",
@@ -154,18 +149,6 @@ func TestDiscoverAbsoluteRun(t *testing.T) {
 	assert.Empty(t, warns)
 	require.Len(t, found, 1)
 	assert.Equal(t, filepath.Clean(absRun), found[0].RunPath)
-}
-
-func TestDiscoverForCwd(t *testing.T) {
-	homeHooks := t.TempDir()
-	cwd := t.TempDir()
-	writeHookTree(t, homeHooks, "u", `{"event":"pre_tool","run":"./run.sh"}`)
-	writeHookTree(t, ProjectHooksDir(cwd), "p", `{"event":"post_tool","run":"./run.sh"}`)
-
-	found, warns, err := DiscoverForCwd(homeHooks, cwd)
-	require.NoError(t, err)
-	assert.Empty(t, warns)
-	require.Len(t, found, 2)
 }
 
 func mustJSONString(s string) string {

--- a/internal/hooks/load.go
+++ b/internal/hooks/load.go
@@ -17,11 +17,6 @@ func Load(userDir, projectDir string) (*Manager, []Warning, error) {
 	return NewManager(EntriesFromDiscovered(found)...), warns, nil
 }
 
-// LoadForCwd loads from userDir and <cwd>/.phi/hooks.
-func LoadForCwd(userDir, cwd string) (*Manager, []Warning, error) {
-	return Load(userDir, ProjectHooksDir(cwd))
-}
-
 // LogWarnings writes each warning to the debug log (PHI_DEBUG=1).
 func LogWarnings(warns []Warning) {
 	for _, w := range warns {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -2,6 +2,7 @@ package mcp_test
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestConfigLoadSave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	servers, err := mcp.Load(t.TempDir())
+	servers, err := mcp.Load(filepath.Join(t.TempDir(), ".phi", "mcp.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +69,7 @@ func TestDisabled(t *testing.T) {
 	if !mcp.Disabled() {
 		t.Fatal("expected disabled")
 	}
-	pool, err := mcp.LoadPool(t.TempDir())
+	pool, err := mcp.LoadPool(filepath.Join(t.TempDir(), ".phi", "mcp.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -42,14 +42,6 @@ func UserConfigPath() (string, error) {
 	return filepath.Join(home, ".phi", "mcp.json"), nil
 }
 
-// ProjectConfigPath returns <cwd>/.phi/mcp.json.
-func ProjectConfigPath(cwd string) string {
-	if cwd == "" {
-		cwd, _ = os.Getwd()
-	}
-	return filepath.Join(cwd, ".phi", "mcp.json")
-}
-
 // LogDir returns ~/.phi/logs/mcp (or PHI_MCP_LOG_DIR if set).
 func LogDir() (string, error) {
 	if override := strings.TrimSpace(os.Getenv("PHI_MCP_LOG_DIR")); override != "" {
@@ -70,9 +62,9 @@ func LogDir() (string, error) {
 	return dir, nil
 }
 
-// Load merges user + project configs (project overrides same name).
-// Missing files yield an empty map without error.
-func Load(cwd string) (map[string]ServerConfig, error) {
+// Load merges ~/.phi/mcp.json with the project config at projectConfigPath
+// (project overrides same name). Missing files yield an empty map without error.
+func Load(projectConfigPath string) (map[string]ServerConfig, error) {
 	servers := map[string]ServerConfig{}
 	userPath, err := UserConfigPath()
 	if err != nil {
@@ -81,7 +73,7 @@ func Load(cwd string) (map[string]ServerConfig, error) {
 	if err := mergeFile(userPath, servers); err != nil {
 		return nil, err
 	}
-	if err := mergeFile(ProjectConfigPath(cwd), servers); err != nil {
+	if err := mergeFile(projectConfigPath, servers); err != nil {
 		return nil, err
 	}
 	return servers, nil

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -35,12 +35,13 @@ func NewPool(servers map[string]ServerConfig) *Pool {
 	}
 }
 
-// LoadPool loads config for cwd and returns a pool, or nil when disabled.
-func LoadPool(cwd string) (*Pool, error) {
+// LoadPool loads config for projectConfigPath (e.g. <root>/.phi/mcp.json)
+// and returns a pool, or nil when disabled.
+func LoadPool(projectConfigPath string) (*Pool, error) {
 	if Disabled() {
 		return nil, nil
 	}
-	servers, err := Load(cwd)
+	servers, err := Load(projectConfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -43,6 +43,18 @@ func (p *Project) JobsDir() string {
 	return p.global.JobsDir()
 }
 
+// HooksDir returns <root>/.phi/hooks, the per-project hooks directory
+// (user hooks live under Global().HooksDir()).
+func (p *Project) HooksDir() string {
+	return filepath.Join(p.root, ".phi", "hooks")
+}
+
+// MCPConfigFile returns <root>/.phi/mcp.json, the per-project MCP config
+// file (the user config is ~/.phi/mcp.json).
+func (p *Project) MCPConfigFile() string {
+	return filepath.Join(p.root, ".phi", "mcp.json")
+}
+
 // Project is the resolved phi workspace: the current working directory plus
 // the global layout and its loaded configuration.
 type Project struct {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -46,6 +46,12 @@ func TestHooksDirPath(t *testing.T) {
 	assert.Equal(t, filepath.Join(p.Global().Root(), "hooks"), p.Global().HooksDir())
 }
 
+func TestProjectDirs(t *testing.T) {
+	p := discoverInTempHome(t)
+	assert.Equal(t, filepath.Join(p.Root(), ".phi", "hooks"), p.HooksDir())
+	assert.Equal(t, filepath.Join(p.Root(), ".phi", "mcp.json"), p.MCPConfigFile())
+}
+
 func TestLoadConfigDefaults(t *testing.T) {
 	p := discoverInTempHome(t)
 	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`

--- a/internal/tui/controller.go
+++ b/internal/tui/controller.go
@@ -68,7 +68,7 @@ func NewController(bus *Bus) *Controller {
 	c.initGate(proj.Config().Permissions)
 	c.agentsEnabled.Store(proj.Config().Agents.Enabled)
 
-	hooksMgr := loadHooksManager(proj, cwd)
+	hooksMgr := loadHooksManager(proj)
 	c.hooksMgr.Store(hooksMgr)
 	jobs, err := agent.NewJobManager(proj.JobsDir(), c.modelCfg, func() llm.ModelConfig {
 		return c.modelCfg
@@ -79,7 +79,7 @@ func NewController(bus *Bus) *Controller {
 	}
 	c.jobs = jobs
 
-	if pool, err := mcp.LoadPool(cwd); err != nil {
+	if pool, err := mcp.LoadPool(proj.MCPConfigFile()); err != nil {
 		debuglog.Logf("mcp: load: %v", err)
 	} else {
 		c.mcpPool = pool
@@ -222,7 +222,7 @@ func (c *Controller) ReloadHooks() (loaded int, warns []hooks.Warning, err error
 	if proj == nil {
 		return 0, nil, errors.New("project not available")
 	}
-	found, warns, err := hooks.DiscoverForCwd(proj.Global().HooksDir(), c.cwd)
+	found, warns, err := hooks.Discover(proj.Global().HooksDir(), proj.HooksDir())
 	if err != nil {
 		return 0, warns, err
 	}
@@ -244,16 +244,16 @@ func (c *Controller) ListHooks() ([]hooks.Discovered, []hooks.Warning, error) {
 	if proj == nil {
 		return nil, nil, errors.New("project not available")
 	}
-	return hooks.DiscoverForCwd(proj.Global().HooksDir(), c.cwd)
+	return hooks.Discover(proj.Global().HooksDir(), proj.HooksDir())
 }
 
 // loadHooksManager discovers ~/.phi/hooks and <cwd>/.phi/hooks.
 // Load errors are non-fatal (fail-open: no hooks). Child engines stay nil until S9.
-func loadHooksManager(proj *project.Project, cwd string) *hooks.Manager {
+func loadHooksManager(proj *project.Project) *hooks.Manager {
 	if proj == nil {
 		return nil
 	}
-	mgr, warns, err := hooks.LoadForCwd(proj.Global().HooksDir(), cwd)
+	mgr, warns, err := hooks.Load(proj.Global().HooksDir(), proj.HooksDir())
 	if err != nil {
 		debuglog.Logf("hooks: load failed: %v", err)
 		return nil
@@ -343,7 +343,7 @@ func (c *Controller) SetModel(name string) error {
 	c.Cancel()
 	c.initGate(proj.Config().Permissions)
 	if c.engine == nil {
-		mgr := loadHooksManager(proj, c.cwd)
+		mgr := loadHooksManager(proj)
 		c.hooksMgr.Store(mgr)
 		eng, err := agent.NewEngine(agent.EngineOpts{
 			Model: cfg,
@@ -427,7 +427,7 @@ func (c *Controller) Resume(id string) (cwdWarning string, err error) {
 		cfg = proj.Config().Model()
 	}
 
-	mgr := loadHooksManager(project.GetDefaultProject(), c.cwd)
+	mgr := loadHooksManager(project.GetDefaultProject())
 	c.hooksMgr.Store(mgr)
 	eng, err := agent.NewEngine(agent.EngineOpts{
 		Model: cfg,


### PR DESCRIPTION
Load MCP servers and hooks from the resolved project layout instead of the raw cwd, so .phi/mcp.json and .phi/hooks are found relative to the project root.

- project: add Project.HooksDir() and Project.MCPConfigFile()
- mcp: Load/LoadPool take the project config path; drop ProjectConfigPath
- hooks: Load/Discover take the project hooks dir; drop LoadForCwd, DiscoverForCwd, and ProjectHooksDir
- cmd, tui: use project-resolved paths for MCP pool and hooks manager
- update tests to cover the new project-based helpers