### PR TITLE
feat(llm): allow explicit provider selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,16 @@ file in your browser.
 ```yaml
 # ~/.phi/config.yaml
 models:
-  - name: gpt-4o            # model name; "claude-*" routes to the Anthropic API
+  - name: gpt-4o            # model name
     api_key: sk-...         # or set PHI_API_KEY
     base_url: https://api.openai.com/v1   # default; PHI_BASE_URL overrides
+    provider: auto           # auto | openai | anthropic; defaults to auto
     context_window: 128000  # optional
     default: true           # the model used at startup; first entry wins if absent
   - name: claude-sonnet-4-20250514   # extra models; switchable at runtime
     api_key: sk-ant-...
     base_url: https://api.anthropic.com
+    provider: anthropic
     context_window: 200000
 
 skill_path: ~/.phi/skills # where SKILL.md files are loaded from
@@ -151,9 +153,24 @@ Environment overrides:
 | `PHI_BASE_URL`   | `models[].base_url` (default model) |
 | `PHI_SKILL_PATH` | `skill_path`       |
 
-Provider routing: a base URL containing `anthropic` or a model name starting
-with `claude` uses the Anthropic Messages API; everything else uses the
-OpenAI-compatible `/chat/completions` path.
+Provider routing defaults to `auto`: a base URL containing `anthropic` or a
+model name starting with `claude` uses the Anthropic Messages API; everything
+else uses the OpenAI-compatible `/chat/completions` path. Set `provider` to
+`openai` for an OpenAI-compatible gateway even when its model is named
+`claude-*`, or set it to `anthropic` when the model name does not include
+`claude`. Provider controls the API protocol, not the model family.
+
+For example, a Claude model behind an OpenAI-compatible gateway is configured
+as:
+
+```yaml
+models:
+  - name: claude-sonnet
+    provider: openai
+    base_url: https://gateway.example.com/v1
+    api_key: sk-...
+    default: true
+```
 
 ### Workspace layout
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,14 +113,16 @@ phi 读取 `~/.phi/config.yaml`（标准 YAML）。环境变量可覆盖配置�
 ```yaml
 # ~/.phi/config.yaml
 models:
-  - name: gpt-4o            # 模型名；"claude-*" 走 Anthropic API
+  - name: gpt-4o            # 模型名
     api_key: sk-...         # 或设置 PHI_API_KEY
     base_url: https://api.openai.com/v1   # 默认；PHI_BASE_URL 可覆盖
+    provider: auto          # auto | openai | anthropic；默认 auto
     context_window: 128000  # 可选
     default: true           # 启动时使用的模型；缺省时第一项生效
   - name: claude-sonnet-4-20250514   # 额外模型；运行时可切换
     api_key: sk-ant-...
     base_url: https://api.anthropic.com
+    provider: anthropic
     context_window: 200000
 
 skill_path: ~/.phi/skills # SKILL.md 文件的加载目录
@@ -151,8 +153,23 @@ permissions:
 | `PHI_BASE_URL` | `models[].base_url`（默认模型） |
 | `PHI_SKILL_PATH` | `skill_path` |
 
-提供商路由：base URL 包含 `anthropic` 或模型名以 `claude` 开头时使用
-Anthropic Messages API；其余走 OpenAI 兼容的 `/chat/completions` 路径。
+提供商路由默认使用 `auto`：base URL 包含 `anthropic` 或模型名以
+`claude` 开头时使用 Anthropic Messages API；其余走 OpenAI 兼容的
+`/chat/completions` 路径。对于 OpenAI 兼容网关，即使模型名是
+`claude-*`，也应设置 `provider: openai`；如果模型名不含 `claude` 但后端
+使用 Anthropic Messages API，则设置 `provider: anthropic`。Provider 控制
+API 协议，不代表模型家族。
+
+例如，Claude 模型位于 OpenAI 兼容网关后面时：
+
+```yaml
+models:
+  - name: claude-sonnet
+    provider: openai
+    base_url: https://gateway.example.com/v1
+    api_key: sk-...
+    default: true
+```
 
 ### 工作区布局
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,6 +21,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/project"
 	"github.com/pulseaiclub/phi/internal/util"
 )
@@ -45,6 +46,7 @@ type modelDoc struct {
 	Name          string `yaml:"name"                     json:"name"`
 	APIKey        string `yaml:"api_key"                  json:"apiKey"`
 	BaseURL       string `yaml:"base_url"                 json:"baseUrl"`
+	Provider      string `yaml:"provider,omitempty"       json:"provider,omitempty"`
 	ContextWindow *int   `yaml:"context_window,omitempty" json:"contextWindow,omitempty"`
 	Default       bool   `yaml:"default,omitempty"        json:"default"`
 }
@@ -74,9 +76,10 @@ type agentsDoc struct {
 }
 
 type modelListRequest struct {
-	BaseURL string `json:"baseUrl"`
-	APIKey  string `json:"apiKey"`
-	Model   string `json:"model"`
+	BaseURL  string `json:"baseUrl"`
+	APIKey   string `json:"apiKey"`
+	Model    string `json:"model"`
+	Provider string `json:"provider"`
 }
 
 type modelListItem struct {
@@ -222,7 +225,17 @@ func (*configHandler) handleModels(w http.ResponseWriter, r *http.Request) {
 
 	baseURL := strings.TrimSpace(input.BaseURL)
 	apiKey := strings.TrimSpace(input.APIKey)
-	anthropic := isAnthropicModelRequest(baseURL, input.Model)
+	provider, err := llm.ParseProvider(input.Provider)
+	if err != nil {
+		writeConfigErr(w, http.StatusBadRequest, err)
+		return
+	}
+	resolved := llm.ResolveProvider(llm.ModelConfig{
+		Name:     input.Model,
+		BaseURL:  baseURL,
+		Provider: provider,
+	})
+	anthropic := resolved == llm.ProviderAnthropic
 	if baseURL == "" {
 		if anthropic {
 			baseURL = "https://api.anthropic.com"
@@ -305,11 +318,6 @@ func modelListHTTPClient() *http.Client {
 		return nil
 	}
 	return &client
-}
-
-func isAnthropicModelRequest(baseURL, model string) bool {
-	return strings.Contains(strings.ToLower(baseURL), "anthropic") ||
-		strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "claude")
 }
 
 func modelListEndpoint(baseURL string, anthropic bool) (string, error) {
@@ -422,6 +430,13 @@ func validateConfigDoc(doc *configDoc) error {
 		m := &doc.Models[i]
 		if m.Name == "" {
 			return fmt.Errorf("model %d has no name", i+1)
+		}
+		provider, err := llm.ParseProvider(m.Provider)
+		if err != nil {
+			return fmt.Errorf("model %d %q: %w", i+1, m.Name, err)
+		}
+		if m.Provider != "" {
+			m.Provider = string(provider)
 		}
 		if !m.Default {
 			continue

--- a/cmd/config.html
+++ b/cmd/config.html
@@ -344,8 +344,9 @@
 
   .field { min-width: 0; }
 
-  .field-name { grid-column: span 5; }
-  .field-base { grid-column: span 7; }
+  .field-name { grid-column: span 4; }
+  .field-provider { grid-column: span 3; }
+  .field-base { grid-column: span 5; }
   .field-key { grid-column: span 9; }
   .field-context { grid-column: span 3; }
 
@@ -675,7 +676,7 @@
 
   @media (max-width: 900px) {
     .model-fields { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-    .field-name, .field-base { grid-column: span 3; }
+    .field-name, .field-provider, .field-base { grid-column: span 3; }
     .field-key { grid-column: span 4; }
     .field-context { grid-column: span 2; }
   }
@@ -693,7 +694,7 @@
     .model-card-actions { width: 100%; justify-content: flex-end; }
     .default-control { flex: 1 1 auto; }
     .model-fields, .settings-fields, .rules-grid, .rule-body { grid-template-columns: minmax(0, 1fr); }
-    .field-name, .field-base, .field-key, .field-context, .settings-fields .field-full, .rule-body .field-wide { grid-column: auto; }
+    .field-name, .field-provider, .field-base, .field-key, .field-context, .settings-fields .field-full, .rule-body .field-wide { grid-column: auto; }
     .panel { padding-right: 0; }
     .panel + .panel { margin-top: 26px; padding-top: 26px; padding-left: 0; border-top: 1px solid var(--border); border-left: 0; }
     .rule-group + .rule-group { padding-top: 24px; padding-left: 0; border-top: 1px solid var(--border); border-left: 0; }
@@ -993,6 +994,11 @@ const I18N = {
     modelName: "Model name",
     modelNameHelp: "Type a name, or fetch the list from the current API base URL and pick one.",
     modelNamePlaceholder: "e.g. gpt-4o",
+    provider: "Provider",
+    providerHelp: "Controls the API protocol; auto keeps the existing detection rules.",
+    providerAuto: "Auto-detect",
+    providerOpenAI: "OpenAI-compatible",
+    providerAnthropic: "Anthropic Messages API",
     apiBase: "API base URL",
     apiBaseHelp: "OpenAI-compatible or Anthropic-compatible endpoint.",
     apiBasePlaceholder: "e.g. https://api.openai.com/v1",
@@ -1106,6 +1112,11 @@ const I18N = {
     modelName: "模型名称",
     modelNameHelp: "可手动填写，也可以从当前 API 地址获取列表后选择。",
     modelNamePlaceholder: "例如 gpt-4o",
+    provider: "服务商协议",
+    providerHelp: "决定 API 协议；自动探测会保留原有判断规则。",
+    providerAuto: "自动探测",
+    providerOpenAI: "OpenAI 兼容",
+    providerAnthropic: "Anthropic Messages API",
     apiBase: "API 地址",
     apiBaseHelp: "OpenAI-compatible 或 Anthropic 兼容地址。",
     apiBasePlaceholder: "例如 https://api.openai.com/v1",
@@ -1352,6 +1363,7 @@ async function fetchModels(row) {
         baseUrl: row.base.value.trim(),
         apiKey: row.key.value.trim(),
         model: row.name.value.trim(),
+        provider: row.provider.value,
       }),
       signal: controller.signal,
     });
@@ -1454,6 +1466,14 @@ function addModelRow(model) {
     placeholder: t("apiBasePlaceholder"),
     autocomplete: "url",
   });
+  const provider = el("select", { id: "model-provider-" + id });
+  for (const option of [
+    ["auto", "providerAuto"],
+    ["openai", "providerOpenAI"],
+    ["anthropic", "providerAnthropic"],
+  ]) {
+    provider.appendChild(el("option", { value: option[0], "data-i18n": option[1] }, t(option[1])));
+  }
   const context = el("input", {
     id: "model-context-" + id,
     type: "number",
@@ -1491,6 +1511,7 @@ function addModelRow(model) {
   if (value.name) name.value = value.name;
   if (value.apiKey) key.value = value.apiKey;
   if (value.baseUrl) base.value = value.baseUrl;
+  provider.value = value.provider || "auto";
   if (value.contextWindow) context.value = value.contextWindow;
   if (value.default || (!model && modelRows.length === 0)) def.checked = true;
 
@@ -1501,6 +1522,7 @@ function addModelRow(model) {
     name,
     key,
     base,
+    provider,
     context,
     def,
     fetchButton,
@@ -1527,6 +1549,7 @@ function addModelRow(model) {
   );
   const fields = el("div", { class: "model-fields" },
     field("modelName", "modelNameHelp", nameControl, "field-name", name.id, null, fetchButton),
+    field("provider", "providerHelp", provider, "field-provider", provider.id),
     field("apiBase", "apiBaseHelp", base, "field-base", base.id),
     field("apiKey", "apiKeyHelp", keyShell, "field-key", key.id),
     field("contextWindow", "contextWindowHelp", context, "field-context", context.id, "tokens"),
@@ -1562,6 +1585,7 @@ function addModelRow(model) {
   });
   fetchButton.addEventListener("click", () => fetchModels(row));
   base.addEventListener("input", () => { clearModelOptions(row); markDirty("models"); });
+  provider.addEventListener("change", () => { clearModelOptions(row); markDirty("models"); });
   key.addEventListener("input", () => {
     key.setAttribute("aria-invalid", "false");
     clearModelOptions(row);
@@ -1729,6 +1753,7 @@ function buildPayload() {
       name: row.name.value.trim(),
       apiKey: row.key.value.trim(),
       baseUrl: row.base.value.trim(),
+      provider: row.provider.value === "auto" ? null : row.provider.value,
       contextWindow: readOptionalInteger(row.context),
       default: row.def.checked,
     })),

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -23,11 +23,13 @@ const configUIFixture = `models:
   - name: model-a
     api_key: key-a
     base_url: https://a.example/v1
+    provider: openai
     context_window: 1000
     default: true
   - name: model-b
     api_key: key-b
     base_url: https://b.example/v1
+    provider: anthropic
 permissions:
   mode: readonly
   dangerously_allow_all: true
@@ -56,6 +58,7 @@ func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
 	require.Len(t, got.Models, 2)
 	assert.Equal(t, "model-a", got.Models[0].Name)
+	assert.Equal(t, "openai", got.Models[0].Provider)
 	assert.True(t, got.Models[0].Default)
 	require.NotNil(t, got.Permissions)
 	require.NotNil(t, got.Permissions.Bash)
@@ -115,6 +118,7 @@ func TestConfigHandlerValidation(t *testing.T) {
 	}{
 		{"no models", configDoc{}},
 		{"default missing api_key", configDoc{Models: []modelDoc{{Name: "m"}}}},
+		{"unknown provider", configDoc{Models: []modelDoc{{Name: "m", Provider: "llama", APIKey: "k", Default: true}}}},
 		{
 			"two defaults",
 			configDoc{
@@ -161,12 +165,14 @@ func TestConfigHandlerServesPage(t *testing.T) {
 	assert.Contains(t, body, "seconds")
 	assert.Contains(t, body, "/api/config")
 	assert.Contains(t, body, "/api/models")
+	assert.Contains(t, body, "providerAuto")
 }
 
 func TestConfigHandlerListsModels(t *testing.T) {
 	cases := []struct {
 		name       string
 		model      string
+		provider   string
 		response   string
 		wantPath   string
 		wantModels []string
@@ -194,6 +200,30 @@ func TestConfigHandlerListsModels(t *testing.T) {
 				assert.Equal(t, "2023-06-01", r.Header.Get("Anthropic-Version"))
 			},
 		},
+		{
+			name:       "explicit anthropic",
+			model:      "gpt-5",
+			provider:   "anthropic",
+			response:   `{"data":[{"id":"gpt-5"}]}`,
+			wantPath:   "/v1/models",
+			wantModels: []string{"gpt-5"},
+			checkAuth: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "test-key", r.Header.Get("X-Api-Key"))
+				assert.Equal(t, "2023-06-01", r.Header.Get("Anthropic-Version"))
+			},
+		},
+		{
+			name:       "explicit openai",
+			model:      "claude-sonnet-4-20250514",
+			provider:   "openai",
+			response:   `{"data":[{"id":"claude-sonnet-4-20250514"}]}`,
+			wantPath:   "/v1/models",
+			wantModels: []string{"claude-sonnet-4-20250514"},
+			checkAuth: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+				assert.Empty(t, r.Header.Get("Anthropic-Version"))
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -207,9 +237,10 @@ func TestConfigHandlerListsModels(t *testing.T) {
 			defer server.Close()
 
 			body, err := json.Marshal(modelListRequest{
-				BaseURL: server.URL + "/v1",
-				APIKey:  "test-key",
-				Model:   tc.model,
+				BaseURL:  server.URL + "/v1",
+				APIKey:   "test-key",
+				Model:    tc.model,
+				Provider: tc.provider,
 			})
 			require.NoError(t, err)
 
@@ -225,6 +256,13 @@ func TestConfigHandlerListsModels(t *testing.T) {
 			assert.Equal(t, tc.wantModels, got.Models)
 		})
 	}
+}
+
+func TestConfigHandlerRejectsUnknownModelProvider(t *testing.T) {
+	rr := requestModelListWithProvider(t, "http://127.0.0.1:1", "model", "llama")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "unknown provider")
+	assert.Contains(t, rr.Body.String(), "llama")
 }
 
 func TestConfigHandlerModelListRedirects(t *testing.T) {
@@ -405,11 +443,16 @@ func TestConfigHandlerRejectsNonLoopbackGET(t *testing.T) {
 }
 
 func requestModelList(t *testing.T, baseURL, model string) *httptest.ResponseRecorder {
+	return requestModelListWithProvider(t, baseURL, model, "")
+}
+
+func requestModelListWithProvider(t *testing.T, baseURL, model, provider string) *httptest.ResponseRecorder {
 	t.Helper()
 	body, err := json.Marshal(modelListRequest{
-		BaseURL: baseURL,
-		APIKey:  "test-key",
-		Model:   model,
+		BaseURL:  baseURL,
+		APIKey:   "test-key",
+		Model:    model,
+		Provider: provider,
 	})
 	require.NoError(t, err)
 

--- a/internal/agent/prompt/prompt_test.go
+++ b/internal/agent/prompt/prompt_test.go
@@ -36,7 +36,8 @@ func TestBuildMCPCatalog(t *testing.T) {
 	if !strings.Contains(got, "- browsermcp") || !strings.Contains(got, "- github") {
 		t.Fatalf("expected server names in catalog, got:\n%s", got)
 	}
-	if !strings.Contains(got, "mcp_list") || !strings.Contains(got, "mcp_inspect") || !strings.Contains(got, "mcp_call") {
+	if !strings.Contains(got, "mcp_list") || !strings.Contains(got, "mcp_inspect") ||
+		!strings.Contains(got, "mcp_call") {
 		t.Fatal("expected mcp_* usage guidance")
 	}
 	if strings.Contains(got, `"properties"`) || strings.Contains(got, "inputSchema") {

--- a/internal/llm/client/client.go
+++ b/internal/llm/client/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"iter"
 	"net/http"
-	"strings"
 
 	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/llm/anthropic"
@@ -14,13 +13,13 @@ import (
 
 // Client talks to the configured LLM endpoint: the OpenAI-compatible
 // /chat/completions API by default, or the Anthropic Messages API when the
-// config targets anthropic (see isAnthropicProvider).
+// config targets Anthropic.
 type Client struct {
 	httpClient *http.Client
 	cfg        llm.ModelConfig
 	tools      []llm.ToolDefinition
 	system     string
-	anthropic  bool
+	provider   llm.Provider
 }
 
 // NewClient builds a streaming chat client.
@@ -30,14 +29,14 @@ func NewClient(cfg llm.ModelConfig, tools []llm.ToolDefinition, systemPrompt str
 		cfg:        cfg,
 		tools:      tools,
 		system:     systemPrompt,
-		anthropic:  isAnthropicProvider(cfg),
+		provider:   llm.ResolveProvider(cfg),
 	}
 }
 
 // Stream runs a streaming chat completion over messages (+ optional system prompt / tools).
 func (c *Client) Stream(ctx context.Context, messages []llm.Message) iter.Seq2[llm.StreamEvent, error] {
 	return func(yield func(llm.StreamEvent, error) bool) {
-		if c.anthropic {
+		if c.provider == llm.ProviderAnthropic {
 			req := anthropic.BuildRequest(c.cfg, c.system, messages, c.tools)
 			for ev, err := range anthropic.Stream(ctx, c.httpClient, c.cfg, &req) {
 				if !yield(ev, err) {
@@ -58,18 +57,15 @@ func (c *Client) Stream(ctx context.Context, messages []llm.Message) iter.Seq2[l
 // Compact sends a single non-streaming chat request and returns the
 // assistant text. It satisfies llm.Compactor for session compaction.
 func (c *Client) Compact(ctx context.Context, prompt string) (string, error) {
-	if c.anthropic {
+	if c.provider == llm.ProviderAnthropic {
 		return anthropic.Compact(ctx, c.httpClient, c.cfg, prompt)
 	}
 	return openai.Compact(ctx, c.httpClient, c.cfg, prompt)
 }
 
-// isAnthropicProvider reports whether the config targets the Anthropic
-// Messages API: either an anthropic base URL or a claude model name.
+// isAnthropicProvider reports whether the config resolves to the Anthropic
+// Messages API. It remains as a small package-local compatibility helper for
+// the routing tests.
 func isAnthropicProvider(cfg llm.ModelConfig) bool {
-	base := strings.ToLower(cfg.BaseURL)
-	if strings.Contains(base, "anthropic") {
-		return true
-	}
-	return strings.HasPrefix(strings.ToLower(cfg.Name), "claude")
+	return llm.ResolveProvider(cfg) == llm.ProviderAnthropic
 }

--- a/internal/llm/client/client_test.go
+++ b/internal/llm/client/client_test.go
@@ -17,6 +17,15 @@ func TestIsAnthropicProvider(t *testing.T) {
 		{llm.ModelConfig{Name: "claude-sonnet-4-20250514", BaseURL: "https://api.anthropic.com"}, true},
 		{llm.ModelConfig{Name: "gpt-4o", BaseURL: "https://api.anthropic.com"}, true},
 		{llm.ModelConfig{Name: "claude-3-5-sonnet", BaseURL: "https://api.openai.com/v1"}, true},
+		{llm.ModelConfig{Name: "gpt-5", BaseURL: "https://api.openai.com/v1", Provider: llm.ProviderAnthropic}, true},
+		{
+			llm.ModelConfig{
+				Name:     "claude-3-5-sonnet",
+				BaseURL:  "https://api.anthropic.com",
+				Provider: llm.ProviderOpenAI,
+			},
+			false,
+		},
 		{llm.ModelConfig{Name: "gpt-4o", BaseURL: "https://api.openai.com/v1"}, false},
 		{llm.ModelConfig{Name: "deepseek-chat", BaseURL: "https://api.deepseek.com/v1"}, false},
 	}
@@ -48,7 +57,7 @@ func TestClientStreamAnthropicEndToEnd(t *testing.T) {
 	defer srv.Close()
 
 	client := NewClient(
-		llm.ModelConfig{Name: "claude-sonnet-4-20250514", BaseURL: srv.URL, APIKey: "sk-test"},
+		llm.ModelConfig{Name: "gpt-5", BaseURL: srv.URL, APIKey: "sk-test", Provider: llm.ProviderAnthropic},
 		nil,
 		"be brief",
 	)
@@ -102,7 +111,11 @@ func TestClientStreamOpenAIEndToEnd(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewClient(llm.ModelConfig{Name: "gpt-4o", BaseURL: srv.URL, APIKey: "sk-test"}, nil, "")
+	client := NewClient(
+		llm.ModelConfig{Name: "claude-sonnet", BaseURL: srv.URL, APIKey: "sk-test", Provider: llm.ProviderOpenAI},
+		nil,
+		"",
+	)
 	events := collectEvents(client.Stream(t.Context(), []llm.Message{{Role: llm.RoleUser, Content: "hello"}}))
 
 	if gotPath != "/chat/completions" {

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -1,0 +1,54 @@
+package llm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Provider selects the wire protocol used to communicate with a model.
+type Provider string
+
+const (
+	ProviderAuto      Provider = "auto"
+	ProviderOpenAI    Provider = "openai"
+	ProviderAnthropic Provider = "anthropic"
+)
+
+// ParseProvider validates and canonicalizes a provider value from config or an
+// API request. An empty value keeps the automatic detection behavior.
+func ParseProvider(value string) (Provider, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", string(ProviderAuto):
+		return ProviderAuto, nil
+	case string(ProviderOpenAI):
+		return ProviderOpenAI, nil
+	case string(ProviderAnthropic):
+		return ProviderAnthropic, nil
+	default:
+		return "", fmt.Errorf("unknown provider %q; want auto, openai, or anthropic", strings.TrimSpace(value))
+	}
+}
+
+// DetectProvider preserves the legacy provider heuristic for automatic mode.
+func DetectProvider(cfg ModelConfig) Provider {
+	base := strings.ToLower(cfg.BaseURL)
+	if strings.Contains(base, "anthropic") ||
+		strings.HasPrefix(strings.ToLower(strings.TrimSpace(cfg.Name)), "claude") {
+		return ProviderAnthropic
+	}
+	return ProviderOpenAI
+}
+
+// ResolveProvider gives an explicit provider precedence over automatic
+// detection. Config and request boundaries must validate Provider with
+// ParseProvider before calling this function.
+func ResolveProvider(cfg ModelConfig) Provider {
+	switch cfg.Provider {
+	case ProviderOpenAI, ProviderAnthropic:
+		return cfg.Provider
+	case "", ProviderAuto:
+		return DetectProvider(cfg)
+	default:
+		return DetectProvider(cfg)
+	}
+}

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -1,0 +1,73 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseProvider(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Provider
+	}{
+		{name: "empty uses auto", want: ProviderAuto},
+		{name: "auto", input: "auto", want: ProviderAuto},
+		{name: "trim and normalize", input: " OpenAI ", want: ProviderOpenAI},
+		{name: "anthropic", input: "anthropic", want: ProviderAnthropic},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseProvider(test.input)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+
+	_, err := ParseProvider("llama")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown provider "llama"`)
+}
+
+func TestResolveProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ModelConfig
+		want Provider
+	}{
+		{
+			name: "explicit anthropic overrides detection",
+			cfg:  ModelConfig{Name: "gpt-5", BaseURL: "https://gateway.example.com/v1", Provider: ProviderAnthropic},
+			want: ProviderAnthropic,
+		},
+		{
+			name: "explicit openai overrides model name",
+			cfg:  ModelConfig{Name: "claude-sonnet", BaseURL: "https://api.anthropic.com", Provider: ProviderOpenAI},
+			want: ProviderOpenAI,
+		},
+		{
+			name: "auto keeps anthropic model detection",
+			cfg:  ModelConfig{Name: "claude-sonnet", BaseURL: "https://gateway.example.com/v1", Provider: ProviderAuto},
+			want: ProviderAnthropic,
+		},
+		{
+			name: "empty keeps anthropic URL detection",
+			cfg:  ModelConfig{Name: "gpt-5", BaseURL: "https://api.anthropic.com", Provider: ""},
+			want: ProviderAnthropic,
+		},
+		{
+			name: "auto defaults to openai compatible",
+			cfg:  ModelConfig{Name: "gpt-5", BaseURL: "https://gateway.example.com/v1", Provider: ProviderAuto},
+			want: ProviderOpenAI,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, ResolveProvider(test.cfg))
+		})
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -12,9 +12,10 @@ type Compactor interface {
 // OpenAI-compatible endpoint or the Anthropic Messages API. It also carries
 // agent-wide settings like the skill directory path.
 type ModelConfig struct {
-	Name    string
-	APIKey  string
-	BaseURL string
+	Name     string
+	APIKey   string
+	BaseURL  string
+	Provider Provider `json:"provider,omitempty" yaml:"provider,omitempty"`
 	// SkillPath is the directory to scan for SKILL.md files.
 	// Defaults to ~/.phi/skills if empty.
 	SkillPath string

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -135,8 +135,11 @@ func parseConfigFile(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
 
-	for _, m := range raw.Models {
-		mc := modelEntryToConfig(m)
+	for i, m := range raw.Models {
+		mc, err := modelEntryToConfig(m)
+		if err != nil {
+			return nil, fmt.Errorf("model %d %q: %w", i+1, m.Name, err)
+		}
 		if m.Default && cfg.DefaultModel == "" {
 			cfg.DefaultModel = mc.Name
 		}
@@ -154,12 +157,16 @@ func parseConfigFile(path string) (*Config, error) {
 	return cfg, nil
 }
 
-func modelEntryToConfig(m modelEntry) llm.ModelConfig {
-	cfg := llm.ModelConfig{Name: m.Name, APIKey: m.APIKey, BaseURL: m.BaseURL}
+func modelEntryToConfig(m modelEntry) (llm.ModelConfig, error) {
+	provider, err := llm.ParseProvider(m.Provider)
+	if err != nil {
+		return llm.ModelConfig{}, err
+	}
+	cfg := llm.ModelConfig{Name: m.Name, APIKey: m.APIKey, BaseURL: m.BaseURL, Provider: provider}
 	if m.ContextWindow != nil && *m.ContextWindow > 0 {
 		cfg.ContextWindow = *m.ContextWindow
 	}
-	return cfg
+	return cfg, nil
 }
 
 // fileConfig mirrors the YAML keys in ~/.phi/config.yaml.
@@ -178,6 +185,7 @@ type modelEntry struct {
 	Name          string `yaml:"name"`
 	APIKey        string `yaml:"api_key"`
 	BaseURL       string `yaml:"base_url"`
+	Provider      string `yaml:"provider"`
 	ContextWindow *int   `yaml:"context_window"`
 	Default       bool   `yaml:"default"`
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulseaiclub/phi/internal/llm"
 )
 
 // discoverInTempHome runs Discover("") with HOME redirected to a temp dir so
@@ -66,6 +68,7 @@ models:
 	assert.Equal(t, "deepseek-chat", cfg.Model().Name)
 	assert.Equal(t, "sk-test", cfg.Model().APIKey)
 	assert.Equal(t, "https://api.openai.com/v1", cfg.Model().BaseURL)
+	assert.Equal(t, llm.ProviderAuto, cfg.Model().Provider)
 	assert.Equal(t, p.Global().SkillsDir(), cfg.SkillPath)
 	// Model() carries the skill path for agent.NewEngine.
 	assert.Equal(t, p.Global().SkillsDir(), cfg.Model().SkillPath)
@@ -101,6 +104,20 @@ func TestLoadConfigMissingAPIKey(t *testing.T) {
 	err := p.LoadConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "api_key")
+}
+
+func TestLoadConfigRejectsUnknownProvider(t *testing.T) {
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
+models:
+  - name: custom
+    api_key: key
+    provider: llama
+`), 0o644))
+
+	err := p.LoadConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown provider "llama"`)
 }
 
 func TestLoadConfigConfigFileMissing(t *testing.T) {
@@ -215,11 +232,13 @@ models:
   - name: p
     api_key: pk
     base_url: https://primary.example/v1
+    provider: anthropic
     context_window: 1000
     default: true
   - name: a1
     api_key: ak1
     base_url: https://a1.example/v1
+    provider: openai
   - name: a2
     api_key: ak2
     base_url: https://a2.example/v1
@@ -230,7 +249,9 @@ models:
 	cfg := p.Config()
 	require.Len(t, cfg.Models, 3)
 	assert.Equal(t, "p", cfg.Models[0].Name)
+	assert.Equal(t, llm.ProviderAnthropic, cfg.Models[0].Provider)
 	assert.Equal(t, "ak1", cfg.Models[1].APIKey)
+	assert.Equal(t, llm.ProviderOpenAI, cfg.Models[1].Provider)
 	assert.Equal(t, 2000, cfg.Models[2].ContextWindow)
 	assert.Equal(t, "p", cfg.DefaultModel)
 


### PR DESCRIPTION
## Summary

Add explicit LLM provider selection while keeping
existing automatic detection behavior.

Users can now choose:

- auto
- openai
- anthropic

## Motivation

Provider detection based on model name and URL
is unreliable for gateways and model aliases.

## Compatibility

Existing configurations are unchanged.

When provider is omitted, phi keeps the current
auto detection behavior.

## Testing

- explicit anthropic selection
- explicit openai selection
- auto detection fallback
- invalid provider rejection
