### PR TITLE
fix(release): apply CHANGELOG section as release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,19 @@ jobs:
 
       - name: Extract release notes from CHANGELOG.md
         run: |
-          scripts/changelog-extract.sh "${{ github.ref_name }}" > /tmp/release-notes.md
+          scripts/changelog-extract.sh "${{ github.ref_name }}" > release-notes.md
           echo "---- release notes ----"
-          cat /tmp/release-notes.md
+          cat release-notes.md
+          if [[ ! -s release-notes.md ]]; then
+            echo "error: release-notes.md is empty (no CHANGELOG section for ${{ github.ref_name }}?)" >&2
+            exit 1
+          fi
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
-          args: release --clean --release-notes /tmp/release-notes.md
+          version: '~> v2'
+          args: release --clean --release-notes=release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,8 @@ changelog:
 release:
   draft: false
   prerelease: auto
+  # Always apply --release-notes from release.yml (replace existing body on re-runs).
+  mode: replace
 
 # Optional Homebrew tap release (requires additional config)
 # brews:

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -4,7 +4,7 @@
 #
 # Updates internal/version/version.go, commits the change, and creates an annotated
 # git tag. Pushing the tag triggers .github/workflows/release.yml (GoReleaser);
-# the changelog is generated from commit history.
+# release notes come from the matching CHANGELOG.md section (see release.yml).
 # Example: ./scripts/bump.sh v0.2.0
 
 set -euo pipefail


### PR DESCRIPTION
GoReleaser was publishing the default "Release vX.Y.Z" body because the notes file lived in /tmp and the action ran in a different container. Write notes to release-notes.md, pass them via --release-notes=release-notes.md, and set release.mode: replace so re-runs overwrite the existing body. Fail the workflow early if the matching CHANGELOG section is empty.