### PR TITLE
Enhance hooks with session lifecycle support and command UI intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Hooks: `command` UI intents — `status` (footer), `list` (palette page).
+- Hooks: session lifecycle events `session_start`, `session_shutdown`, `session_before_switch`.
+
 ### Changed
 
 ### Deprecated

--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -133,12 +133,12 @@ A file is either `{"name":"plugin-id","hooks":[…]}` or a top-level `[…]` arr
 | `name` (plugin) | string | no | directory name | Optional plugin id |
 | `hooks` | array | yes* | — | Hook entries (`*` not needed for a top-level array) |
 | `name` (hook) | string | yes† | plugin `name` | Unique id; used for user/project override. †Optional only when the file has exactly one hook and the plugin has a name |
-| `event` | string | yes | — | `pre_tool`, `post_tool`, or `command` |
-| `match` | string | no | `*` | Exact tool name, or `*` for all tools. Not a regex. Ignored for `command`. |
+| `event` | string | yes | — | `pre_tool`, `post_tool`, `command`, `session_start`, `session_shutdown`, or `session_before_switch` |
+| `match` | string | no | `*` | Exact tool name, or `*` for all tools. Not a regex. Ignored for `command` and session events. |
 | `run` | string | yes | — | Executable path relative to `plugin.json`'s directory, or absolute. Executed directly (no shell). |
 | `timeout` | string \| number | no | `5s` | Go duration string (e.g. `"5s"`) or seconds as a number. Maximum `60s`. |
-| `fail_closed` | boolean | no | `false` | On failure, deny (Pre) / stop (Post) instead of ignoring. Invalid on `command`. |
-| `async` | boolean | no | `false` | `post_tool` only: fire-and-forget; result ignored |
+| `fail_closed` | boolean | no | `false` | On failure, deny (Pre / before_switch) / stop (Post). Invalid on `command`, `session_start`, `session_shutdown`. |
+| `async` | boolean | no | `false` | `post_tool` / `session_start` / `session_shutdown`: fire-and-forget; result ignored |
 | `disabled` | boolean | no | `false` | Skip loading this hook |
 
 ### PreTool response
@@ -191,12 +191,24 @@ stdin:
 { "session_id": "…", "cwd": "/path/to/project", "hook_event": "command", "command": "review", "args": ["the", "diff"] }
 ```
 
-stdout (first JSON line). Empty body + exit `0` is a silent success:
+stdout (first JSON line). Empty body + exit `0` is a silent success.
+
+Apply order after a successful run: **status** → **toast** → **list** (palette page) → **submit** (skipped when `list` is present).
 
 ```json
 { "submit": "optional text sent as a user message" }
 { "toast": "optional success toast" }
+{ "status": "footer status text" }
+{ "status": "" }
+{ "list": { "title": "Findings", "items": [{ "label": "auth.go:12", "detail": "nil check", "submit": "fix auth.go:12" }] } }
 ```
+
+| Field | Effect |
+| --- | --- |
+| `submit` | Send as a user message (ignored when `list` is set) |
+| `toast` | Success toast |
+| `status` | Set footer status when the key is present (empty string clears) |
+| `list` | Push a Ctrl+K palette page; item `submit` runs on select |
 
 | Exit code | Behavior |
 | --- | --- |
@@ -205,19 +217,58 @@ stdout (first JSON line). Empty body + exit `0` is a silent success:
 
 The TUI runs at most one hook command at a time (like `!` bash). Reload drops in-flight results.
 
+### Session lifecycle
+
+| Event | When | Can block? |
+| --- | --- | --- |
+| `session_before_switch` | Before `/clear` or `/resume` replaces the engine | Yes — `action: deny` or exit `2` |
+| `session_shutdown` | Leaving a session (`new` / `resume` / `quit`) | No |
+| `session_start` | After a session is ready (`startup` / `new` / `resume`) | No |
+
+`async: true` is allowed on `session_start` and `session_shutdown` (fire-and-forget). `fail_closed` is allowed only on `session_before_switch`. `match` is ignored.
+
+stdin:
+
+```json
+{
+  "session_id": "…",
+  "cwd": "/path/to/project",
+  "hook_event": "session_before_switch",
+  "reason": "resume",
+  "target_session_id": "abcd…"
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `reason` | `startup` \| `new` \| `resume` \| `quit` |
+| `previous_session_id` | On `session_start` after a switch: the session just left |
+| `target_session_id` | On `session_before_switch` for resume: destination id |
+
+stdout examples:
+
+```json
+{ "action": "deny", "reason": "uncommitted changes" }
+{ "toast": "session ready", "status": "hooks on" }
+```
+
+`session_before_switch` runs **serially** (first deny wins). Start/shutdown run **in parallel** (like PostTool). Toast/status from session hooks are applied by the TUI when present.
+
 ### Failure policy (`fail_closed`)
 
 | Value | When the script crashes, times out, or returns invalid JSON |
 | --- | --- |
 | `false` (default) | Ignore that hook (suitable for audit) |
-| `true` | Deny (Pre) or stop (Post) (suitable for security gates) |
+| `true` | Deny (Pre / before_switch) or stop (Post) (suitable for security gates) |
 
-In `permissions.mode: readonly`, only hooks with `fail_closed: true` run, so slow audit hooks do not stall exploratory tool use. Interactive sessions and `phi run` run all loaded hooks.
+In `permissions.mode: readonly`, only hooks with `fail_closed: true` run for the tool loop, so slow audit hooks do not stall exploratory tool use. Interactive sessions and `phi run` run all loaded hooks. `session_start` / `session_shutdown` cannot set `fail_closed`, so they are skipped under the readonly FailClosedOnly view; use `session_before_switch` with `fail_closed` when a switch must be gated.
 
 ### Ordering and concurrency
 
 - Matching **PreTool** hooks run **serially**. First deny wins; modify results chain onto `input`.
 - Matching **PostTool** hooks run **in parallel** (except `async`, which is detached).
+- **session_before_switch** runs **serially**. First deny wins.
+- **session_start** / **session_shutdown** run **in parallel** (except `async`).
 - Order across multiple hooks is **not** guaranteed. If order matters, put the logic in one hook.
 - Because PostTool runs in parallel, do not rely on several hooks each rewriting `output` for the same tool call; put rewrite logic in one sync hook.
 
@@ -240,18 +291,21 @@ External hooks use a single JSON line on stdin and a single JSON line on stdout.
 }
 ```
 
-| Field | PreTool | PostTool | Command |
-| --- | --- | --- | --- |
-| `session_id` | yes | yes | yes |
-| `cwd` | yes | yes | yes |
-| `hook_event` | `pre_tool` | `post_tool` | `command` |
-| `tool` | yes | yes | — |
-| `tool_use_id` | yes | yes | — |
-| `input` | yes | yes | — |
-| `output` | — | tool stdout / result text when present | — |
-| `error` | — | tool error text; empty on success | — |
-| `command` | — | — | hook name |
-| `args` | — | — | slash args after `/name` |
+| Field | PreTool | PostTool | Command | Session |
+| --- | --- | --- | --- | --- |
+| `session_id` | yes | yes | yes | yes |
+| `cwd` | yes | yes | yes | yes |
+| `hook_event` | `pre_tool` | `post_tool` | `command` | `session_*` |
+| `tool` | yes | yes | — | — |
+| `tool_use_id` | yes | yes | — | — |
+| `input` | yes | yes | — | — |
+| `output` | — | tool stdout / result text when present | — | — |
+| `error` | — | tool error text; empty on success | — | — |
+| `command` | — | — | hook name | — |
+| `args` | — | — | slash args after `/name` | — |
+| `reason` | — | — | — | `startup` / `new` / `resume` / `quit` |
+| `previous_session_id` | — | — | — | start after switch |
+| `target_session_id` | — | — | — | before_switch resume |
 
 ### Environment
 
@@ -261,7 +315,7 @@ Injected variables:
 
 | Variable | Value |
 | --- | --- |
-| `PHI_HOOK_EVENT` | `pre_tool`, `post_tool`, or `command` |
+| `PHI_HOOK_EVENT` | `pre_tool`, `post_tool`, `command`, or `session_*` |
 | `PHI_SESSION_ID` | Session id |
 | `PHI_CWD` | Workspace cwd |
 | `PHI_PROJECT_DIR` | Same as cwd for command hooks |

--- a/internal/hooks/command.go
+++ b/internal/hooks/command.go
@@ -100,17 +100,33 @@ func (h *CommandHook) Command(ctx context.Context, ev CommandEvent) (CommandResu
 	return h.runCommand(ctx, ev)
 }
 
+// Session runs a session lifecycle hook; other kinds return allow.
+func (h *CommandHook) Session(ctx context.Context, ev SessionEvent) (SessionResult, error) {
+	switch h.kind {
+	case KindSessionStart, KindSessionShutdown, KindSessionBeforeSwitch:
+		if h.kind != ev.Kind {
+			return SessionResult{Action: ActionAllow}, nil
+		}
+		return h.runSession(ctx, ev)
+	default:
+		return SessionResult{Action: ActionAllow}, nil
+	}
+}
+
 type wireIn struct {
-	SessionID string          `json:"session_id"`
-	Cwd       string          `json:"cwd"`
-	HookEvent string          `json:"hook_event"`
-	Tool      string          `json:"tool"`
-	ToolUseID string          `json:"tool_use_id"`
-	Input     json.RawMessage `json:"input"`
-	Output    string          `json:"output,omitempty"`
-	Err       string          `json:"error,omitempty"`
-	Command   string          `json:"command,omitempty"`
-	Args      []string        `json:"args,omitempty"`
+	SessionID         string          `json:"session_id"`
+	Cwd               string          `json:"cwd"`
+	HookEvent         string          `json:"hook_event"`
+	Tool              string          `json:"tool"`
+	ToolUseID         string          `json:"tool_use_id"`
+	Input             json.RawMessage `json:"input"`
+	Output            string          `json:"output,omitempty"`
+	Err               string          `json:"error,omitempty"`
+	Command           string          `json:"command,omitempty"`
+	Args              []string        `json:"args,omitempty"`
+	Reason            string          `json:"reason,omitempty"`
+	PreviousSessionID string          `json:"previous_session_id,omitempty"`
+	TargetSessionID   string          `json:"target_session_id,omitempty"`
 }
 
 type wirePreOut struct {
@@ -128,9 +144,18 @@ type wirePostOut struct {
 }
 
 type wireCommandOut struct {
-	Submit string `json:"submit"`
-	Toast  string `json:"toast"`
-	Reason string `json:"reason"`
+	Submit string       `json:"submit"`
+	Toast  string       `json:"toast"`
+	Reason string       `json:"reason"`
+	Status *string      `json:"status"`
+	List   *CommandList `json:"list"`
+}
+
+type wireSessionOut struct {
+	Action string  `json:"action"`
+	Reason string  `json:"reason"`
+	Toast  string  `json:"toast"`
+	Status *string `json:"status"`
 }
 
 func (h *CommandHook) runPre(ctx context.Context, ev Event) (PreResult, error) {
@@ -242,7 +267,77 @@ func (h *CommandHook) runCommand(ctx context.Context, ev CommandEvent) (CommandR
 	if err := json.Unmarshal([]byte(line), &out); err != nil {
 		return CommandResult{}, fmt.Errorf("hook %s invalid json: %w", h.name, err)
 	}
-	return CommandResult{Submit: out.Submit, Toast: out.Toast}, nil
+	res := CommandResult{Submit: out.Submit, Toast: out.Toast, List: out.List}
+	if out.Status != nil {
+		res.Status = *out.Status
+		res.StatusSet = true
+	}
+	if res.List != nil && len(res.List.Items) == 0 {
+		res.List = nil
+	}
+	return res, nil
+}
+
+func (h *CommandHook) runSession(ctx context.Context, ev SessionEvent) (SessionResult, error) {
+	stdout, code, err := h.spawn(ctx, wireIn{
+		SessionID:         ev.SessionID,
+		Cwd:               ev.Cwd,
+		HookEvent:         string(ev.Kind),
+		Reason:            ev.Reason,
+		PreviousSessionID: ev.PreviousSessionID,
+		TargetSessionID:   ev.TargetSessionID,
+	})
+	if err != nil {
+		return SessionResult{}, err
+	}
+	line := firstJSONLine(stdout)
+	if code == ExitDeny {
+		res := SessionResult{Action: ActionDeny, Reason: "hook denied (exit 2)"}
+		if line != "" {
+			var out wireSessionOut
+			if json.Unmarshal([]byte(line), &out) == nil {
+				if out.Reason != "" {
+					res.Reason = out.Reason
+				}
+				res.Toast = out.Toast
+				if out.Status != nil {
+					res.Status = *out.Status
+					res.StatusSet = true
+				}
+			}
+		}
+		return res, nil
+	}
+	if code != 0 {
+		reason := ""
+		if line != "" {
+			var out wireSessionOut
+			if json.Unmarshal([]byte(line), &out) == nil {
+				reason = out.Reason
+			}
+		}
+		if reason == "" {
+			return SessionResult{}, fmt.Errorf("hook %s exited %d", h.name, code)
+		}
+		return SessionResult{}, fmt.Errorf("hook %s exited %d: %s", h.name, code, reason)
+	}
+	if line == "" {
+		return SessionResult{Action: ActionAllow}, nil
+	}
+	var out wireSessionOut
+	if err := json.Unmarshal([]byte(line), &out); err != nil {
+		return SessionResult{}, fmt.Errorf("hook %s invalid json: %w", h.name, err)
+	}
+	action, err := parseWireAction(out.Action)
+	if err != nil {
+		return SessionResult{}, fmt.Errorf("hook %s: %w", h.name, err)
+	}
+	res := SessionResult{Action: action, Reason: out.Reason, Toast: out.Toast}
+	if out.Status != nil {
+		res.Status = *out.Status
+		res.StatusSet = true
+	}
+	return res, nil
 }
 
 func (h *CommandHook) invoke(ctx context.Context, kind Kind, ev Event) ([]byte, int, error) {

--- a/internal/hooks/command_test.go
+++ b/internal/hooks/command_test.go
@@ -191,6 +191,46 @@ func TestCommandHookCommandToast(t *testing.T) {
 	assert.Equal(t, "done", res.Toast)
 }
 
+func TestCommandHookCommandUIIntents(t *testing.T) {
+	h := cmdHook(t, "command_ui.sh")
+	res, err := h.Command(t.Context(), CommandEvent{})
+	require.NoError(t, err)
+	require.True(t, res.StatusSet)
+	assert.Equal(t, "3 findings", res.Status)
+	require.NotNil(t, res.List)
+	assert.Equal(t, "Findings", res.List.Title)
+	require.Len(t, res.List.Items, 1)
+	assert.Equal(t, "auth.go:12", res.List.Items[0].Label)
+	assert.Equal(t, "fix auth.go:12", res.List.Items[0].Submit)
+}
+
+func TestCommandHookSession(t *testing.T) {
+	start := &CommandHook{
+		name:    "on-start",
+		kind:    KindSessionStart,
+		runPath: testScript(t, "session_start.sh"),
+		dir:     filepath.Dir(testScript(t, "session_start.sh")),
+		timeout: 5 * time.Second,
+	}
+	res, err := start.Session(t.Context(), SessionEvent{Kind: KindSessionStart, Reason: "startup"})
+	require.NoError(t, err)
+	assert.Equal(t, "session ready", res.Toast)
+	require.True(t, res.StatusSet)
+	assert.Equal(t, "hooks on", res.Status)
+
+	deny := &CommandHook{
+		name:    "guard",
+		kind:    KindSessionBeforeSwitch,
+		runPath: testScript(t, "session_deny.sh"),
+		dir:     filepath.Dir(testScript(t, "session_deny.sh")),
+		timeout: 5 * time.Second,
+	}
+	res, err = deny.Session(t.Context(), SessionEvent{Kind: KindSessionBeforeSwitch, Reason: "new"})
+	require.NoError(t, err)
+	assert.Equal(t, ActionDeny, res.Action)
+	assert.Equal(t, "dirty repo", res.Reason)
+}
+
 func TestCommandHookCommandWrongKind(t *testing.T) {
 	h := preHook(t, "allow.sh", "*", 0)
 	res, err := h.Command(t.Context(), CommandEvent{})

--- a/internal/hooks/doc.go
+++ b/internal/hooks/doc.go
@@ -1,5 +1,5 @@
-// Package hooks is the policy extension surface for phi tool calls and
-// TUI slash commands.
+// Package hooks is the policy extension surface for phi tool calls,
+// TUI slash commands, and session lifecycle.
 //
 // Hooks sit beside — not inside — the other extension layers:
 //
@@ -8,14 +8,15 @@
 //     the tool may run under workspace policy.
 //   - Hooks (this package): user/org policy, audit, and context injection around
 //     the tool loop — PreTool before Gate, PostTool after Run — plus KindCommand
-//     entries that register TUI slash commands.
+//     slash commands and session_start / session_shutdown / session_before_switch.
 //   - Tools / Jobs: what the model can invoke.
 //
 // Configuration is discovered from ~/.phi/hooks and <cwd>/.phi/hooks (see
 // doc/hooks.md). It must not be mixed into ~/.phi/config.yaml.
 //
 // [Manager] fans [Entry] values (Hook + Kind + FailClosed/Async) across the
-// tool loop and [Manager.RunCommand] for KindCommand. [Discover] / [Load]
-// build Managers from plugin.json; [CommandHook] runs external scripts via
-// stdin/stdout JSON. TUI and `phi run` call [Load] at Engine construction.
+// tool loop, [Manager.RunCommand] for KindCommand, and session lifecycle
+// methods. [Discover] / [Load] build Managers from plugin.json; [CommandHook]
+// runs external scripts via stdin/stdout JSON. TUI and `phi run` call [Load]
+// at Engine construction.
 package hooks

--- a/internal/hooks/hook.go
+++ b/internal/hooks/hook.go
@@ -10,22 +10,25 @@ import "context"
 // string or a Match that returns true for every tool means "all tools".
 // When multiple hooks match the same event, call order is not guaranteed.
 // Command is only invoked for KindCommand entries.
+// Session is only invoked for session_* kinds.
 type Hook interface {
 	Name() string
 	Match(tool string) bool
 	PreTool(ctx context.Context, ev Event) (PreResult, error)
 	PostTool(ctx context.Context, ev Event) (PostResult, error)
 	Command(ctx context.Context, ev CommandEvent) (CommandResult, error)
+	Session(ctx context.Context, ev SessionEvent) (SessionResult, error)
 }
 
 // FuncHook implements Hook with closures. Useful in tests and thin wrappers.
-// A nil MatchFn matches every tool. Nil Pre/Post return zero results.
+// A nil MatchFn matches every tool. Nil Pre/Post/Cmd/Sess return zero results.
 type FuncHook struct {
 	HookName string
 	MatchFn  func(tool string) bool
 	Pre      func(ctx context.Context, ev Event) (PreResult, error)
 	Post     func(ctx context.Context, ev Event) (PostResult, error)
 	Cmd      func(ctx context.Context, ev CommandEvent) (CommandResult, error)
+	Sess     func(ctx context.Context, ev SessionEvent) (SessionResult, error)
 }
 
 // Name returns the hook name, defaulting to "func" when unset.
@@ -66,6 +69,14 @@ func (h FuncHook) Command(ctx context.Context, ev CommandEvent) (CommandResult, 
 		return CommandResult{}, nil
 	}
 	return h.Cmd(ctx, ev)
+}
+
+// Session invokes the Sess closure, allowing when Sess is nil.
+func (h FuncHook) Session(ctx context.Context, ev SessionEvent) (SessionResult, error) {
+	if h.Sess == nil {
+		return SessionResult{Action: ActionAllow}, nil
+	}
+	return h.Sess(ctx, ev)
 }
 
 // MatchTool returns a MatchFn that equals a single tool name.

--- a/internal/hooks/manager.go
+++ b/internal/hooks/manager.go
@@ -20,9 +20,12 @@ type Kind string
 
 // Kind values select which hook event an entry participates in.
 const (
-	KindPreTool  Kind = "pre_tool"
-	KindPostTool Kind = "post_tool"
-	KindCommand  Kind = "command" // TUI slash command; not part of the tool loop
+	KindPreTool             Kind = "pre_tool"
+	KindPostTool            Kind = "post_tool"
+	KindCommand             Kind = "command" // TUI slash command; not part of the tool loop
+	KindSessionStart        Kind = "session_start"
+	KindSessionShutdown     Kind = "session_shutdown"
+	KindSessionBeforeSwitch Kind = "session_before_switch"
 )
 
 // Entry wraps a Hook with per-registration metadata.
@@ -30,29 +33,19 @@ const (
 // directory discovery and CommandHook fill these fields.
 type Entry struct {
 	Hook       Hook
-	Kind       Kind // KindPreTool, KindPostTool, or KindCommand
+	Kind       Kind
 	FailClosed bool
-	Async      bool // Post only: fire-and-forget; result ignored
+	Async      bool // Post / session_start / session_shutdown: fire-and-forget
 }
 
-// Manager fans events out to registered entries.
-//
-// PreTool runs matching KindPreTool entries serially: first Deny wins;
-// Modify chains onto Input. PostTool runs matching KindPostTool entries in
-// parallel (except Async, which is detached). Call order across entries is
-// not guaranteed — serialize logic inside one hook if order matters.
-//
-// Default failure mode is fail-open: hook errors / invalid Modify skip that
-// entry. FailClosed turns those failures into Deny (Pre) or Stop (Post).
-//
-// A nil *Manager is safe and is a no-op.
-//
-// Readonly mode (permission.ModeReadonly) should call FailClosedOnly so
-// exploratory tool loops are not stalled by slow audit hooks; security
-// hooks keep FailClosed: true and still run.
-type Manager struct {
-	entries        []Entry
-	failClosedOnly bool
+func validKind(k Kind) bool {
+	switch k {
+	case KindPreTool, KindPostTool, KindCommand,
+		KindSessionStart, KindSessionShutdown, KindSessionBeforeSwitch:
+		return true
+	default:
+		return false
+	}
 }
 
 // NewManager returns a manager over entries. Nil Hook entries are skipped.
@@ -62,12 +55,36 @@ func NewManager(entries ...Entry) *Manager {
 		if e.Hook == nil {
 			continue
 		}
-		if e.Kind != KindPreTool && e.Kind != KindPostTool && e.Kind != KindCommand {
+		if !validKind(e.Kind) {
 			continue
 		}
 		out = append(out, e)
 	}
 	return &Manager{entries: out}
+}
+
+// Manager fans events out to registered entries.
+//
+// PreTool runs matching KindPreTool entries serially: first Deny wins;
+// Modify chains onto Input. PostTool runs matching KindPostTool entries in
+// parallel (except Async, which is detached). Call order across entries is
+// not guaranteed — serialize logic inside one hook if order matters.
+//
+// SessionBeforeSwitch runs serially; first Deny wins. SessionStart and
+// SessionShutdown run in parallel (Async detached).
+//
+// Default failure mode is fail-open: hook errors / invalid Modify skip that
+// entry. FailClosed turns those failures into Deny (Pre / before_switch) or
+// Stop (Post).
+//
+// A nil *Manager is safe and is a no-op.
+//
+// Readonly mode (permission.ModeReadonly) should call FailClosedOnly so
+// exploratory tool loops are not stalled by slow audit hooks; security
+// hooks keep FailClosed: true and still run.
+type Manager struct {
+	entries        []Entry
+	failClosedOnly bool
 }
 
 // CommandEntries returns KindCommand entries. Nil-safe.
@@ -307,6 +324,139 @@ func (*Manager) runPostAsync(e Entry, ev Event) {
 	// Detach from the tool-call context so a finished turn does not abort audit hooks.
 	if _, err := e.Hook.PostTool(context.Background(), ev); err != nil {
 		debuglog.Logf("hooks: %s PostTool async: %v", e.Hook.Name(), err)
+	}
+}
+
+// SessionOutcome aggregates session lifecycle hook results for the Controller.
+type SessionOutcome struct {
+	Denied    bool
+	Reason    string
+	Toast     string
+	Status    string
+	StatusSet bool
+}
+
+// SessionBeforeSwitch runs session_before_switch entries serially. First Deny wins.
+func (m *Manager) SessionBeforeSwitch(ctx context.Context, ev SessionEvent) SessionOutcome {
+	ev.Kind = KindSessionBeforeSwitch
+	return m.runSessionGate(ctx, KindSessionBeforeSwitch, ev)
+}
+
+// SessionStart runs session_start entries (parallel; Async detached).
+func (m *Manager) SessionStart(ctx context.Context, ev SessionEvent) SessionOutcome {
+	ev.Kind = KindSessionStart
+	return m.runSessionNotify(ctx, KindSessionStart, ev)
+}
+
+// SessionShutdown runs session_shutdown entries (parallel; Async detached).
+func (m *Manager) SessionShutdown(ctx context.Context, ev SessionEvent) SessionOutcome {
+	ev.Kind = KindSessionShutdown
+	return m.runSessionNotify(ctx, KindSessionShutdown, ev)
+}
+
+func (m *Manager) runSessionGate(ctx context.Context, kind Kind, ev SessionEvent) SessionOutcome {
+	if m == nil {
+		return SessionOutcome{}
+	}
+	var out SessionOutcome
+	for _, e := range m.entries {
+		if e.Kind != kind {
+			continue
+		}
+		if m.failClosedOnly && !e.FailClosed {
+			continue
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		res, err := e.Hook.Session(ctx, ev)
+		if err != nil {
+			debuglog.Logf("hooks: %s Session: %v", e.Hook.Name(), err)
+			if e.FailClosed {
+				out.Denied = true
+				out.Reason = failClosedReason(e.Hook.Name(), err)
+				return out
+			}
+			continue
+		}
+		mergeSessionUI(&out, res)
+		if res.Action == ActionDeny {
+			out.Denied = true
+			out.Reason = res.Reason
+			if out.Reason == "" {
+				out.Reason = "session switch denied by hook " + e.Hook.Name()
+			}
+			return out
+		}
+	}
+	return out
+}
+
+func (m *Manager) runSessionNotify(ctx context.Context, kind Kind, ev SessionEvent) SessionOutcome {
+	if m == nil {
+		return SessionOutcome{}
+	}
+
+	type result struct {
+		res SessionResult
+		err error
+		e   Entry
+	}
+
+	var syncEntries []Entry
+	for _, e := range m.entries {
+		if e.Kind != kind {
+			continue
+		}
+		if m.failClosedOnly && !e.FailClosed {
+			continue
+		}
+		if e.Async {
+			go m.runSessionAsync(e, ev) //nolint:gosec // G118: async session hooks use Background on purpose
+			continue
+		}
+		syncEntries = append(syncEntries, e)
+	}
+	if len(syncEntries) == 0 {
+		return SessionOutcome{}
+	}
+
+	var wg sync.WaitGroup
+	results := make([]result, len(syncEntries))
+	for i, e := range syncEntries {
+		wg.Add(1)
+		go func(i int, e Entry) {
+			defer wg.Done()
+			res, err := e.Hook.Session(ctx, ev)
+			results[i] = result{res: res, err: err, e: e}
+		}(i, e)
+	}
+	wg.Wait()
+
+	var out SessionOutcome
+	for _, r := range results {
+		if r.err != nil {
+			debuglog.Logf("hooks: %s Session: %v", r.e.Hook.Name(), r.err)
+			continue
+		}
+		mergeSessionUI(&out, r.res)
+	}
+	return out
+}
+
+func (*Manager) runSessionAsync(e Entry, ev SessionEvent) {
+	if _, err := e.Hook.Session(context.Background(), ev); err != nil {
+		debuglog.Logf("hooks: %s Session async: %v", e.Hook.Name(), err)
+	}
+}
+
+func mergeSessionUI(out *SessionOutcome, res SessionResult) {
+	if res.Toast != "" {
+		out.Toast = res.Toast
+	}
+	if res.StatusSet {
+		out.Status = res.Status
+		out.StatusSet = true
 	}
 }
 

--- a/internal/hooks/manager_test.go
+++ b/internal/hooks/manager_test.go
@@ -365,3 +365,31 @@ func TestNewManagerFiltersInvalid(t *testing.T) {
 	assert.True(t, out.Denied)
 	assert.Equal(t, "hit", out.Reason)
 }
+
+func TestManagerSessionBeforeSwitchDeny(t *testing.T) {
+	m := NewManager(Entry{Hook: FuncHook{
+		HookName: "guard",
+		Sess: func(_ context.Context, ev SessionEvent) (SessionResult, error) {
+			assert.Equal(t, KindSessionBeforeSwitch, ev.Kind)
+			assert.Equal(t, "new", ev.Reason)
+			return SessionResult{Action: ActionDeny, Reason: "dirty"}, nil
+		},
+	}, Kind: KindSessionBeforeSwitch})
+	out := m.SessionBeforeSwitch(t.Context(), SessionEvent{Reason: "new"})
+	assert.True(t, out.Denied)
+	assert.Equal(t, "dirty", out.Reason)
+}
+
+func TestManagerSessionStartToast(t *testing.T) {
+	m := NewManager(Entry{Hook: FuncHook{
+		HookName: "boot",
+		Sess: func(_ context.Context, _ SessionEvent) (SessionResult, error) {
+			return SessionResult{Toast: "hi", Status: "on", StatusSet: true}, nil
+		},
+	}, Kind: KindSessionStart})
+	out := m.SessionStart(t.Context(), SessionEvent{Reason: "startup"})
+	assert.False(t, out.Denied)
+	assert.Equal(t, "hi", out.Toast)
+	assert.True(t, out.StatusSet)
+	assert.Equal(t, "on", out.Status)
+}

--- a/internal/hooks/plugin.go
+++ b/internal/hooks/plugin.go
@@ -23,7 +23,7 @@ const (
 // Manifest is one hook entry parsed from plugin.json.
 type Manifest struct {
 	Name       string
-	Kind       Kind // KindPreTool, KindPostTool, or KindCommand
+	Kind       Kind // KindPreTool, KindPostTool, KindCommand, or session_*
 	Match      string
 	Run        string // as written in the file (may be relative)
 	Timeout    time.Duration
@@ -166,11 +166,16 @@ func manifestFromRaw(abs, dir, pluginName string, single bool, raw pluginHookRaw
 	}
 	m.Timeout = timeout
 
-	if m.Async && m.Kind != KindPostTool {
-		return Manifest{}, fmt.Errorf("async is only valid for event %q", KindPostTool)
+	if m.Async && m.Kind != KindPostTool && m.Kind != KindSessionStart && m.Kind != KindSessionShutdown {
+		return Manifest{}, fmt.Errorf(
+			"async is only valid for event %q, %q, or %q",
+			KindPostTool,
+			KindSessionStart,
+			KindSessionShutdown,
+		)
 	}
-	if m.FailClosed && m.Kind == KindCommand {
-		return Manifest{}, fmt.Errorf("fail_closed is not valid for event %q", KindCommand)
+	if m.FailClosed && (m.Kind == KindCommand || m.Kind == KindSessionStart || m.Kind == KindSessionShutdown) {
+		return Manifest{}, fmt.Errorf("fail_closed is not valid for event %q", m.Kind)
 	}
 
 	return m, nil
@@ -184,10 +189,20 @@ func parseEvent(event string) (Kind, error) {
 		return KindPostTool, nil
 	case KindCommand:
 		return KindCommand, nil
+	case KindSessionStart:
+		return KindSessionStart, nil
+	case KindSessionShutdown:
+		return KindSessionShutdown, nil
+	case KindSessionBeforeSwitch:
+		return KindSessionBeforeSwitch, nil
 	case "":
 		return "", errors.New("missing required field \"event\"")
 	default:
-		return "", fmt.Errorf("invalid event %q (want %q, %q, or %q)", event, KindPreTool, KindPostTool, KindCommand)
+		return "", fmt.Errorf(
+			"invalid event %q (want %q, %q, %q, %q, %q, or %q)",
+			event, KindPreTool, KindPostTool, KindCommand,
+			KindSessionStart, KindSessionShutdown, KindSessionBeforeSwitch,
+		)
 	}
 }
 

--- a/internal/hooks/plugin_test.go
+++ b/internal/hooks/plugin_test.go
@@ -191,6 +191,16 @@ func TestParsePluginErrors(t *testing.T) {
 			want: "fail_closed is not valid",
 		},
 		{
+			name: "fail_closed on session_start",
+			body: `{"hooks":[{"name":"h","event":"session_start","run":"./r","fail_closed":true}]}`,
+			want: "fail_closed is not valid",
+		},
+		{
+			name: "async on session_before_switch",
+			body: `{"hooks":[{"name":"h","event":"session_before_switch","run":"./r","async":true}]}`,
+			want: "async is only valid",
+		},
+		{
 			name: "invalid json",
 			body: `{`,
 			want: "parse",
@@ -217,6 +227,25 @@ func TestParsePluginDisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ms, 1)
 	assert.True(t, ms[0].Disabled)
+}
+
+func TestParsePluginSessionEvents(t *testing.T) {
+	dir := t.TempDir()
+	path := writePluginJSON(t, dir, `{
+  "hooks": [
+    {"name":"boot","event":"session_start","run":"./a.sh","async":true},
+    {"name":"bye","event":"session_shutdown","run":"./b.sh"},
+    {"name":"guard","event":"session_before_switch","run":"./c.sh","fail_closed":true}
+  ]
+}`)
+	ms, err := ParsePlugin(path)
+	require.NoError(t, err)
+	require.Len(t, ms, 3)
+	assert.Equal(t, KindSessionStart, ms[0].Kind)
+	assert.True(t, ms[0].Async)
+	assert.Equal(t, KindSessionShutdown, ms[1].Kind)
+	assert.Equal(t, KindSessionBeforeSwitch, ms[2].Kind)
+	assert.True(t, ms[2].FailClosed)
 }
 
 func TestParsePluginFileMissing(t *testing.T) {

--- a/internal/hooks/testdata/command_ui.sh
+++ b/internal/hooks/testdata/command_ui.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# KindCommand hook: status + list UI intents.
+cat >/dev/null
+echo '{"status":"3 findings","list":{"title":"Findings","items":[{"label":"auth.go:12","detail":"nil check","submit":"fix auth.go:12"}]}}'
+exit 0

--- a/internal/hooks/testdata/session_deny.sh
+++ b/internal/hooks/testdata/session_deny.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# session_before_switch: deny.
+cat >/dev/null
+echo '{"action":"deny","reason":"dirty repo"}'
+exit 0

--- a/internal/hooks/testdata/session_start.sh
+++ b/internal/hooks/testdata/session_start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# session_start: toast + status.
+cat >/dev/null
+echo '{"toast":"session ready","status":"hooks on"}'
+exit 0

--- a/internal/hooks/types.go
+++ b/internal/hooks/types.go
@@ -47,11 +47,51 @@ type CommandEvent struct {
 	Args      []string
 }
 
+// CommandList is a palette page of selectable rows.
+type CommandList struct {
+	Title string            `json:"title"`
+	Items []CommandListItem `json:"items"`
+}
+
+// CommandListItem is one row in a CommandList.
+type CommandListItem struct {
+	Label  string `json:"label"`
+	Detail string `json:"detail"`
+	Submit string `json:"submit"`
+}
+
 // CommandResult is returned from a KindCommand hook.
-// Empty stdout with exit 0 is a silent success (both fields empty).
+// Empty stdout with exit 0 is a silent success (all fields empty).
 type CommandResult struct {
 	Submit string // if set, TUI sends this as a user message
 	Toast  string // if set, TUI shows this as a success toast
+
+	// Status updates the footer status line when StatusSet is true
+	// (empty Status clears it).
+	Status    string
+	StatusSet bool
+
+	List *CommandList // if set, TUI pushes a palette page
+}
+
+// SessionEvent is the payload for session lifecycle hooks.
+type SessionEvent struct {
+	Kind              Kind   // KindSessionStart, KindSessionShutdown, or KindSessionBeforeSwitch
+	SessionID         string // current session (before_switch: the one being left)
+	Cwd               string
+	Reason            string // startup | new | resume | quit
+	PreviousSessionID string // start after switch: the session just left
+	TargetSessionID   string // before_switch resume: destination id
+}
+
+// SessionResult is returned from a session lifecycle hook.
+type SessionResult struct {
+	Action Action // before_switch: Allow or Deny; start/shutdown ignore Deny
+	Reason string
+	Toast  string
+
+	Status    string
+	StatusSet bool
 }
 
 // PreResult is returned from PreTool.

--- a/internal/tui/controller/controller.go
+++ b/internal/tui/controller/controller.go
@@ -118,6 +118,7 @@ func NewController(bus *Bus, proj *project.Project, cwd string) (*Controller, er
 	}
 	c.engine = eng
 	c.startJobProgress()
+	c.emitSessionStart("startup", eng.SessionID(), "")
 	return c, nil
 }
 
@@ -418,7 +419,19 @@ func (c *Controller) Resume(id string) (cwdWarning string, err error) {
 	if c.sessionDir == "" {
 		return "", errors.New("session directory not configured")
 	}
+
+	prevID := c.SessionID()
+	if out := c.sessionBeforeSwitch("resume", prevID, id); out.Denied {
+		c.publishSessionEffects(out)
+		reason := out.Reason
+		if reason == "" {
+			reason = "session switch denied by hook"
+		}
+		return "", errors.New(reason)
+	}
+
 	c.Cancel()
+	c.sessionShutdown("resume", prevID)
 
 	cfg := c.modelCfg
 	if cfg.Name == "" {
@@ -456,6 +469,7 @@ func (c *Controller) Resume(id string) (cwdWarning string, err error) {
 	}
 	c.engine = eng
 	c.modelCfg = cfg
+	c.emitSessionStart("resume", eng.SessionID(), prevID)
 	return cwdWarning, nil
 }
 
@@ -465,6 +479,18 @@ func (c *Controller) Clear() error {
 	if c.sessionDir == "" {
 		return errors.New("session directory not configured")
 	}
+
+	prevID := c.SessionID()
+	if out := c.sessionBeforeSwitch("new", prevID, ""); out.Denied {
+		c.publishSessionEffects(out)
+		reason := out.Reason
+		if reason == "" {
+			reason = "session switch denied by hook"
+		}
+		return errors.New(reason)
+	}
+	c.sessionShutdown("new", prevID)
+
 	cfg := c.modelCfg
 	if cfg.Name == "" {
 		if c.proj == nil {
@@ -496,6 +522,7 @@ func (c *Controller) Clear() error {
 	}
 	c.engine = engine
 	c.modelCfg = cfg
+	c.emitSessionStart("new", engine.SessionID(), prevID)
 	return nil
 }
 
@@ -566,6 +593,7 @@ func (c *Controller) Cancel() {
 
 // Close cancels the stream and shuts down the job manager.
 func (c *Controller) Close() {
+	c.sessionShutdown("quit", c.SessionID())
 	c.Cancel()
 	if c.unsubJobs != nil {
 		c.unsubJobs()
@@ -578,6 +606,57 @@ func (c *Controller) Close() {
 		_ = c.mcpPool.Close()
 		c.mcpPool = nil
 	}
+}
+
+func (c *Controller) sessionBeforeSwitch(reason, fromID, targetID string) hooks.SessionOutcome {
+	mgr := c.Hooks()
+	if mgr == nil {
+		return hooks.SessionOutcome{}
+	}
+	return mgr.SessionBeforeSwitch(context.Background(), hooks.SessionEvent{
+		SessionID:       fromID,
+		Cwd:             c.cwd,
+		Reason:          reason,
+		TargetSessionID: targetID,
+	})
+}
+
+func (c *Controller) sessionShutdown(reason, sessionID string) {
+	mgr := c.Hooks()
+	if mgr == nil {
+		return
+	}
+	out := mgr.SessionShutdown(context.Background(), hooks.SessionEvent{
+		SessionID: sessionID,
+		Cwd:       c.cwd,
+		Reason:    reason,
+	})
+	c.publishSessionEffects(out)
+}
+
+func (c *Controller) emitSessionStart(reason, sessionID, previousID string) {
+	mgr := c.Hooks()
+	if mgr == nil {
+		return
+	}
+	out := mgr.SessionStart(context.Background(), hooks.SessionEvent{
+		SessionID:         sessionID,
+		Cwd:               c.cwd,
+		Reason:            reason,
+		PreviousSessionID: previousID,
+	})
+	c.publishSessionEffects(out)
+}
+
+func (c *Controller) publishSessionEffects(out hooks.SessionOutcome) {
+	if out.Toast == "" && !out.StatusSet {
+		return
+	}
+	c.publish(HookSessionEffectsMsg{
+		Toast:     out.Toast,
+		Status:    out.Status,
+		StatusSet: out.StatusSet,
+	})
 }
 
 // Alive reports whether the stream generation still matches gen.

--- a/internal/tui/controller/msg.go
+++ b/internal/tui/controller/msg.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"github.com/pulseaiclub/phi/internal/hooks"
 	"github.com/pulseaiclub/phi/internal/job"
 	"github.com/pulseaiclub/phi/internal/permission"
 	"github.com/pulseaiclub/phi/internal/session"
@@ -92,13 +93,25 @@ func (UpdateAvailableMsg) isMsg() {}
 
 // HookCommandResultMsg delivers the result of a KindCommand hook slash command.
 type HookCommandResultMsg struct {
-	Gen    uint64
-	Submit string
-	Toast  string
-	Err    string
+	Gen       uint64
+	Submit    string
+	Toast     string
+	Status    string
+	StatusSet bool
+	List      *hooks.CommandList
+	Err       string
 }
 
 func (HookCommandResultMsg) isMsg() {}
+
+// HookSessionEffectsMsg applies toast/status from session lifecycle hooks.
+type HookSessionEffectsMsg struct {
+	Toast     string
+	Status    string
+	StatusSet bool
+}
+
+func (HookSessionEffectsMsg) isMsg() {}
 
 // JobProgressMsg carries a live sub-agent tool update for the nested tree UI.
 type JobProgressMsg struct {

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -71,6 +71,7 @@ type Editor struct {
 	lastUsage     session.TokenUsage
 
 	updateHint string // footer right: "vX.Y.Z available · phi update"
+	hookStatus string // footer left override from command/session hooks
 
 	permAsk     *permAskState
 	continueAsk *continueAskState
@@ -447,6 +448,13 @@ func (editor *Editor) Update(m controller.Msg) {
 	case controller.HookCommandResultMsg:
 		if editor.hookCmds != nil {
 			editor.hookCmds.Apply(msg)
+		}
+	case controller.HookSessionEffectsMsg:
+		if msg.StatusSet {
+			editor.hookStatus = msg.Status
+		}
+		if msg.Toast != "" {
+			editor.toast.Show(msg.Toast, toast.ToastSuccess, 3*time.Second)
 		}
 	case controller.JobProgressMsg:
 		// Applied in drainBus so we can skip Sync when the tree is unchanged.

--- a/internal/tui/hook_commands.go
+++ b/internal/tui/hook_commands.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pulseaiclub/phi/internal/components/palette"
 	"github.com/pulseaiclub/phi/internal/components/toast"
 	"github.com/pulseaiclub/phi/internal/debuglog"
 	"github.com/pulseaiclub/phi/internal/hooks"
@@ -89,7 +90,14 @@ func (h *HookCommands) run(name string, args []string) {
 		e.Publish(controller.HookCommandResultMsg{Gen: gen, Err: err.Error()})
 		return
 	}
-	e.Publish(controller.HookCommandResultMsg{Gen: gen, Submit: res.Submit, Toast: res.Toast})
+	e.Publish(controller.HookCommandResultMsg{
+		Gen:       gen,
+		Submit:    res.Submit,
+		Toast:     res.Toast,
+		Status:    res.Status,
+		StatusSet: res.StatusSet,
+		List:      res.List,
+	})
 }
 
 // Apply delivers a finished hook command onto the UI goroutine.
@@ -102,18 +110,78 @@ func (h *HookCommands) Apply(msg controller.HookCommandResultMsg) {
 		e.toast.Show(msg.Err, toast.ToastError, 3*time.Second)
 		return
 	}
+	h.applyIntents(msg)
+}
+
+// applyIntents applies status / toast / list / submit.
+func (h *HookCommands) applyIntents(msg controller.HookCommandResultMsg) {
+	e := h.e
+	if msg.StatusSet {
+		e.hookStatus = msg.Status
+	}
+	if msg.Toast != "" {
+		e.toast.Show(msg.Toast, toast.ToastSuccess, 3*time.Second)
+	}
+	if msg.List != nil && len(msg.List.Items) > 0 {
+		h.pushList(*msg.List)
+		return
+	}
 	if msg.Submit != "" {
 		if e.isBusy() {
 			e.toast.Show("Cannot submit hook command while a reply is running", toast.ToastWarning, 3*time.Second)
 			return
 		}
-		if msg.Toast != "" {
-			e.toast.Show(msg.Toast, toast.ToastSuccess, 3*time.Second)
-		}
 		e.handleSubmit(msg.Submit)
+	}
+}
+
+func (h *HookCommands) pushList(list hooks.CommandList) {
+	e := h.e
+	title := list.Title
+	if title == "" {
+		title = "Hook"
+	}
+	cmds := make([]palette.PaletteCommand, 0, len(list.Items))
+	for _, item := range list.Items {
+		item := item
+		label := item.Label
+		if label == "" {
+			label = item.Submit
+		}
+		if label == "" {
+			continue
+		}
+		cmds = append(cmds, palette.PaletteCommand{
+			Verb:     label,
+			Keywords: keywordsForDetail(item.Detail),
+			Run: func() {
+				if item.Submit == "" {
+					return
+				}
+				if e.isBusy() {
+					e.toast.Show("Cannot submit while a reply is running", toast.ToastWarning, 3*time.Second)
+					return
+				}
+				e.handleSubmit(item.Submit)
+			},
+		})
+	}
+	if len(cmds) == 0 {
+		e.toast.Show("Hook list had no usable items", toast.ToastWarning, 3*time.Second)
 		return
 	}
-	if msg.Toast != "" {
-		e.toast.Show(msg.Toast, toast.ToastSuccess, 3*time.Second)
+	if !e.palette.Open {
+		e.palette.Show()
 	}
+	e.palette.Push(title, cmds)
+	if e.App != nil {
+		e.App.RequestFocus(&e.palette)
+	}
+}
+
+func keywordsForDetail(detail string) []string {
+	if detail == "" {
+		return nil
+	}
+	return []string{detail}
 }

--- a/internal/tui/hook_commands.go
+++ b/internal/tui/hook_commands.go
@@ -143,7 +143,6 @@ func (h *HookCommands) pushList(list hooks.CommandList) {
 	}
 	cmds := make([]palette.PaletteCommand, 0, len(list.Items))
 	for _, item := range list.Items {
-		item := item
 		label := item.Label
 		if label == "" {
 			label = item.Submit

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -158,6 +158,13 @@ func (l *EditorLayout) drawFooter(ctx components.DrawContext, width int) compone
 	footer := components.NewSurface(width, 1, nil)
 	dim := e.theme.Muted
 	msg := e.activity.Label(e.snap)
+	if hs := strings.TrimSpace(e.hookStatus); hs != "" {
+		if msg == "" {
+			msg = hs
+		} else {
+			msg = hs + " · " + msg
+		}
+	}
 	if e.ctrl != nil {
 		if n := e.ctrl.LiveJobCount(); n > 0 {
 			jobBit := fmt.Sprintf("%d job", n)

--- a/internal/tui/session_actions.go
+++ b/internal/tui/session_actions.go
@@ -117,6 +117,9 @@ func (s *SessionActions) Resume(id string) {
 		e.toast.Show(err.Error(), toast.ToastError, 4*time.Second)
 		return
 	}
+	if e.hookCmds != nil {
+		e.hookCmds.Sync()
+	}
 	e.snap = e.ctrl.ReplaySnapshot()
 	e.list.Entries = nil
 	e.listIDs = nil


### PR DESCRIPTION
- Added new session lifecycle events: `session_start`, `session_shutdown`, and `session_before_switch`.
- Introduced command UI intents for `status` and `list` in hooks.
- Updated documentation and tests to reflect these changes, ensuring proper handling of session events and command results.