### PR TITLE
refactor(tui): drop activity nil guards, split submit paths

### DIFF
--- a/internal/tui/overlays/overlays.go
+++ b/internal/tui/overlays/overlays.go
@@ -149,9 +149,7 @@ func (o *Overlays) beginPermissionAsk(msg controller.PermissionAskMsg) {
 		o.composer.HidePalette()
 	}
 	o.perm = newPermAskState(msg.Request, msg.Reason, msg.Reply)
-	if o.activity != nil {
-		o.activity.Apply(controller.ActivityAwaitingApproval)
-	}
+	o.activity.Apply(controller.ActivityAwaitingApproval)
 	if o.focusEditor != nil {
 		o.focusEditor()
 	}
@@ -203,9 +201,7 @@ func (o *Overlays) beginContinueAsk(msg controller.ContinueAskMsg) {
 		o.composer.HidePalette()
 	}
 	o.cont = newContinueAskState(msg.MaxRounds, msg.Reply)
-	if o.activity != nil {
-		o.activity.Apply(controller.ActivityAwaitingApproval)
-	}
+	o.activity.Apply(controller.ActivityAwaitingApproval)
 	if o.focusEditor != nil {
 		o.focusEditor()
 	}

--- a/internal/tui/submit/submitter.go
+++ b/internal/tui/submit/submitter.go
@@ -86,15 +86,19 @@ func (s *Submitter) Submit(text string) {
 		if s.bash != nil && s.bash.HandleSubmit(text) {
 			return
 		}
-	}
-	if strings.HasPrefix(text, "/") {
+	} else if strings.HasPrefix(text, "/") {
 		if s.dispatchSlash(text) {
 			s.composer.HideCompleters()
 			s.composer.ClearInput()
 			s.composer.SyncBashBorder("")
 			return
 		}
+	} else {
+		s.handleUserInput(text)
 	}
+}
+
+func (s *Submitter) handleUserInput(text string) {
 	pendingSkills := s.composer.PendingSkills()
 	if (text == "" && len(pendingSkills) == 0) || s.IsBusy() {
 		return
@@ -102,9 +106,7 @@ func (s *Submitter) Submit(text string) {
 
 	s.composer.CloseMentionSlash()
 
-	if s.activity != nil {
-		s.activity.Apply(controller.ActivitySubmitting)
-	}
+	s.activity.Apply(controller.ActivitySubmitting)
 	display := text
 	if display == "" && len(pendingSkills) > 0 {
 		display = "Skills: " + strings.Join(pendingSkills, ", ")
@@ -112,9 +114,8 @@ func (s *Submitter) Submit(text string) {
 	s.transcript.ApplySession(session.UserAppend{Text: display})
 	s.transcript.Sync()
 	s.transcript.StickToBottom()
-	if s.activity != nil {
-		s.activity.Apply(controller.ActivityWaiting)
-	}
+
+	s.activity.Apply(controller.ActivityWaiting)
 
 	s.composer.ClearInput()
 	s.composer.ClearPendingSkills()
@@ -143,9 +144,7 @@ func (s *Submitter) Cancel() {
 	}
 	s.transcript.ApplySession(session.CancelStreaming{})
 	s.transcript.Sync()
-	if s.activity != nil {
-		s.activity.Apply(controller.ActivityCancelled)
-	}
+	s.activity.Apply(controller.ActivityCancelled)
 	if s.publish != nil {
 		time.AfterFunc(1200*time.Millisecond, func() {
 			s.publish(controller.ClearIfActivityMsg{If: controller.ActivityCancelled})

--- a/internal/tui/submit/submitter.go
+++ b/internal/tui/submit/submitter.go
@@ -86,16 +86,16 @@ func (s *Submitter) Submit(text string) {
 		if s.bash != nil && s.bash.HandleSubmit(text) {
 			return
 		}
-	} else if strings.HasPrefix(text, "/") {
+	}
+	if strings.HasPrefix(text, "/") {
 		if s.dispatchSlash(text) {
 			s.composer.HideCompleters()
 			s.composer.ClearInput()
 			s.composer.SyncBashBorder("")
 			return
 		}
-	} else {
-		s.handleUserInput(text)
 	}
+	s.handleUserInput(text)
 }
 
 func (s *Submitter) handleUserInput(text string) {

--- a/internal/tui/submit/submitter_test.go
+++ b/internal/tui/submit/submitter_test.go
@@ -3,8 +3,13 @@ package submit
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/status"
+	"github.com/pulseaiclub/phi/internal/session"
+	"github.com/pulseaiclub/phi/internal/tui/commands"
 	"github.com/pulseaiclub/phi/internal/tui/controller"
 	"github.com/pulseaiclub/phi/internal/tui/transcript"
 )
@@ -57,4 +62,53 @@ func TestSubmitter_StreamActive_activity(t *testing.T) {
 	if !sub.StreamActive() {
 		t.Fatal("expected stream active while waiting")
 	}
+}
+
+func TestSubmitter_Submit_unknownSlashFallsThroughToAgent(t *testing.T) {
+	th := components.DefaultTheme()
+	spin := status.NewSpinner(th.ToolName)
+	tp := transcript.NewTranscriptPane(th, spin, "Phi test")
+	sub := NewSubmitter(
+		nil,
+		commands.NewBuiltinRegistry(),
+		tp,
+		nil,
+		stubComposer{},
+		nil,
+		func() commands.CommandContext { return commands.CommandContext{} },
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	sub.Submit("/not-a-real-command")
+	require.Len(t, tp.Snapshot().Messages, 1)
+	assert.Equal(t, "/not-a-real-command", tp.Snapshot().Messages[0].Text)
+	assert.Equal(t, session.RoleUser, tp.Snapshot().Messages[0].Role)
+}
+
+func TestSubmitter_Submit_bareBangFallsThroughToAgent(t *testing.T) {
+	th := components.DefaultTheme()
+	spin := status.NewSpinner(th.ToolName)
+	tp := transcript.NewTranscriptPane(th, spin, "Phi test")
+	sub := NewSubmitter(
+		nil,
+		nil,
+		tp,
+		nil,
+		stubComposer{},
+		NewBashRunner(tp, stubComposer{}, nil, nil),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	sub.Submit("!")
+	require.Len(t, tp.Snapshot().Messages, 1)
+	assert.Equal(t, "!", tp.Snapshot().Messages[0].Text)
 }


### PR DESCRIPTION
Split the user-prompt branch out of Submit into handleUserInput and turn the bash/slash checks into an if-else chain. Remove now-dead activity nil guards in overlays and submitter since activity is always wired at construction; keep the guard in StreamActive.