### PR TITLE
refactor: drop agent_list status filter parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+- `agent_list` `status` filter parameter (always returns the full list; each row still includes `status`).
+
 ### Fixed
 
 ### Security

--- a/internal/agent/prompt/system-prompt.tmpl
+++ b/internal/agent/prompt/system-prompt.tmpl
@@ -1,50 +1,27 @@
 You are phi, an autonomous coding agent in a shared workspace. Deliver the outcome the user wants: correct, minimal, verified.
 
-# Classify
-Classify the request, then choose a path. Only Implement / Debug default to editing.
-1. **Answer / explain** — tools only for evidence; do not edit.
-2. **Implement / fix** — explore → change → verify → summarize.
-3. **Debug** — reproduce or locate failure → hypothesis → evidence → fix root cause → re-verify. No shotgun unrelated changes.
-4. **Review / plan** — analyze and recommend; edit only if asked.
-
-When intent is ambiguous but low-risk, take the smallest useful action on that path. Ask only when missing information would materially change the design, touch shared APIs, delete data, or drive a multi-file refactor—keep questions narrow.
-
-# Evidence
-- Do not invent file contents, APIs, flags, or libraries—ground claims in tool results or injected context.
-- Before using a dependency, confirm it exists in the repo (manifests, imports, or neighbors).
-
-# Discovery
-Use the narrowest tool that answers the next uncertainty; stop when uncertainty is resolved. Prefer specialized tools over `bash` (bash for builds, tests, git, and OS tasks those tools cannot do — never cat, ls(1), find(1), grep, or rg).
-1. Known file path → `read`. Exact symbol → `grep`. Directory listing → `ls`. Filename pattern → `find`. Never `read` a directory.
+# Tools
+1. Known file path → `read`. Exact symbol → `grep`. Directory listing → `ls`. Filename pattern → `find`.
 {{- if .AgentsEnabled}}
 2. Open-ended search (vague keyword, unsure where, likely many find/grep rounds) → prefer `agent_spawn` (role=explore) + `agent_wait` so exploration stays out of this context; then act on the summary.
 {{- else}}
-2. Open-ended search (vague keyword, unsure where, likely many find/grep rounds) → `find` / `grep` / `ls` yourself; stay narrow and stop when uncertainty is resolved.
+2. Open-ended search (vague keyword, unsure where, likely many find/grep rounds) → `find` / `grep` / `ls` yourself.
 {{- end}}
-3. `bash` — as above.
+3. `bash` for builds, tests, git, and OS tasks.
 {{- if .AgentsEnabled}}
 
 Sub-agents: `explore` (default, read-only search), `review` (read-only checks/diffs), `worker` (may edit; only for a scoped, already-planned independent change). Use `agent_spawn` + `agent_wait` for one job or several in parallel. Wait timeout does not cancel a job.
 {{- end}}
 
-Parallelize independent read-only calls. Do not widen exploration just because tools are available. Treat skills as constraints and shortcuts—apply the smallest relevant part.
+Parallelize independent read-only calls.
 
 # Change
-- Before `edit`, `read` (or `grep`) the target file. Set `edit.hash` to the 4 hex chars after `#` in `@file path#TAG` (e.g. `A1B2` from `@file src/app.py#A1B2`) — not `@file`, not the path, not the `#`. `from`/`to` are `LINE#abc` only (e.g. `5#abc`); do not include `|content`. Put every change for that file in one `edits` array. After a successful edit, TAG and LINE#HASH anchors for that path are dead — re-read before another `edit` on it. On mismatch, re-read and retry once.
+- Before `edit`, `read` (or `grep`) the target file; set `edit.hash` to the 4 hex chars after `#` in `@file path#TAG`.
 - If an approach fails: read the error, revise the hypothesis, retry with a different tactic—not the identical failing call.
-
-# Verify
-Scale checks to blast radius:
-- Pure Q&A / trivial typo → skip heavy checks.
-- Localized change → targeted test, lint, typecheck, or build as appropriate.
-- Shared contracts / user-facing behavior → broaden coverage.
-
-Before running via `bash`, confirm the script/target exists (e.g. a `lint` target). Report results honestly; do not silence type/lint errors unless the user explicitly asks.
 
 # Tool contracts
 - Follow `# Current Project context` and any `<project_context>` instructions (AGENTS.md / CLAUDE.md) before the first tool call.
 - Prefer cwd-relative paths in tool arguments. Absolute paths are accepted; tools return them only for files outside cwd.
-- `read` body lines are `N#abc|content`. `grep` match lines are `path:>>N#abc|content`. Copy only the 4 hex chars after `#` in `@file path#TAG` into `edit.hash`; copy only `N#abc` into `from`/`to`.
 - `write` creates or overwrites a file. Use `edit` for surgical changes to an existing file.
 
 # Current Project context

--- a/internal/job/manager_test.go
+++ b/internal/job/manager_test.go
@@ -135,7 +135,7 @@ func TestConcurrencyBusy(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestListAndFilter(t *testing.T) {
+func TestHandleList(t *testing.T) {
 	var n atomic.Int32
 	m := newMgr(t, job.RunnerFunc(func(_ context.Context, _ job.RunEnv) (string, error) {
 		n.Add(1)
@@ -154,10 +154,9 @@ func TestListAndFilter(t *testing.T) {
 		_, _ = m.Wait(ctx, info.ID)
 	}
 
-	raw, _ := json.Marshal(job.ListArgs{Status: string(job.StatusCompleted)})
-	filtered, err := m.HandleList(ctx, raw)
+	got, err := m.HandleList(ctx, nil)
 	require.NoError(t, err)
-	require.Len(t, filtered, 2)
+	require.Len(t, got, 2)
 }
 
 func TestHandleWaitTimeoutDoesNotCancelJob(t *testing.T) {

--- a/internal/job/tools.go
+++ b/internal/job/tools.go
@@ -32,11 +32,6 @@ type CancelArgs struct {
 	JobID string `json:"job_id"`
 }
 
-// ListArgs is the JSON argument shape for agent_list.
-type ListArgs struct {
-	Status string `json:"status,omitempty"`
-}
-
 // HandleSpawn is a JSON-tool style entry for agent_spawn.
 func (m *Manager) HandleSpawn(ctx context.Context, raw json.RawMessage) (Info, error) {
 	var args SpawnArgs
@@ -58,28 +53,9 @@ func (m *Manager) HandleSpawn(ctx context.Context, raw json.RawMessage) (Info, e
 }
 
 // HandleList is a JSON-tool style entry for agent_list.
-func (m *Manager) HandleList(ctx context.Context, raw json.RawMessage) ([]Info, error) {
-	var args ListArgs
-	if len(raw) > 0 {
-		if err := json.Unmarshal(raw, &args); err != nil {
-			return nil, fmt.Errorf("%w: %w", ErrInvalid, err)
-		}
-	}
-	list, err := m.List(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if args.Status == "" {
-		return list, nil
-	}
-	want := Status(args.Status)
-	out := make([]Info, 0, len(list))
-	for _, info := range list {
-		if info.Status == want {
-			out = append(out, info)
-		}
-	}
-	return out, nil
+// Args are ignored; callers filter on Info.Status if needed.
+func (m *Manager) HandleList(ctx context.Context, _ json.RawMessage) ([]Info, error) {
+	return m.List(ctx)
 }
 
 // HandleWait is a JSON-tool style entry for agent_wait.

--- a/internal/tools/agenttool/agent.go
+++ b/internal/tools/agenttool/agent.go
@@ -177,28 +177,13 @@ func agentListTool(deps AgentDeps) tooldef.Tool {
 	return tooldef.Tool{
 		Definition: llm.ToolDefinition{
 			Name:        "agent_list",
-			Description: `List sub-agent jobs (newest first). Optional status filter: starting, running, completed, failed, cancelled, timed_out.`,
+			Description: `List sub-agent jobs (newest first). Each row includes status; filter client-side if needed.`,
 			Params: &llm.FunctionParameters{
-				Type: "object",
-				Properties: llm.Object{
-					"status": llm.Object{
-						"type":        "string",
-						"description": "Optional status filter.",
-					},
-				},
+				Type:       "object",
+				Properties: llm.Object{},
 			},
 		},
-		DetailFromArgs: func(input json.RawMessage) string {
-			var in struct {
-				Status string `json:"status"`
-			}
-			_ = json.Unmarshal(input, &in)
-			return in.Status
-		},
 		Run: func(ctx context.Context, input json.RawMessage) (tooldef.Result, error) {
-			if len(input) == 0 {
-				input = json.RawMessage(`{}`)
-			}
 			list, err := deps.Manager.HandleList(ctx, input)
 			if err != nil {
 				return tooldef.Result{}, err


### PR DESCRIPTION
agent_list now always returns the full job list; each row already carries status, so callers can filter client-side. Removes the ListArgs struct, the filter branch in HandleList, and the tool's status param.