### PR TITLE
fix(mcp): refresh tool lists and recover transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Assistant fenced code blocks drop the box/`-----` chrome; a muted language caption sits above the highlighted code so mouse selection stays copy-clean.
+- MCP tool listings now cache empty results correctly, follow pagination, support
+  explicit refresh, and recover from expired or broken transports.
 
 ### Security
 

--- a/doc/mcp.md
+++ b/doc/mcp.md
@@ -22,13 +22,14 @@ That is the main difference from hosts that dump every `tools/list` schema into 
 
 Agent-facing tools:
 
-- `mcp_list` — list tool **names** on one server (compact text)
+- `mcp_list` — list tool **names** on one server (compact text; `refresh=true` forces a fresh fetch)
 - `mcp_inspect` — slim parameter summary for one tool
 - `mcp_call` — actually invoke
 
 Configured **server names** are listed in the system prompt (like Skills), so the model knows what exists without calling `mcp_list` first. Schemas still stay out of context.
 
 Typical rhythm: pick a server from the prompt → `mcp_list(server=…)` → `mcp_inspect` → `mcp_call`.
+Use `mcp_list(server=…, refresh=true)` when the server's tool set may have changed.
 
 ---
 
@@ -142,7 +143,12 @@ Logs: `~/.phi/logs/mcp/<name>.log` (override with `PHI_MCP_LOG_DIR`).
 
 - Transports: **stdio** and **http** (POST JSON / SSE `data:` bodies, `Mcp-Session-Id`)
 - MCP tools are not registered individually into the model tool list (by design)
-- Dead subprocesses reconnect on the next call; no elaborate self-heal state machine
+- Tool lists are cached for 5 minutes; `mcp_list(refresh=true)` bypasses the cache. A refresh transfers the full `tools/list` definitions, but only compact names are shown to the model.
+- Empty tool lists are cached, and paginated `tools/list` responses are merged before caching.
+- Stdio EOF, write failures, malformed responses, timeouts, and cancellations retire the current subprocess; the next call starts a new process and initializes again.
+- A stdio tool call that exceeds the 60-second request deadline is terminated with its subprocess; long-running calls may lose server-local state.
+- HTTP session expiry is recognized from `404` responses to requests that carried a session ID; HTTP GET SSE and `tools/list_changed` notifications are not implemented.
+- The HTTP client negotiates protocol revision `2024-11-05` while using a compatibility subset of newer session-header behavior; the required Streamable HTTP headers and capability negotiation are not implemented.
 - Some third-party packages may crash on start — use `doctor` + logs.
 
 ---

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -10,6 +11,8 @@ import (
 const (
 	protocolVersion = "2024-11-05"
 )
+
+var errTransportBroken = errors.New("mcp transport broken")
 
 // ToolDef is a subset of an MCP tools/list entry.
 type ToolDef struct {
@@ -22,6 +25,7 @@ type ToolDef struct {
 type Client interface {
 	Initialize(ctx context.Context) error
 	ListTools(ctx context.Context) ([]ToolDef, error)
+	RefreshTools(ctx context.Context) ([]ToolDef, error)
 	FindTool(ctx context.Context, name string) (*ToolDef, error)
 	CallTool(ctx context.Context, name string, args map[string]any) (string, error)
 	Close() error

--- a/internal/mcp/http.go
+++ b/internal/mcp/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -55,6 +56,7 @@ func newHTTPTransport(name string, cfg ServerConfig) (*httpTransport, error) {
 }
 
 func (t *httpTransport) call(ctx context.Context, method string, params map[string]any) (json.RawMessage, error) {
+	hadSession := t.sessionID != ""
 	id := nextID(&t.id)
 	payload, err := marshalRequest(id, method, params)
 	if err != nil {
@@ -68,19 +70,30 @@ func (t *httpTransport) call(ctx context.Context, method string, params map[stri
 
 	resp, err := t.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("mcp http %s: %w", method, err)
+		if isContextError(err) {
+			return nil, fmt.Errorf("mcp http %s: %w", method, err)
+		}
+		return nil, t.brokenError(method, err)
 	}
 	defer resp.Body.Close()
 
-	if sid := resp.Header.Get(headerSessionID); sid != "" {
-		t.sessionID = sid
+	if method == "initialize" && resp.StatusCode < http.StatusBadRequest {
+		if sid := resp.Header.Get(headerSessionID); sid != "" {
+			t.sessionID = sid
+		}
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, httpMaxBody))
 	if err != nil {
-		return nil, fmt.Errorf("mcp http %s read: %w", method, err)
+		if isContextError(err) {
+			return nil, fmt.Errorf("mcp http %s read: %w", method, err)
+		}
+		return nil, t.brokenError(method, err)
 	}
 	if resp.StatusCode >= 400 {
+		if resp.StatusCode == http.StatusNotFound && hadSession {
+			return nil, t.brokenError(method, fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncate(string(body), 300)))
+		}
 		return nil, fmt.Errorf("mcp http %s: HTTP %d: %s", method, resp.StatusCode, truncate(string(body), 300))
 	}
 
@@ -92,6 +105,7 @@ func (t *httpTransport) call(ctx context.Context, method string, params map[stri
 }
 
 func (t *httpTransport) notify(ctx context.Context, method string, params map[string]any) error {
+	hadSession := t.sessionID != ""
 	payload, err := marshalNotification(method, params)
 	if err != nil {
 		return err
@@ -104,18 +118,40 @@ func (t *httpTransport) notify(ctx context.Context, method string, params map[st
 	}
 	resp, err := t.client.Do(req)
 	if err != nil {
-		return nil // fire-and-forget
+		if isContextError(err) {
+			return fmt.Errorf("mcp http notify %s: %w", method, err)
+		}
+		return t.brokenError("notify "+method, err)
 	}
+	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		if resp.StatusCode == http.StatusNotFound && hadSession {
+			return t.brokenError("notify "+method, fmt.Errorf("HTTP %d", resp.StatusCode))
+		}
+		return fmt.Errorf("mcp http notify %s: HTTP %d", method, resp.StatusCode)
+	}
 	return nil
 }
 
-func (t *httpTransport) close() error {
+func (t *httpTransport) brokenError(method string, err error) error {
+	t.resetSession()
+	return fmt.Errorf("mcp http %s: %w: %w", method, errTransportBroken, err)
+}
+
+func (t *httpTransport) resetSession() {
 	t.sessionID = ""
 	if t.client != nil {
 		t.client.CloseIdleConnections()
 	}
+}
+
+func isContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func (t *httpTransport) close() error {
+	t.resetSession()
 	return nil
 }
 

--- a/internal/mcp/http_transport_test.go
+++ b/internal/mcp/http_transport_test.go
@@ -1,0 +1,234 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestHTTP404WithSessionRestarts(t *testing.T) {
+	var mu sync.Mutex
+	initCount := 0
+	listCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := readHTTPMethod(t, r)
+		switch method {
+		case "initialize":
+			mu.Lock()
+			initCount++
+			count := initCount
+			mu.Unlock()
+			w.Header().Set(headerSessionID, fmt.Sprintf("sid-%d", count))
+			writeHTTPTestJSONRPC(w, map[string]any{
+				"protocolVersion": protocolVersion,
+				"capabilities":    map[string]any{},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			mu.Lock()
+			listCount++
+			mu.Unlock()
+			if r.Header.Get(headerSessionID) == "sid-1" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			writeHTTPTestJSONRPC(w, map[string]any{
+				"tools": []map[string]string{{"name": "echo"}},
+			})
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	tr, err := newHTTPTransport("demo", ServerConfig{Transport: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newSession("demo", tr)
+	if _, err := s.ListTools(t.Context()); !errors.Is(err, errTransportBroken) {
+		t.Fatalf("err = %v, want transport error", err)
+	}
+
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("tools = %+v, want echo after restart", tools)
+	}
+	mu.Lock()
+	gotInit, gotList := initCount, listCount
+	mu.Unlock()
+	if gotInit != 2 || gotList != 2 {
+		t.Fatalf("initialize/list calls = %d/%d, want 2/2", gotInit, gotList)
+	}
+}
+
+func TestHTTP404WithoutSessionIsOrdinaryError(t *testing.T) {
+	var mu sync.Mutex
+	initCount := 0
+	listCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := readHTTPMethod(t, r)
+		switch method {
+		case "initialize":
+			mu.Lock()
+			initCount++
+			mu.Unlock()
+			writeHTTPTestJSONRPC(w, map[string]any{
+				"protocolVersion": protocolVersion,
+				"capabilities":    map[string]any{},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			mu.Lock()
+			listCount++
+			mu.Unlock()
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	tr, err := newHTTPTransport("demo", ServerConfig{Transport: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newSession("demo", tr)
+	for range 2 {
+		if _, err := s.ListTools(t.Context()); err == nil || errors.Is(err, errTransportBroken) {
+			t.Fatalf("err = %v, want ordinary HTTP error", err)
+		}
+	}
+	mu.Lock()
+	gotInit, gotList := initCount, listCount
+	mu.Unlock()
+	if gotInit != 1 || gotList != 2 {
+		t.Fatalf("initialize/list calls = %d/%d, want 1/2", gotInit, gotList)
+	}
+}
+
+func TestHTTPNotify404Restarts(t *testing.T) {
+	var mu sync.Mutex
+	initCount := 0
+	notifyCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := readHTTPMethod(t, r)
+		switch method {
+		case "initialize":
+			mu.Lock()
+			initCount++
+			count := initCount
+			mu.Unlock()
+			w.Header().Set(headerSessionID, fmt.Sprintf("sid-%d", count))
+			writeHTTPTestJSONRPC(w, map[string]any{
+				"protocolVersion": protocolVersion,
+				"capabilities":    map[string]any{},
+			})
+		case "notifications/initialized":
+			mu.Lock()
+			notifyCount++
+			count := notifyCount
+			mu.Unlock()
+			if count == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			writeHTTPTestJSONRPC(w, map[string]any{
+				"tools": []map[string]string{{"name": "echo"}},
+			})
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	tr, err := newHTTPTransport("demo", ServerConfig{Transport: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newSession("demo", tr)
+	if _, err := s.ListTools(t.Context()); !errors.Is(err, errTransportBroken) {
+		t.Fatalf("err = %v, want transport error", err)
+	}
+	if _, err := s.ListTools(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	gotInit, gotNotify := initCount, notifyCount
+	mu.Unlock()
+	if gotInit != 2 || gotNotify != 2 {
+		t.Fatalf("initialize/notify calls = %d/%d, want 2/2", gotInit, gotNotify)
+	}
+}
+
+func TestHTTPNotifyNetworkErrorIsTransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := readHTTPMethod(t, r)
+		if method == "initialize" {
+			writeHTTPTestJSONRPC(w, map[string]any{
+				"protocolVersion": protocolVersion,
+				"capabilities":    map[string]any{},
+			})
+			return
+		}
+		if method == "notifications/initialized" {
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("server does not support hijacking")
+				return
+			}
+			conn, _, err := hijacker.Hijack()
+			if err == nil {
+				_ = conn.Close()
+			}
+			return
+		}
+		http.Error(w, "unexpected", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	tr, err := newHTTPTransport("demo", ServerConfig{Transport: "http", URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newSession("demo", tr)
+	if _, err := s.ListTools(t.Context()); !errors.Is(err, errTransportBroken) {
+		t.Fatalf("err = %v, want transport error", err)
+	}
+}
+
+func readHTTPMethod(t *testing.T, r *http.Request) string {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		t.Fatal(err)
+	}
+	return request.Method
+}
+
+func writeHTTPTestJSONRPC(w http.ResponseWriter, result any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"result":  result,
+	})
+}

--- a/internal/mcp/pool.go
+++ b/internal/mcp/pool.go
@@ -77,6 +77,15 @@ func (p *Pool) ListTools(ctx context.Context, server string) ([]ToolDef, error) 
 	return c.ListTools(ctx)
 }
 
+// RefreshTools forces a fresh tool list for a server.
+func (p *Pool) RefreshTools(ctx context.Context, server string) ([]ToolDef, error) {
+	c, err := p.client(server)
+	if err != nil {
+		return nil, err
+	}
+	return c.RefreshTools(ctx)
+}
+
 // Inspect returns one tool definition.
 func (p *Pool) Inspect(ctx context.Context, server, tool string) (*ToolDef, error) {
 	c, err := p.client(server)

--- a/internal/mcp/rpc.go
+++ b/internal/mcp/rpc.go
@@ -49,14 +49,20 @@ func nextID(counter *atomic.Int64) int64 {
 	return counter.Add(1)
 }
 
-func decodeToolsList(raw json.RawMessage) ([]ToolDef, error) {
+type toolsListPage struct {
+	Tools      []ToolDef
+	NextCursor *string
+}
+
+func decodeToolsList(raw json.RawMessage) (toolsListPage, error) {
 	var parsed struct {
-		Tools []ToolDef `json:"tools"`
+		Tools      []ToolDef `json:"tools"`
+		NextCursor *string   `json:"nextCursor"`
 	}
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		return nil, fmt.Errorf("decode tools/list: %w", err)
+		return toolsListPage{}, fmt.Errorf("decode tools/list: %w", err)
 	}
-	return parsed.Tools, nil
+	return toolsListPage{Tools: parsed.Tools, NextCursor: parsed.NextCursor}, nil
 }
 
 // extractToolContent turns a tools/call result into model-facing text.

--- a/internal/mcp/session.go
+++ b/internal/mcp/session.go
@@ -3,8 +3,15 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
+)
+
+const (
+	toolsCacheTTL     = 5 * time.Minute
+	maxToolsListPages = 100
 )
 
 // transport is the wire protocol for one MCP connection.
@@ -21,9 +28,11 @@ type session struct {
 	name string
 	tr   transport
 
-	mu    sync.Mutex
-	tools []ToolDef
-	ready bool
+	mu             sync.Mutex
+	tools          []ToolDef
+	toolsValid     bool
+	toolsFetchedAt time.Time
+	ready          bool
 }
 
 func newSession(name string, tr transport) *session {
@@ -45,11 +54,11 @@ func (s *session) initLocked(ctx context.Context) error {
 		"capabilities":    map[string]any{},
 		"clientInfo":      map[string]string{"name": "phi", "version": "0.1"},
 	}); err != nil {
-		_ = s.tr.close()
+		s.handleInitErrorLocked(err)
 		return err
 	}
 	if err := s.tr.notify(ctx, "notifications/initialized", map[string]any{}); err != nil {
-		_ = s.tr.close()
+		s.handleInitErrorLocked(err)
 		return err
 	}
 	s.ready = true
@@ -59,26 +68,73 @@ func (s *session) initLocked(ctx context.Context) error {
 func (s *session) ListTools(ctx context.Context) ([]ToolDef, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.listToolsLocked(ctx, false)
+}
+
+func (s *session) RefreshTools(ctx context.Context) ([]ToolDef, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.listToolsLocked(ctx, true)
+}
+
+func (s *session) listToolsLocked(ctx context.Context, force bool) ([]ToolDef, error) {
 	if err := s.initLocked(ctx); err != nil {
 		return nil, err
 	}
-	if len(s.tools) > 0 {
+	if !force && s.toolsValid && time.Since(s.toolsFetchedAt) < toolsCacheTTL {
 		return cloneTools(s.tools), nil
 	}
-	raw, err := s.tr.call(ctx, "tools/list", map[string]any{})
+
+	tools, err := s.fetchToolsLocked(ctx)
 	if err != nil {
-		return nil, err
-	}
-	tools, err := decodeToolsList(raw)
-	if err != nil {
+		s.handleToolsErrorLocked(err)
 		return nil, err
 	}
 	s.tools = tools
+	s.toolsValid = true
+	s.toolsFetchedAt = time.Now()
 	return cloneTools(tools), nil
 }
 
+func (s *session) fetchToolsLocked(ctx context.Context) ([]ToolDef, error) {
+	var tools []ToolDef
+	seen := make(map[string]struct{})
+	cursor := ""
+	hasCursor := false
+
+	for range maxToolsListPages {
+		params := map[string]any{}
+		if hasCursor {
+			params["cursor"] = cursor
+		}
+		raw, err := s.tr.call(ctx, "tools/list", params)
+		if err != nil {
+			return nil, err
+		}
+		result, err := decodeToolsList(raw)
+		if err != nil {
+			return nil, err
+		}
+		tools = append(tools, result.Tools...)
+		if result.NextCursor == nil {
+			return tools, nil
+		}
+		nextCursor := *result.NextCursor
+		if _, ok := seen[nextCursor]; ok {
+			return nil, fmt.Errorf("server %q returned repeated tools/list cursor %q", s.name, nextCursor)
+		}
+		seen[nextCursor] = struct{}{}
+		cursor = nextCursor
+		hasCursor = true
+	}
+
+	return nil, fmt.Errorf("server %q tools/list exceeded %d pages", s.name, maxToolsListPages)
+}
+
 func (s *session) FindTool(ctx context.Context, name string) (*ToolDef, error) {
-	tools, err := s.ListTools(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tools, err := s.listToolsLocked(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +144,7 @@ func (s *session) FindTool(ctx context.Context, name string) (*ToolDef, error) {
 			return &t, nil
 		}
 	}
+	s.invalidateToolsLocked()
 	return nil, fmt.Errorf("tool %q not found on server %q", name, s.name)
 }
 
@@ -105,6 +162,9 @@ func (s *session) CallTool(ctx context.Context, name string, args map[string]any
 		"arguments": args,
 	})
 	if err != nil {
+		if errors.Is(err, errTransportBroken) {
+			s.resetSessionLocked()
+		}
 		return "", err
 	}
 	return extractToolContent(raw), nil
@@ -113,9 +173,35 @@ func (s *session) CallTool(ctx context.Context, name string, args map[string]any
 func (s *session) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.resetSessionLocked()
+	return s.tr.close()
+}
+
+func (s *session) handleInitErrorLocked(err error) {
+	if errors.Is(err, errTransportBroken) {
+		s.resetSessionLocked()
+		return
+	}
+	_ = s.tr.close()
+	s.resetSessionLocked()
+}
+
+func (s *session) handleToolsErrorLocked(err error) {
+	s.invalidateToolsLocked()
+	if errors.Is(err, errTransportBroken) {
+		s.resetSessionLocked()
+	}
+}
+
+func (s *session) invalidateToolsLocked() {
+	s.toolsValid = false
+	s.toolsFetchedAt = time.Time{}
+}
+
+func (s *session) resetSessionLocked() {
 	s.ready = false
 	s.tools = nil
-	return s.tr.close()
+	s.invalidateToolsLocked()
 }
 
 func cloneTools(in []ToolDef) []ToolDef {

--- a/internal/mcp/session_test.go
+++ b/internal/mcp/session_test.go
@@ -1,0 +1,311 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+type sessionTransport struct {
+	calls         []string
+	listParams    []map[string]any
+	listResponses []json.RawMessage
+	callErrors    map[string][]error
+	closed        int
+}
+
+func (f *sessionTransport) call(_ context.Context, method string, params map[string]any) (json.RawMessage, error) {
+	f.calls = append(f.calls, method)
+	if errorsForMethod := f.callErrors[method]; len(errorsForMethod) > 0 {
+		err := errorsForMethod[0]
+		f.callErrors[method] = errorsForMethod[1:]
+		return nil, err
+	}
+	if method == "tools/list" {
+		f.listParams = append(f.listParams, params)
+		if len(f.listResponses) > 0 {
+			raw := f.listResponses[0]
+			f.listResponses = f.listResponses[1:]
+			return raw, nil
+		}
+		return rawJSON(`{"tools":[]}`), nil
+	}
+	return rawJSON(`{}`), nil
+}
+
+func (*sessionTransport) notify(context.Context, string, map[string]any) error {
+	return nil
+}
+
+func (f *sessionTransport) close() error {
+	f.closed++
+	return nil
+}
+
+func TestSessionCachesEmptyToolsList(t *testing.T) {
+	f := &sessionTransport{
+		callErrors:    map[string][]error{},
+		listResponses: []json.RawMessage{rawJSON(`{"tools":[]}`)},
+	}
+	s := newSession("fake", f)
+
+	for range 2 {
+		tools, err := s.ListTools(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(tools) != 0 {
+			t.Fatalf("tools = %v, want empty", tools)
+		}
+	}
+	if got := countMethod(f.calls, "tools/list"); got != 1 {
+		t.Fatalf("tools/list calls = %d, want 1", got)
+	}
+}
+
+func TestSessionRefreshesExpiredTools(t *testing.T) {
+	f := &sessionTransport{
+		callErrors: map[string][]error{},
+		listResponses: []json.RawMessage{
+			toolPage("old", ""),
+			toolPage("new", ""),
+		},
+	}
+	s := newSession("fake", f)
+	if _, err := s.ListTools(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	s.toolsFetchedAt = time.Now().Add(-toolsCacheTTL)
+
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "new" {
+		t.Fatalf("tools = %+v, want new", tools)
+	}
+	if got := countMethod(f.calls, "tools/list"); got != 2 {
+		t.Fatalf("tools/list calls = %d, want 2", got)
+	}
+}
+
+func TestSessionRefreshFailureInvalidatesCache(t *testing.T) {
+	f := &sessionTransport{
+		callErrors: map[string][]error{},
+		listResponses: []json.RawMessage{
+			toolPage("old", ""),
+			toolPage("new", ""),
+		},
+	}
+	s := newSession("fake", f)
+	if _, err := s.ListTools(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	f.callErrors["tools/list"] = []error{errors.New("temporary list failure")}
+	if _, err := s.RefreshTools(t.Context()); err == nil {
+		t.Fatal("expected refresh error")
+	}
+	if s.toolsValid {
+		t.Fatal("expected failed refresh to invalidate cache")
+	}
+	if len(s.tools) != 1 || s.tools[0].Name != "old" {
+		t.Fatalf("tools = %+v, want preserved old snapshot", s.tools)
+	}
+
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "new" {
+		t.Fatalf("tools = %+v, want new", tools)
+	}
+}
+
+func TestSessionPaginatesTools(t *testing.T) {
+	f := &sessionTransport{
+		callErrors: map[string][]error{},
+		listResponses: []json.RawMessage{
+			toolPage("first", "cursor-1"),
+			toolPage("second", ""),
+		},
+	}
+	s := newSession("fake", f)
+
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 2 || tools[0].Name != "first" || tools[1].Name != "second" {
+		t.Fatalf("tools = %+v, want both pages", tools)
+	}
+	if got := f.listParams[1]["cursor"]; got != "cursor-1" {
+		t.Fatalf("second cursor = %v, want cursor-1", got)
+	}
+}
+
+func TestSessionPaginatesWithEmptyCursor(t *testing.T) {
+	f := &sessionTransport{
+		callErrors: map[string][]error{},
+		listResponses: []json.RawMessage{
+			rawJSON(`{"tools":[{"name":"first"}],"nextCursor":""}`),
+			toolPage("second", ""),
+		},
+	}
+	s := newSession("fake", f)
+
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 2 || tools[0].Name != "first" || tools[1].Name != "second" {
+		t.Fatalf("tools = %+v, want both pages", tools)
+	}
+	cursor, ok := f.listParams[1]["cursor"]
+	if !ok || cursor != "" {
+		t.Fatalf("second cursor = %v (present %v), want present empty string", cursor, ok)
+	}
+}
+
+func TestSessionRejectsRepeatedToolsCursor(t *testing.T) {
+	f := &sessionTransport{
+		callErrors: map[string][]error{},
+		listResponses: []json.RawMessage{
+			toolPage("first", "cursor-1"),
+			toolPage("again", "cursor-1"),
+		},
+	}
+	s := newSession("fake", f)
+
+	_, err := s.ListTools(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "repeated tools/list cursor") {
+		t.Fatalf("err = %v, want repeated cursor error", err)
+	}
+	if s.toolsValid {
+		t.Fatal("expected repeated cursor to invalidate cache")
+	}
+}
+
+func TestSessionLimitsToolsListPages(t *testing.T) {
+	f := &sessionTransport{callErrors: map[string][]error{}}
+	for i := range maxToolsListPages {
+		f.listResponses = append(f.listResponses, toolPage(fmt.Sprintf("tool-%d", i), fmt.Sprintf("cursor-%d", i)))
+	}
+	s := newSession("fake", f)
+
+	_, err := s.ListTools(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "tools/list exceeded") {
+		t.Fatalf("err = %v, want page limit error", err)
+	}
+	if s.toolsValid {
+		t.Fatal("expected page limit to invalidate cache")
+	}
+}
+
+func TestSessionFindToolMissInvalidatesCache(t *testing.T) {
+	f := &sessionTransport{
+		callErrors: map[string][]error{},
+		listResponses: []json.RawMessage{
+			toolPage("old", ""),
+			toolPage("new", ""),
+		},
+	}
+	s := newSession("fake", f)
+	if _, err := s.ListTools(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.FindTool(t.Context(), "missing"); err == nil {
+		t.Fatal("expected missing tool error")
+	}
+	if s.toolsValid {
+		t.Fatal("expected miss to invalidate cache")
+	}
+
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "new" {
+		t.Fatalf("tools = %+v, want new", tools)
+	}
+}
+
+func TestSessionTransportErrorResetsSession(t *testing.T) {
+	f := &sessionTransport{
+		callErrors: map[string][]error{
+			"tools/list": {fmt.Errorf("read failed: %w", errTransportBroken)},
+		},
+		listResponses: []json.RawMessage{toolPage("new", "")},
+	}
+	s := newSession("fake", f)
+	if _, err := s.ListTools(t.Context()); !errors.Is(err, errTransportBroken) {
+		t.Fatalf("err = %v, want transport error", err)
+	}
+	if s.ready || s.toolsValid {
+		t.Fatalf("session state after transport error: ready=%v valid=%v", s.ready, s.toolsValid)
+	}
+	if f.closed != 0 {
+		t.Fatalf("session closed transport %d times, want 0", f.closed)
+	}
+
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "new" {
+		t.Fatalf("tools = %+v, want new", tools)
+	}
+	if got := countMethod(f.calls, "initialize"); got != 2 {
+		t.Fatalf("initialize calls = %d, want 2", got)
+	}
+}
+
+func TestSessionJSONRPCErrorKeepsState(t *testing.T) {
+	f := &sessionTransport{
+		callErrors: map[string][]error{
+			"tools/call": {errors.New("mcp tools/call: [1] rejected")},
+		},
+		listResponses: []json.RawMessage{toolPage("echo", "")},
+	}
+	s := newSession("fake", f)
+	if _, err := s.ListTools(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CallTool(t.Context(), "echo", nil); err == nil {
+		t.Fatal("expected call error")
+	}
+	if !s.ready || !s.toolsValid {
+		t.Fatalf("session state after JSON-RPC error: ready=%v valid=%v", s.ready, s.toolsValid)
+	}
+}
+
+func rawJSON(value string) json.RawMessage {
+	return json.RawMessage(value)
+}
+
+func toolPage(name, next string) json.RawMessage {
+	payload := map[string]any{
+		"tools": []map[string]string{{"name": name}},
+	}
+	if next != "" {
+		payload["nextCursor"] = next
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func countMethod(calls []string, method string) int {
+	count := 0
+	for _, call := range calls {
+		if call == method {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/mcp/stdio.go
+++ b/internal/mcp/stdio.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -40,9 +41,14 @@ func newStdioTransport(name string, cfg ServerConfig) (*stdioTransport, error) {
 }
 
 func (t *stdioTransport) call(ctx context.Context, method string, params map[string]any) (json.RawMessage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if err := t.ensureStarted(); err != nil {
 		return nil, err
 	}
+	stdin := t.stdin
+	stdout := t.stdout
 	id := nextID(&t.id)
 	payload, err := marshalRequest(id, method, params)
 	if err != nil {
@@ -56,12 +62,14 @@ func (t *stdioTransport) call(ctx context.Context, method string, params map[str
 		err error
 	}
 	ch := make(chan outcome, 1)
+	done := make(chan struct{})
 	go func() {
-		if _, werr := t.stdin.Write(payload); werr != nil {
-			ch <- outcome{err: fmt.Errorf("write %s: %w", method, werr)}
+		defer close(done)
+		if _, werr := stdin.Write(payload); werr != nil {
+			ch <- outcome{err: fmt.Errorf("write %s: %w: %w", method, errTransportBroken, werr)}
 			return
 		}
-		rpc, rerr := t.readResponse()
+		rpc, rerr := t.readResponse(stdout)
 		if rerr != nil {
 			ch <- outcome{err: fmt.Errorf("read %s: %w", method, rerr)}
 			return
@@ -74,10 +82,18 @@ func (t *stdioTransport) call(ctx context.Context, method string, params map[str
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		_ = t.close()
+		<-done
+		return nil, fmt.Errorf("mcp %s: %w: %w", method, errTransportBroken, ctx.Err())
 	case <-timer.C:
-		return nil, fmt.Errorf("mcp %s: timeout after %s", method, deadline)
+		_ = t.close()
+		<-done
+		return nil, fmt.Errorf("mcp %s: timeout after %s: %w", method, deadline, errTransportBroken)
 	case out := <-ch:
+		<-done
+		if out.err != nil && errors.Is(out.err, errTransportBroken) {
+			_ = t.close()
+		}
 		return out.raw, out.err
 	}
 }
@@ -92,6 +108,10 @@ func (t *stdioTransport) notify(_ context.Context, method string, params map[str
 	}
 	payload = append(payload, '\n')
 	_, err = t.stdin.Write(payload)
+	if err != nil {
+		_ = t.close()
+		return fmt.Errorf("write notification %s: %w: %w", method, errTransportBroken, err)
+	}
 	return err
 }
 
@@ -103,7 +123,11 @@ func (t *stdioTransport) close() error {
 	var err error
 	if t.cmd != nil && t.cmd.Process != nil {
 		_ = t.cmd.Process.Kill()
-		err = t.cmd.Wait()
+		waitErr := t.cmd.Wait()
+		var exitErr *exec.ExitError
+		if waitErr != nil && !errors.As(waitErr, &exitErr) {
+			err = waitErr
+		}
 		t.cmd = nil
 	}
 	if t.stderr != nil {
@@ -164,15 +188,20 @@ func (t *stdioTransport) ensureStarted() error {
 	return nil
 }
 
-func (t *stdioTransport) readResponse() (jsonRPCResponse, error) {
+func (*stdioTransport) readResponse(stdout *bufio.Reader) (jsonRPCResponse, error) {
 	for {
-		line, err := t.stdout.ReadBytes('\n')
+		line, err := stdout.ReadBytes('\n')
 		if err != nil {
-			return jsonRPCResponse{}, err
+			return jsonRPCResponse{}, fmt.Errorf("%w: %w", errTransportBroken, err)
 		}
 		var rpc jsonRPCResponse
 		if err := json.Unmarshal(line, &rpc); err != nil {
-			return jsonRPCResponse{}, fmt.Errorf("parse response: %w; raw=%q", err, truncate(string(line), 200))
+			return jsonRPCResponse{}, fmt.Errorf(
+				"%w: parse response: %w; raw=%q",
+				errTransportBroken,
+				err,
+				truncate(string(line), 200),
+			)
 		}
 		// Skip server notifications (method set, no id).
 		if rpc.Method != "" && rpc.ID == nil {

--- a/internal/mcp/stdio_test.go
+++ b/internal/mcp/stdio_test.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStdioRestartsAfterEOF(t *testing.T) {
+	tr := newHelperStdioTransport(t, "exit-first")
+	s := newSession("helper", tr)
+
+	if _, err := s.ListTools(t.Context()); !errors.Is(err, errTransportBroken) {
+		t.Fatalf("err = %v, want transport error", err)
+	}
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("tools = %+v, want echo after restart", tools)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStdioTimeoutRetiresWorker(t *testing.T) {
+	tr := newHelperStdioTransport(t, "delay-first")
+	tr.timeout = 250 * time.Millisecond
+	s := newSession("helper", tr)
+
+	if _, err := s.ListTools(t.Context()); !errors.Is(err, errTransportBroken) {
+		t.Fatalf("err = %v, want transport error", err)
+	}
+	tools, err := s.ListTools(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("tools = %+v, want echo after timeout restart", tools)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newHelperStdioTransport(t *testing.T, mode string) *stdioTransport {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	marker := filepath.Join(home, "helper-started")
+	tr, err := newStdioTransport("helper", ServerConfig{
+		Command: []string{os.Args[0]},
+		Args:    []string{"-test.run=TestStdioHelperProcess", "--"},
+		Env: map[string]string{
+			"PHI_MCP_HELPER":        "1",
+			"PHI_MCP_HELPER_MODE":   mode,
+			"PHI_MCP_HELPER_MARKER": marker,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tr
+}
+
+func TestStdioHelperProcess(_ *testing.T) {
+	if os.Getenv("PHI_MCP_HELPER") != "1" {
+		return
+	}
+
+	mode := os.Getenv("PHI_MCP_HELPER_MODE")
+	marker := os.Getenv("PHI_MCP_HELPER_MARKER")
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &request); err != nil {
+			panic(err)
+		}
+		switch request.Method {
+		case "initialize":
+			writeHelperResponse(request.ID, map[string]any{
+				"protocolVersion": protocolVersion,
+				"capabilities":    map[string]any{},
+				"serverInfo":      map[string]string{"name": "helper", "version": "0.1"},
+			})
+		case "notifications/initialized":
+			continue
+		case "tools/list":
+			first := false
+			if _, err := os.Stat(marker); os.IsNotExist(err) {
+				if err := os.WriteFile(marker, []byte("started\n"), 0o600); err != nil {
+					panic(err)
+				}
+				first = true
+			}
+			if first && mode == "exit-first" {
+				return
+			}
+			if first && mode == "delay-first" {
+				time.Sleep(time.Second)
+			}
+			writeHelperResponse(request.ID, map[string]any{
+				"tools": []map[string]string{{"name": "echo"}},
+			})
+		default:
+			writeHelperResponse(request.ID, map[string]any{})
+		}
+	}
+}
+
+func writeHelperResponse(id json.RawMessage, result any) {
+	var idValue any
+	if err := json.Unmarshal(id, &idValue); err != nil {
+		panic(err)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      idValue,
+		"result":  result,
+	}); err != nil {
+		panic(err)
+	}
+}

--- a/internal/tools/mcptool/mcp.go
+++ b/internal/tools/mcptool/mcp.go
@@ -38,6 +38,10 @@ Returns space-separated tool names. Schemas never enter the model context — us
 						"type":        "string",
 						"description": "MCP server name",
 					},
+					"refresh": llm.Object{
+						"type":        "boolean",
+						"description": "Force a fresh tools/list request",
+					},
 				},
 				Required: []string{"server"},
 			},
@@ -51,7 +55,8 @@ Returns space-separated tool names. Schemas never enter the model context — us
 		},
 		Run: func(ctx context.Context, input json.RawMessage) (tooldef.Result, error) {
 			var in struct {
-				Server string `json:"server"`
+				Server  string `json:"server"`
+				Refresh bool   `json:"refresh"`
 			}
 			if err := json.Unmarshal(input, &in); err != nil {
 				return tooldef.Result{}, fmt.Errorf("mcp_list: %w", err)
@@ -59,7 +64,13 @@ Returns space-separated tool names. Schemas never enter the model context — us
 			if in.Server == "" {
 				return tooldef.Result{}, errors.New("mcp_list: server is required")
 			}
-			tools, err := pool.ListTools(ctx, in.Server)
+			var tools []mcp.ToolDef
+			var err error
+			if in.Refresh {
+				tools, err = pool.RefreshTools(ctx, in.Server)
+			} else {
+				tools, err = pool.ListTools(ctx, in.Server)
+			}
 			if err != nil {
 				return tooldef.Result{}, err
 			}

--- a/internal/tools/mcptool/mcp_test.go
+++ b/internal/tools/mcptool/mcp_test.go
@@ -1,7 +1,11 @@
 package mcptool_test
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pulseaiclub/phi/internal/mcp"
@@ -46,6 +50,91 @@ func TestMCPListRequiresServer(t *testing.T) {
 	_, err := list.Run(t.Context(), []byte(`{}`))
 	if err == nil || !strings.Contains(err.Error(), "server is required") {
 		t.Fatalf("err = %v, want server is required", err)
+	}
+}
+
+func TestMCPListSupportsRefresh(t *testing.T) {
+	pool := mcp.NewPool(map[string]mcp.ServerConfig{
+		"echo": {Command: []string{"true"}},
+	})
+	list := findTool(t, mcptool.Tools(pool), "mcp_list")
+	refresh, ok := list.Definition.Params.Properties["refresh"].(map[string]any)
+	if !ok || refresh["type"] != "boolean" {
+		t.Fatalf("refresh property = %#v, want boolean", list.Definition.Params.Properties["refresh"])
+	}
+}
+
+func TestMCPListRefreshBypassesAndUpdatesCache(t *testing.T) {
+	var listCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if request.Method == "notifications/initialized" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		var result any
+		switch request.Method {
+		case "initialize":
+			result = map[string]any{
+				"protocolVersion": "2024-11-05",
+				"capabilities":    map[string]any{},
+			}
+		case "tools/list":
+			name := "old"
+			if listCalls.Add(1) > 1 {
+				name = "new"
+			}
+			result = map[string]any{"tools": []map[string]string{{"name": name}}}
+		default:
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request.ID,
+			"result":  result,
+		})
+	}))
+	defer srv.Close()
+
+	pool := mcp.NewPool(map[string]mcp.ServerConfig{
+		"echo": {Transport: "http", URL: srv.URL},
+	})
+	defer func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("close pool: %v", err)
+		}
+	}()
+	list := findTool(t, mcptool.Tools(pool), "mcp_list")
+	run := func(input string) string {
+		t.Helper()
+		result, err := list.Run(t.Context(), []byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result.Content
+	}
+
+	if got := run(`{"server":"echo"}`); got != "old" {
+		t.Fatalf("first list = %q, want old", got)
+	}
+	if got := run(`{"server":"echo"}`); got != "old" || listCalls.Load() != 1 {
+		t.Fatalf("cached list/calls = %q/%d, want old/1", got, listCalls.Load())
+	}
+	if got := run(`{"server":"echo","refresh":true}`); got != "new" || listCalls.Load() != 2 {
+		t.Fatalf("refreshed list/calls = %q/%d, want new/2", got, listCalls.Load())
+	}
+	if got := run(`{"server":"echo"}`); got != "new" || listCalls.Load() != 2 {
+		t.Fatalf("post-refresh list/calls = %q/%d, want new/2", got, listCalls.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary

- cache complete `tools/list` results, including empty lists, with a five-minute TTL and an explicit `mcp_list(refresh=true)` path
- follow opaque cursor pagination safely, invalidating stale snapshots on misses and failed refreshes
- retire broken stdio workers and expired HTTP sessions so the next request initializes a fresh transport
- document behavior and compatibility limits, and add session, transport, and end-to-end coverage

Refs #54

## Testing

- `go test ./internal/mcp ./internal/tools/mcptool -count=1`
- `go test -race ./internal/mcp ./internal/tools/mcptool -count=1`
- `go test ./... -count=1`
- `make fmt-check`
- `make lint`
- `git diff --check`