### PR TITLE
ci: generate release notes from CHANGELOG.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
     groups:
       go-minor-and-patch:
         applies-to: version-updates
@@ -21,3 +23,5 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,45 @@
+# Require PRs targeting main to touch CHANGELOG.md.
+# Skip with the "Skip Changelog" or "dependencies" label, or "[chore]" in the title.
+
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+        !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') &&
+        !contains(github.event.pull_request.title, '[chore]')
+      }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Check for CHANGELOG changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Only the latest commit of the feature branch is available
+          # automatically. To diff with the base branch, we need to
+          # fetch that too (and we only need its latest commit).
+          git fetch origin "$BASE_REF" --depth=1
+          if [[ $(git diff --name-only FETCH_HEAD | grep CHANGELOG) ]]
+          then
+            echo "A CHANGELOG was modified. Looks good!"
+          else
+            echo "No CHANGELOG was modified."
+            echo "Please add a CHANGELOG entry, or add the \"Skip Changelog\" label if not required."
+            false
+          fi

--- a/.github/workflows/protect-released-changelog.yml
+++ b/.github/workflows/protect-released-changelog.yml
@@ -1,0 +1,29 @@
+# Fail if a PR changes released CHANGELOG sections.
+# Release PRs must add the "Unlock Released Changelog" label.
+
+name: Protect released changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  protect-released-changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Unlock Released Changelog') }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Protect the released changelog
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          ./verify_released_changelog.sh "$BASE_REF"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0   # full history needed for changelog
+          fetch-depth: 0   # full history needed for GoReleaser
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -26,11 +26,17 @@ jobs:
       - name: Run tests
         run: make test
 
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          scripts/changelog-extract.sh "${{ github.ref_name }}" > /tmp/release-notes.md
+          echo "---- release notes ----"
+          cat /tmp/release-notes.md
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release --clean --release-notes /tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,16 +45,9 @@ archives:
 checksum:
   name_template: "checksums_{{ .Version }}.txt"
 
+# Release notes come from CHANGELOG.md via --release-notes (see release.yml).
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
-      - '^ci:'
-      - '^chore:'
-      - Merge pull request
-      - Merge branch
+  disable: true
 
 release:
   draft: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ Minimal Go terminal coding-agent harness. Layout: [doc/project-layout.md](doc/pr
 - Conventional Commits, English, lowercase, imperative, ≤72 chars. One logical change per commit.
 - Do not put `@mentions` or `fixes #...` in commit messages (those belong in the PR).
 - Do not add `Co-authored-by:`.
+- User-visible changes update `CHANGELOG.md` under `## [Unreleased]`. Only release PRs
+  move entries under `<!-- Released section -->` (requires `Unlock Released Changelog`).
+  Skip with `Skip Changelog` / `dependencies` / `[chore]` in the PR title when no entry is needed.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Changelog gate: PRs must update `CHANGELOG.md` (with skip labels / `[chore]`), released sections are protected, and GitHub Release notes are taken from this file.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+<!-- Released section -->
+<!-- Don't change this section unless doing release -->
+
+## [0.11.0] - 2026-08-16
+
+Baseline release when this changelog became the source of truth for user-visible changes.
+Earlier releases are available from GitHub tags only.
+
+<!-- Released section ended -->
+
+[Unreleased]: https://github.com/pulseaiclub/phi/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/pulseaiclub/phi/releases/tag/v0.11.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,19 +119,39 @@ change per commit.
    ```
 
 3. Make your change, add/update tests, and run `make fmt`, `make test`, and `make lint`.
-4. Commit with a conventional message (see above).
-5. Push and open a pull request against the main branch. Describe what changed
+4. For user-visible changes, add an entry under `## [Unreleased]` in
+   `CHANGELOG.md` (Added / Changed / Deprecated / Removed / Fixed / Security).
+   You may omit the PR number until the PR exists, then update the entry before
+   merge (e.g. `(#123)`).
+5. Commit with a conventional message (see above).
+6. Push and open a pull request against the main branch. Describe what changed
    and why, and reference the issue number if there is one.
-6. Address review feedback with follow-up commits; the diff should stay
+7. Address review feedback with follow-up commits; the diff should stay
    focused on the change.
+
+CI requires every PR to touch `CHANGELOG.md` unless you skip the check by:
+
+- adding the `Skip Changelog` label, or
+- adding the `dependencies` label (Dependabot PRs get this automatically), or
+- putting `[chore]` in the pull request title.
+
+Do not edit text under `<!-- Released section -->` except in a release PR
+(see below).
 
 ## Release process
 
-Releases are cut by maintainers. Pushing a tag matching `v*` (for example
-`v1.2.0` or `v1.2.0-rc1`) triggers the `.github/workflows/release.yml`
-workflow, which runs the test suite and builds release artifacts with
-GoReleaser. The changelog is generated from commit history, so descriptive,
-conventional commit messages matter.
+`CHANGELOG.md` is the source of truth for user-facing release notes.
+
+1. Open a release PR that moves entries from `## [Unreleased]` into a new
+   version section under `<!-- Released section -->` (for example
+   `## [0.12.0] - YYYY-MM-DD`), leaves empty Unreleased headings for the next
+   cycle, and updates the compare/tag links at the bottom.
+2. Apply the `Unlock Released Changelog` label so CI allows editing the
+   released section.
+3. After merge, push a tag matching `v*` (for example `v0.12.0` or
+   `v0.12.0-rc1`). That triggers `.github/workflows/release.yml`, which runs
+   tests and GoReleaser. Release notes are extracted from the matching
+   `CHANGELOG.md` section via `scripts/changelog-extract.sh`.
 
 ## Code of conduct
 

--- a/scripts/changelog-extract.sh
+++ b/scripts/changelog-extract.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Extract a Keep a Changelog version section from CHANGELOG.md.
+# Usage: scripts/changelog-extract.sh <version> [changelog-path]
+# Version may be "v0.12.0" or "0.12.0". Writes the section body to stdout.
+
+set -euo pipefail
+
+VERSION="${1:?Must provide version (e.g. v0.12.0 or 0.12.0)}"
+FILE="${2:-CHANGELOG.md}"
+
+VERSION="${VERSION#v}"
+
+if [[ ! -f "$FILE" ]]; then
+	echo "error: changelog file not found: $FILE" >&2
+	exit 1
+fi
+
+# Match "## [0.12.0] - date" or "## [0.12.0]"; stop before the next version
+# heading, the released-section end marker, or footer reference links.
+awk -v ver="$VERSION" '
+	BEGIN { found = 0 }
+	$0 ~ "^## \\[" ver "\\]" {
+		found = 1
+		next
+	}
+	found && (/^## \[/ || /^<!-- Released section ended -->/ || /^\[[^]]+\]:/) { exit }
+	found { print }
+	END {
+		if (!found) {
+			print "error: no CHANGELOG section for version " ver > "/dev/stderr"
+			exit 1
+		}
+	}
+' "$FILE"

--- a/verify_released_changelog.sh
+++ b/verify_released_changelog.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TARGET="${1:?Must provide target ref}"
+
+FILE="CHANGELOG.md"
+TEMP_DIR=$(mktemp -d)
+echo "Temp folder: $TEMP_DIR"
+
+# Only the latest commit of the feature branch is available
+# automatically. To diff with the base branch, we need to
+# fetch that too (and we only need its latest commit).
+git fetch origin "${TARGET}" --depth=1
+
+if ! git cat-file -e "FETCH_HEAD:${FILE}" 2>/dev/null; then
+	echo "No ${FILE} on base branch; nothing to protect yet."
+	rm -rf "$TEMP_DIR"
+	exit 0
+fi
+
+# Checkout the previous version on the base branch of the changelog to tmpfolder
+git --work-tree="$TEMP_DIR" checkout FETCH_HEAD "$FILE"
+
+PREVIOUS_FILE="$TEMP_DIR/$FILE"
+CURRENT_FILE="$FILE"
+PREVIOUS_LOCKED_FILE="$TEMP_DIR/previous_locked_section.md"
+CURRENT_LOCKED_FILE="$TEMP_DIR/current_locked_section.md"
+
+# Extract released sections from the previous version
+awk '/^<!-- Released section -->/ {flag=1} /^<!-- Released section ended -->/ {flag=0} flag' "$PREVIOUS_FILE" >"$PREVIOUS_LOCKED_FILE"
+
+# Extract released sections from the current version
+awk '/^<!-- Released section -->/ {flag=1} /^<!-- Released section ended -->/ {flag=0} flag' "$CURRENT_FILE" >"$CURRENT_LOCKED_FILE"
+
+# Compare the released sections
+if ! diff -q "$PREVIOUS_LOCKED_FILE" "$CURRENT_LOCKED_FILE"; then
+	echo "Error: The released sections of the changelog file have been modified."
+	diff "$PREVIOUS_LOCKED_FILE" "$CURRENT_LOCKED_FILE" || true
+	rm -rf "$TEMP_DIR"
+	false
+fi
+
+rm -rf "$TEMP_DIR"
+echo "The released sections remain unchanged."


### PR DESCRIPTION
Make CHANGELOG.md the source of truth for user-facing release notes.

- Add CI gate requiring PRs to main to touch CHANGELOG.md, skippable via the "Skip Changelog" / "dependencies" labels or "[chore]" in the title (dependabot PRs get the label automatically).
- Protect released CHANGELOG sections; release PRs must add the "Unlock Released Changelog" label.
- Extract release notes from the matching CHANGELOG section via scripts/changelog-extract.sh and pass them to GoReleaser with --release-notes, disabling GoReleaser's git-history changelog.
- Document the changelog entry rules and the new release process in AGENTS.md and CONTRIBUTING.md.