### PR TITLE
feat(run): add --yolo flag to skip permission checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `phi run --yolo`: skip all permission checks for one headless run (benchmarks / CI).
 - Hooks: session lifecycle events now include `usage` — token counts of the latest completed assistant turn.
 - Hooks: `post_turn` event fires after each completed assistant stream with per-round `usage` (for audit metrics such as cache hit ratio).
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Flags:
 | -------------------- | ---------------------------------------------- |
 | `-p, --prompt STRING`| Prompt to run (required)                       |
 | `--jsonl`            | Emit JSONL events to stdout                    |
+| `--yolo`             | Skip all permission checks for this run (benchmarks / CI only) |
 | `--max-rounds N`     | Cap tool rounds (default 64)                   |
 | `--timeout DURATION` | Limit the agent run wall-clock time (e.g. `10m`; disabled by default) |
 | `--session ID`       | Resume a persisted session by id or unique prefix |
@@ -279,7 +280,9 @@ In the interactive TUI, exhausting the tool-round budget prompts Continue /
 Stop. Headless `phi run` has no confirmation UI, so it exits with code 2.
 
 In headless mode, permission `ask` decisions are denied (there is no approval
-UI), so `readonly`-style safety applies without extra flags.
+UI), so `readonly`-style safety applies without extra flags. For benchmarks
+that need arbitrary shell (`pytest`, `npm test`, …), pass `--yolo` to skip the
+permission gate for that run only.
 
 ## Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -270,6 +270,7 @@ phi run -p "fix the failing test in internal/tools"
 | -------------------- | ---------------------------------------------- |
 | `-p, --prompt STRING` | 要运行的提示词（必填） |
 | `--jsonl` | 向 stdout 输出 JSONL 事件 |
+| `--yolo` | 本次运行跳过所有权限检查（仅用于 benchmark / CI） |
 | `--max-rounds N` | 限制工具轮数（默认 64） |
 | `--timeout DURATION` | 限制 Agent 运行总时长（例如 `10m`，默认不限制） |
 | `--session ID` | 按 id 或唯一前缀恢复已持久化的会话 |
@@ -283,7 +284,8 @@ phi run -p "fix the failing test in internal/tools"
 无头 `phi run` 没有确认界面，因此直接以退出码 2 结束。
 
 无头模式下，权限 `ask` 的决策会被拒绝（没有审批界面），因此无需额外参数
-即可获得 `readonly` 级别的安全性。
+即可获得 `readonly` 级别的安全性。跑 benchmark 需要任意 shell（`pytest`、
+`npm test` 等）时，对该次运行加 `--yolo` 即可跳过权限门控。
 
 ## Skills（技能）
 

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -51,7 +51,8 @@ type runBootstrap struct {
 // loadRunBootstrap wires the shared startup path used by `phi run` (and any
 // future headless subcommand). It must stay in sync with the TUI controller's
 // initialization; search-tool install failures are non-fatal warnings.
-func loadRunBootstrap(ctx context.Context, sessionDirOverride string) (*runBootstrap, error) {
+// When yolo is true, permission checks are skipped for this run only.
+func loadRunBootstrap(ctx context.Context, sessionDirOverride string, yolo bool) (*runBootstrap, error) {
 	proj := project.GetDefaultProject()
 	if err := proj.LoadConfig(); err != nil {
 		return nil, err
@@ -59,7 +60,11 @@ func loadRunBootstrap(ctx context.Context, sessionDirOverride string) (*runBoots
 	if err := EnsureSearchTools(ctx, proj); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: could not install search tools:", err)
 	}
-	gate, err := HeadlessGate(proj.Config().Permissions)
+	policy := proj.Config().Permissions
+	if yolo {
+		policy.DangerouslyAllowAll = true
+	}
+	gate, err := HeadlessGate(policy)
 	if err != nil {
 		return nil, fmt.Errorf("permissions: %w", err)
 	}

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -131,3 +131,25 @@ func TestHeadlessGateDangerouslyAllowAll(t *testing.T) {
 	})
 	assert.Equal(t, permission.Allow, dec)
 }
+
+func TestLoadRunBootstrapYolo(t *testing.T) {
+	p, _ := testProject(t)
+	cfgPath := p.Global().ConfigFile()
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`models:
+  - name: m
+    api_key: k
+permissions:
+  mode: headless-strict
+`), 0o644))
+
+	bs, err := loadRunBootstrap(t.Context(), "", true)
+	require.NoError(t, err)
+	require.NotNil(t, bs.Gate)
+
+	dec, _ := bs.Gate.Check(t.Context(), permission.Request{
+		Action:  permission.ActionBash,
+		Command: "pip install numpy",
+	})
+	assert.Equal(t, permission.Allow, dec)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,6 +22,7 @@ import (
 type runOptions struct {
 	prompt       string
 	jsonl        bool
+	yolo         bool
 	maxRounds    int
 	timeout      time.Duration
 	session      string
@@ -54,10 +55,13 @@ func runCmd(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	bs, err := loadRunBootstrap(ctx, opts.sessionDir)
+	bs, err := loadRunBootstrap(ctx, opts.sessionDir, opts.yolo)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "phi run:", err)
 		return ExitUsage
+	}
+	if opts.yolo {
+		fmt.Fprintln(os.Stderr, "warning: --yolo skips all permission checks for this run")
 	}
 
 	resumeID, resumePath := "", ""
@@ -226,6 +230,8 @@ func parseRunArgs(args []string) (runOptions, error) {
 			o.help = true
 		case arg == "--jsonl":
 			o.jsonl = true
+		case arg == "--yolo":
+			o.yolo = true
 		case arg == "--continue-last":
 			o.continueLast = true
 		case arg == "-p" || arg == "--prompt":
@@ -304,6 +310,7 @@ Run one agent loop headlessly and exit. Human logs go to stderr; with
 flags:
   -p, --prompt STRING   prompt to run (required)
       --jsonl           emit JSONL events to stdout
+      --yolo            skip all permission checks for this run (benchmarks / CI only)
       --max-rounds N    cap tool rounds (default 64)
       --timeout DURATION stop after a wall-clock duration (e.g. 10m; default unlimited)
       --session ID      resume a persisted session by id or unique prefix

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -25,6 +25,7 @@ func TestParseRunArgs(t *testing.T) {
 	opts, err := parseRunArgs([]string{
 		"-p", "do the thing",
 		"--jsonl",
+		"--yolo",
 		"--max-rounds", "10",
 		"--timeout", "10m",
 		"--session", "abc123",
@@ -32,6 +33,7 @@ func TestParseRunArgs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "do the thing", opts.prompt)
 	assert.True(t, opts.jsonl)
+	assert.True(t, opts.yolo)
 	assert.Equal(t, 10, opts.maxRounds)
 	assert.Equal(t, 10*time.Minute, opts.timeout)
 	assert.Equal(t, "abc123", opts.session)


### PR DESCRIPTION
Headless runs have no approval UI, so `ask` decisions are denied by default. Add --yolo for benchmarks/CI that need arbitrary shell (pytest, npm test, ...): it sets DangerouslyAllowAll for this run only and prints a warning. Documented in READMEs and CHANGELOG.