### PR TITLE
feat(run): add --tools builtin filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - `phi run --yolo`: skip all permission checks for one headless run (benchmarks / CI).
+- `phi run --tools`: limit a headless run to selected built-in tools.
 - Hooks: session lifecycle events now include `usage` — token counts of the latest completed assistant turn.
 - Hooks: `post_turn` event fires after each completed assistant stream with per-round `usage` (for audit metrics such as cache hit ratio).
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ Flags:
 | `--session ID`       | Resume a persisted session by id or unique prefix |
 | `--continue-last`    | Resume the newest persisted session for this directory |
 | `--session-dir DIR`  | Override the session storage directory         |
+| `--tools LIST`       | Enable only these comma-separated built-in tools |
+
+`--tools` accepts built-in names such as `read,ls,grep`. MCP and agent tools
+still append when configured; the flag only scopes the built-in toolset.
 
 Exit codes: `0` success · `1` runtime/LLM error · `2` max rounds reached ·
 `3` config/usage error.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -276,6 +276,10 @@ phi run -p "fix the failing test in internal/tools"
 | `--session ID` | 按 id 或唯一前缀恢复已持久化的会话 |
 | `--continue-last` | 恢复当前目录最新的持久化会话 |
 | `--session-dir DIR` | 覆盖会话存储目录 |
+| `--tools LIST` | 仅启用逗号分隔的指定内置工具 |
+
+`--tools` 接受 `read,ls,grep` 之类的内置工具名称。已配置的 MCP 和 agent
+工具仍会照常追加；该参数只限制内置工具集。
 
 退出码：`0` 成功 · `1` 运行时/LLM 错误 · `2` 达到最大轮数 ·
 `3` 配置/用法错误。

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/pulseaiclub/phi/internal/hooks"
 	"github.com/pulseaiclub/phi/internal/mcp"
 	"github.com/pulseaiclub/phi/internal/session"
+	"github.com/pulseaiclub/phi/internal/tools"
 )
 
 // runOptions holds parsed `phi run` flags.
@@ -28,6 +30,7 @@ type runOptions struct {
 	session      string
 	continueLast bool
 	sessionDir   string
+	builtinTools []tools.Tool
 	help         bool
 }
 
@@ -95,6 +98,7 @@ func runCmd(args []string) int {
 		// does not fold Ask).
 		Ask:   nil,
 		Hooks: loadRunHooks(bs),
+		Tools: opts.builtinTools,
 	}
 	if pool, err := mcp.LoadPool(bs.Proj.MCPConfigFile()); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: mcp:", err)
@@ -294,11 +298,75 @@ func parseRunArgs(args []string) (runOptions, error) {
 			o.sessionDir = v
 		case strings.HasPrefix(arg, "--session-dir="):
 			o.sessionDir = strings.TrimPrefix(arg, "--session-dir=")
+		case arg == "--tools":
+			v, err := next(arg)
+			if err != nil {
+				return o, err
+			}
+			o.builtinTools, err = selectBuiltinTools(v)
+			if err != nil {
+				return o, err
+			}
+		case strings.HasPrefix(arg, "--tools="):
+			var err error
+			o.builtinTools, err = selectBuiltinTools(strings.TrimPrefix(arg, "--tools="))
+			if err != nil {
+				return o, err
+			}
 		default:
 			return o, fmt.Errorf("unknown flag %q", arg)
 		}
 	}
 	return o, nil
+}
+
+func selectBuiltinTools(raw string) ([]tools.Tool, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, errors.New("--tools requires at least one built-in tool name")
+	}
+
+	requested := make(map[string]struct{})
+	for part := range strings.SplitSeq(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, errors.New("--tools contains an empty tool name")
+		}
+		requested[name] = struct{}{}
+	}
+
+	defaults := tools.DefaultTools()
+	available := make([]string, 0, len(defaults))
+	selected := make([]tools.Tool, 0, len(requested))
+	// Keep the default schema order stable regardless of flag order; the map
+	// also collapses duplicate names without exposing duplicate definitions.
+	for _, tool := range defaults {
+		name := tool.Definition.Name
+		available = append(available, name)
+		if _, ok := requested[name]; ok {
+			selected = append(selected, tool)
+			delete(requested, name)
+		}
+	}
+
+	if len(requested) > 0 {
+		unknown := make([]string, 0, len(requested))
+		for name := range requested {
+			unknown = append(unknown, strconv.Quote(name))
+		}
+		sort.Strings(unknown)
+		noun := "tool"
+		if len(unknown) > 1 {
+			noun = "tools"
+		}
+		return nil, fmt.Errorf(
+			"--tools contains unknown built-in %s %s (available: %s)",
+			noun,
+			strings.Join(unknown, ", "),
+			strings.Join(available, ", "),
+		)
+	}
+
+	return selected, nil
 }
 
 func printRunUsage(w *os.File) {
@@ -316,6 +384,7 @@ flags:
       --session ID      resume a persisted session by id or unique prefix
       --continue-last   resume the newest persisted session for this directory
       --session-dir DIR override the session storage directory
+      --tools LIST      enable only these built-in tools (comma-separated)
   -h, --help            show this help
 
 exit codes:

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/agent"
+	"github.com/pulseaiclub/phi/internal/job"
 	"github.com/pulseaiclub/phi/internal/llm"
+	"github.com/pulseaiclub/phi/internal/mcp"
 	"github.com/pulseaiclub/phi/internal/permission"
 	"github.com/pulseaiclub/phi/internal/session"
+	"github.com/pulseaiclub/phi/internal/tools"
 )
 
 func TestParseRunArgs(t *testing.T) {
@@ -29,6 +32,7 @@ func TestParseRunArgs(t *testing.T) {
 		"--max-rounds", "10",
 		"--timeout", "10m",
 		"--session", "abc123",
+		"--tools", "grep, read,grep",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "do the thing", opts.prompt)
@@ -37,6 +41,7 @@ func TestParseRunArgs(t *testing.T) {
 	assert.Equal(t, 10, opts.maxRounds)
 	assert.Equal(t, 10*time.Minute, opts.timeout)
 	assert.Equal(t, "abc123", opts.session)
+	assert.Equal(t, []string{"read", "grep"}, toolNames(opts.builtinTools))
 	assert.False(t, opts.continueLast)
 }
 
@@ -47,6 +52,7 @@ func TestParseRunArgsEqualsForms(t *testing.T) {
 		"--timeout=1500ms",
 		"--session-dir=/tmp/sess",
 		"--continue-last",
+		"--tools=write,bash",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "hi", opts.prompt)
@@ -54,23 +60,81 @@ func TestParseRunArgsEqualsForms(t *testing.T) {
 	assert.Equal(t, 1500*time.Millisecond, opts.timeout)
 	assert.Equal(t, "/tmp/sess", opts.sessionDir)
 	assert.True(t, opts.continueLast)
+	assert.Equal(t, []string{"bash", "write"}, toolNames(opts.builtinTools))
 }
 
 func TestParseRunArgsErrors(t *testing.T) {
 	cases := [][]string{
-		{"--prompt"},            // missing value
-		{"--max-rounds", "abc"}, // non-integer
-		{"--max-rounds", "0"},   // non-positive
-		{"--timeout"},           // missing value
-		{"--timeout", "abc"},    // invalid duration
-		{"--timeout", "0"},      // non-positive
-		{"--timeout", "-1s"},    // non-positive
-		{"--bogus", "x"},        // unknown flag
+		{"--prompt"},             // missing value
+		{"--max-rounds", "abc"},  // non-integer
+		{"--max-rounds", "0"},    // non-positive
+		{"--timeout"},            // missing value
+		{"--timeout", "abc"},     // invalid duration
+		{"--timeout", "0"},       // non-positive
+		{"--timeout", "-1s"},     // non-positive
+		{"--tools"},              // missing value
+		{"--tools="},             // empty list
+		{"--tools", "read,,ls"},  // empty name
+		{"--tools", "read,nope"}, // unknown name
+		{"--bogus", "x"},         // unknown flag
 	}
 	for _, args := range cases {
 		_, err := parseRunArgs(args)
 		assert.Error(t, err, "args %v should error", args)
 	}
+}
+
+func TestParseRunArgsLeavesBuiltinToolsUnsetByDefault(t *testing.T) {
+	opts, err := parseRunArgs([]string{"-p", "hi"})
+	require.NoError(t, err)
+	assert.Nil(t, opts.builtinTools)
+}
+
+func toolNames(list []tools.Tool) []string {
+	names := make([]string, 0, len(list))
+	for _, tool := range list {
+		names = append(names, tool.Definition.Name)
+	}
+	return names
+}
+
+func TestSelectBuiltinToolsErrorListsAvailableNames(t *testing.T) {
+	_, err := selectBuiltinTools("read,nope,missing")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `unknown built-in tools "missing", "nope"`)
+	assert.ErrorContains(t, err, "available: bash, read, write, grep, ls, edit, find")
+}
+
+func TestSelectedBuiltinToolsStillAppendExternalTools(t *testing.T) {
+	selected, err := selectBuiltinTools("read")
+	require.NoError(t, err)
+	pool := mcp.NewPool(map[string]mcp.ServerConfig{
+		"echo": {Command: []string{"true"}},
+	})
+	t.Cleanup(func() { require.NoError(t, pool.Close()) })
+	jobs, err := job.New(job.Options{
+		Root: t.TempDir(),
+		Runner: job.RunnerFunc(func(_ context.Context, _ job.RunEnv) (string, error) {
+			return "ok", nil
+		}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, jobs.Close(t.Context())) })
+
+	engine, err := agent.NewEngine(agent.EngineOpts{
+		Model:       llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
+		SessionOpts: agent.SessionOpts{Cwd: t.TempDir()},
+		Tools:       selected,
+		MCP:         pool,
+		Jobs:        jobs,
+	})
+	require.NoError(t, err)
+	assert.True(t, engine.HasTool("read"))
+	assert.False(t, engine.HasTool("bash"))
+	for _, name := range []string{"mcp_list", "mcp_inspect", "mcp_call"} {
+		assert.True(t, engine.HasTool(name), "MCP tool %q should still be appended", name)
+	}
+	assert.True(t, engine.HasTool("agent_spawn"))
 }
 
 func TestRunLoopTimeoutCancelsLLMRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `--tools LIST` and `--tools=LIST` to scope `phi run` to selected built-in tools
- normalize whitespace and duplicates in stable default order, with actionable errors for empty or unknown names
- preserve configured MCP and agent meta-tools while filtering only the built-in toolset
- document the flag in both READMEs and the Unreleased changelog

Closes #95

## Test plan

- `make fmt-check`
- `make lint` (0 issues)
- `make test`
- `make build BINARY=/tmp/phi-tools-filter`
- verified `phi run --help` lists `--tools`
- verified an unknown tool exits 3 and lists all available built-ins

## AI assistance

OpenAI Codex assisted with issue analysis, implementation, tests, and PR preparation.