### PR TITLE
add image support to llm messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Minimal Go terminal coding-agent harness. Layout: [doc/project-layout.md](doc/pr
 - **Stay lean.** Direct module deps are few on purpose. Don't add a dependency without a clear need.
 - **Format with `make fmt`** (gofumpt / goimports / golines, 120 cols, local prefix `github.com/pulseaiclub/phi`). Don't hand-fight import groups.
 - **`testing` / `testify` stay in `*_test.go`.** `depguard` will fail the lint otherwise.
+- **Tests use testify** (`assert` / `require`) for assertions — no raw `t.Fatalf` checks.
 - After dependency changes: `go mod tidy`. `go.mod` is not generated.
 
 ## Contributor Guidelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `phi run --tools`: limit a headless run to selected built-in tools.
 - Hooks: session lifecycle events now include `usage` — token counts of the latest completed assistant turn.
 - Hooks: `post_turn` event fires after each completed assistant stream with per-round `usage` (for audit metrics such as cache hit ratio).
-- `llm.Message` carries an `images` field (base64 + MIME type); OpenAI-compatible and Anthropic requests now serialize attached images (`image_url` data URLs / `image` source blocks).
+- `util/image.Load` reads an image file (raw bytes + content-sniffed MIME type; png/jpeg/gif/webp, up to 10 MiB).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `phi run --tools`: limit a headless run to selected built-in tools.
 - Hooks: session lifecycle events now include `usage` — token counts of the latest completed assistant turn.
 - Hooks: `post_turn` event fires after each completed assistant stream with per-round `usage` (for audit metrics such as cache hit ratio).
+- `llm.Message` carries an `images` field (base64 + MIME type); OpenAI-compatible and Anthropic requests now serialize attached images (`image_url` data URLs / `image` source blocks).
 
 ### Changed
 

--- a/internal/llm/anthropic/anthropic_test.go
+++ b/internal/llm/anthropic/anthropic_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/llm"
 )
 
@@ -105,19 +108,13 @@ func TestBuildRequestUserImages(t *testing.T) {
 		},
 	}, nil)
 
-	if len(req.Messages) != 1 {
-		t.Fatalf("expected 1 user message, got %d", len(req.Messages))
-	}
+	require.Len(t, req.Messages, 1)
 	blocks, ok := req.Messages[0].Content.([]anthropicContentBlock)
-	if !ok {
-		t.Fatalf("expected content blocks, got %T", req.Messages[0].Content)
-	}
-	if len(blocks) != 3 {
-		t.Fatalf("expected 3 blocks (text + 2 images), got %d", len(blocks))
-	}
-	if blocks[0].Type != "text" || blocks[0].Text != "what is this?" {
-		t.Fatalf("unexpected text block: %+v", blocks[0])
-	}
+	require.True(t, ok, "expected content blocks, got %T", req.Messages[0].Content)
+	require.Len(t, blocks, 3)
+
+	assert.Equal(t, "text", blocks[0].Type)
+	assert.Equal(t, "what is this?", blocks[0].Text)
 	for i, want := range []struct {
 		mediaType string
 		data      string
@@ -126,34 +123,24 @@ func TestBuildRequestUserImages(t *testing.T) {
 		{"image/jpeg", "REVG"},
 	} {
 		b := blocks[i+1]
-		if b.Type != "image" || b.Source == nil {
-			t.Fatalf("block %d: expected image with source, got %+v", i, b)
-		}
-		if b.Source.Type != "base64" || b.Source.MediaType != want.mediaType || b.Source.Data != want.data {
-			t.Fatalf("block %d: unexpected source: %+v", i, b.Source)
-		}
+		assert.Equal(t, "image", b.Type)
+		require.NotNil(t, b.Source)
+		assert.Equal(t, "base64", b.Source.Type)
+		assert.Equal(t, want.mediaType, b.Source.MediaType)
+		assert.Equal(t, want.data, b.Source.Data)
 	}
 
 	// cache_control must land on the text block, never on an image block.
-	if blocks[0].CacheControl == nil {
-		t.Fatal("expected cache_control on the text block")
-	}
+	assert.NotNil(t, blocks[0].CacheControl, "cache_control must land on the text block")
 	for _, b := range blocks[1:] {
-		if b.CacheControl != nil {
-			t.Fatal("image block must not carry cache_control")
-		}
+		assert.Nil(t, b.CacheControl, "image block must not carry cache_control")
 	}
 
 	body, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if !strings.Contains(string(body), `"media_type"`) || !strings.Contains(string(body), `"image/png"`) {
-		t.Fatalf("expected image source in wire body: %s", string(body))
-	}
-	if strings.Contains(string(body), `"images"`) {
-		t.Fatalf("images field must not leak into the wire body: %s", string(body))
-	}
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"media_type"`)
+	assert.Contains(t, string(body), `"image/png"`)
+	assert.NotContains(t, string(body), `"images"`)
 }
 
 func TestBuildRequestToolsSchema(t *testing.T) {

--- a/internal/llm/anthropic/anthropic_test.go
+++ b/internal/llm/anthropic/anthropic_test.go
@@ -92,6 +92,70 @@ func TestBuildRequestMergesToolResults(t *testing.T) {
 	}
 }
 
+func TestBuildRequestUserImages(t *testing.T) {
+	cfg := llm.ModelConfig{Name: "claude-sonnet-4-20250514", APIKey: "k", BaseURL: "https://api.anthropic.com"}
+	req := BuildRequest(cfg, "", []llm.Message{
+		{
+			Role:    llm.RoleUser,
+			Content: "what is this?",
+			Images: []llm.Image{
+				{Data: "QUJD", MimeType: "image/png"},
+				{Data: "REVG", MimeType: "image/jpeg"},
+			},
+		},
+	}, nil)
+
+	if len(req.Messages) != 1 {
+		t.Fatalf("expected 1 user message, got %d", len(req.Messages))
+	}
+	blocks, ok := req.Messages[0].Content.([]anthropicContentBlock)
+	if !ok {
+		t.Fatalf("expected content blocks, got %T", req.Messages[0].Content)
+	}
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks (text + 2 images), got %d", len(blocks))
+	}
+	if blocks[0].Type != "text" || blocks[0].Text != "what is this?" {
+		t.Fatalf("unexpected text block: %+v", blocks[0])
+	}
+	for i, want := range []struct {
+		mediaType string
+		data      string
+	}{
+		{"image/png", "QUJD"},
+		{"image/jpeg", "REVG"},
+	} {
+		b := blocks[i+1]
+		if b.Type != "image" || b.Source == nil {
+			t.Fatalf("block %d: expected image with source, got %+v", i, b)
+		}
+		if b.Source.Type != "base64" || b.Source.MediaType != want.mediaType || b.Source.Data != want.data {
+			t.Fatalf("block %d: unexpected source: %+v", i, b.Source)
+		}
+	}
+
+	// cache_control must land on the text block, never on an image block.
+	if blocks[0].CacheControl == nil {
+		t.Fatal("expected cache_control on the text block")
+	}
+	for _, b := range blocks[1:] {
+		if b.CacheControl != nil {
+			t.Fatal("image block must not carry cache_control")
+		}
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(body), `"media_type"`) || !strings.Contains(string(body), `"image/png"`) {
+		t.Fatalf("expected image source in wire body: %s", string(body))
+	}
+	if strings.Contains(string(body), `"images"`) {
+		t.Fatalf("images field must not leak into the wire body: %s", string(body))
+	}
+}
+
 func TestBuildRequestToolsSchema(t *testing.T) {
 	cfg := llm.ModelConfig{Name: "claude-sonnet-4-20250514", APIKey: "k", BaseURL: "https://api.anthropic.com"}
 	tools := []llm.ToolDefinition{{

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -10,6 +10,7 @@ import (
 	"iter"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/pulseaiclub/phi/internal/llm"
@@ -81,10 +82,27 @@ func BuildRequest(
 		m := msgs[i]
 		switch m.Role {
 		case llm.RoleUser:
-			req.Messages = append(req.Messages, anthropicMessage{
-				Role:    "user",
-				Content: m.Content,
-			})
+			msg := anthropicMessage{Role: "user"}
+			if len(m.Images) > 0 {
+				blocks := make([]anthropicContentBlock, 0, len(m.Images)+1)
+				if m.Content != "" {
+					blocks = append(blocks, anthropicContentBlock{Type: "text", Text: m.Content})
+				}
+				for _, img := range m.Images {
+					blocks = append(blocks, anthropicContentBlock{
+						Type: "image",
+						Source: &anthropicImageSource{
+							Type:      "base64",
+							MediaType: img.MimeType,
+							Data:      img.Data,
+						},
+					})
+				}
+				msg.Content = blocks
+			} else {
+				msg.Content = m.Content
+			}
+			req.Messages = append(req.Messages, msg)
 
 		case llm.RoleAssistant:
 			msg := anthropicMessage{Role: "assistant"}
@@ -127,12 +145,19 @@ func BuildRequest(
 	}
 
 	// Pin prompt caching to the tail of the last user message, mirroring
-	// panda / go-ai behavior.
+	// panda / go-ai behavior. Image blocks cannot carry cache_control, so
+	// the pin lands on the last non-image block (text or tool_result).
 	if len(req.Messages) > 0 {
 		last := &req.Messages[len(req.Messages)-1]
 		if last.Role == "user" {
 			if blocks, ok := last.Content.([]anthropicContentBlock); ok && len(blocks) > 0 {
-				blocks[len(blocks)-1].CacheControl = cc
+				for i, b := range slices.Backward(blocks) {
+					if b.Type == "image" {
+						continue
+					}
+					blocks[i].CacheControl = cc
+					break
+				}
 				last.Content = blocks
 			} else if text, ok := last.Content.(string); ok {
 				last.Content = []anthropicContentBlock{

--- a/internal/llm/anthropic/request.go
+++ b/internal/llm/anthropic/request.go
@@ -34,16 +34,24 @@ type sysBlock struct {
 	CacheControl *cacheControl `json:"cache_control,omitempty"`
 }
 
+// anthropicImageSource is the base64 source inside an image content block.
+type anthropicImageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
+}
+
 // anthropicContentBlock represents a single content block inside an Anthropic message.
 type anthropicContentBlock struct {
-	Type         string          `json:"type"`
-	Text         string          `json:"text,omitempty"`
-	ID           string          `json:"id,omitempty"`
-	Name         string          `json:"name,omitempty"`
-	Input        json.RawMessage `json:"input,omitempty"`
-	ToolUseID    string          `json:"tool_use_id,omitempty"`
-	Content      string          `json:"content,omitempty"`
-	CacheControl *cacheControl   `json:"cache_control,omitempty"`
+	Type         string                `json:"type"`
+	Text         string                `json:"text,omitempty"`
+	ID           string                `json:"id,omitempty"`
+	Name         string                `json:"name,omitempty"`
+	Input        json.RawMessage       `json:"input,omitempty"`
+	ToolUseID    string                `json:"tool_use_id,omitempty"`
+	Content      string                `json:"content,omitempty"`
+	Source       *anthropicImageSource `json:"source,omitempty"`
+	CacheControl *cacheControl         `json:"cache_control,omitempty"`
 }
 
 func resolveCacheControl() *cacheControl {

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -26,9 +26,17 @@ type apiTool struct {
 	Function llm.ToolDefinition `json:"function"`
 }
 
+type apiMessage struct {
+	Role             llm.Role       `json:"role"`
+	Content          any            `json:"content"` // string, or []contentPart when images are attached
+	ReasoningContent string         `json:"reasoning_content,omitempty"`
+	ToolCalls        []llm.ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID       string         `json:"tool_call_id,omitempty"`
+}
+
 type apiRequest struct {
 	Model         string         `json:"model"`
-	Messages      []llm.Message  `json:"messages"`
+	Messages      []apiMessage   `json:"messages"`
 	Tools         []apiTool      `json:"tools,omitempty"`
 	Stream        bool           `json:"stream,omitempty"`
 	StreamOptions *streamOptions `json:"stream_options,omitempty"`
@@ -57,15 +65,47 @@ type StreamChoice struct {
 	Message *llm.Message    `json:"message,omitempty"`
 }
 
+// toAPIMessage converts a normalized message. With attached images the
+// content becomes the OpenAI content-parts array (text + image_url data
+// URLs); otherwise it stays a plain string, keeping the wire shape stable.
+func toAPIMessage(m llm.Message) apiMessage {
+	out := apiMessage{
+		Role:             m.Role,
+		ReasoningContent: m.ReasoningContent,
+		ToolCalls:        m.ToolCalls,
+		ToolCallID:       m.ToolCallID,
+	}
+	if len(m.Images) == 0 {
+		out.Content = m.Content
+		return out
+	}
+	parts := make([]any, 0, len(m.Images)+1)
+	if m.Content != "" {
+		parts = append(parts, map[string]string{"type": "text", "text": m.Content})
+	}
+	for _, img := range m.Images {
+		parts = append(parts, map[string]any{
+			"type": "image_url",
+			"image_url": map[string]string{
+				"url": "data:" + img.MimeType + ";base64," + img.Data,
+			},
+		})
+	}
+	out.Content = parts
+	return out
+}
+
 // BuildRequest converts the normalized messages into an OpenAI-shaped request.
 // The system prompt is prepended as a system message, mirroring the previous
 // in-client behavior.
 func BuildRequest(cfg llm.ModelConfig, system string, messages []llm.Message, tools []llm.ToolDefinition) *apiRequest {
-	msgs := make([]llm.Message, 0, len(messages)+1)
+	msgs := make([]apiMessage, 0, len(messages)+1)
 	if strings.TrimSpace(system) != "" {
-		msgs = append(msgs, llm.Message{Role: llm.RoleSystem, Content: system})
+		msgs = append(msgs, apiMessage{Role: llm.RoleSystem, Content: system})
 	}
-	msgs = append(msgs, messages...)
+	for _, m := range messages {
+		msgs = append(msgs, toAPIMessage(m))
+	}
 
 	apiTools := make([]apiTool, len(tools))
 	for i, t := range tools {
@@ -96,7 +136,7 @@ func isThinkingModeModel(model string) bool {
 func Compact(ctx context.Context, httpClient *http.Client, cfg llm.ModelConfig, prompt string) (string, error) {
 	body, err := json.Marshal(&apiRequest{
 		Model:    cfg.Name,
-		Messages: []llm.Message{{Role: llm.RoleUser, Content: prompt}},
+		Messages: []apiMessage{{Role: llm.RoleUser, Content: prompt}},
 	})
 	if err != nil {
 		return "", err

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -2,8 +2,10 @@ package openai
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/llm"
 )
@@ -20,39 +22,24 @@ func TestBuildRequestImages(t *testing.T) {
 		},
 	}, nil)
 
-	if len(req.Messages) != 2 {
-		t.Fatalf("expected system + user messages, got %d", len(req.Messages))
-	}
+	require.Len(t, req.Messages, 2) // system + user
 	parts, ok := req.Messages[1].Content.([]any)
-	if !ok {
-		t.Fatalf("expected content parts array with images, got %T", req.Messages[1].Content)
-	}
-	if len(parts) != 2 {
-		t.Fatalf("expected 2 parts (text + image), got %d", len(parts))
-	}
+	require.True(t, ok, "expected content parts array with images, got %T", req.Messages[1].Content)
+	require.Len(t, parts, 2)
+
 	text := parts[0].(map[string]string)
-	if text["type"] != "text" || text["text"] != "what is this?" {
-		t.Fatalf("unexpected text part: %+v", text)
-	}
+	assert.Equal(t, "text", text["type"])
+	assert.Equal(t, "what is this?", text["text"])
+
 	img := parts[1].(map[string]any)
-	if img["type"] != "image_url" {
-		t.Fatalf("expected image_url part, got %+v", img)
-	}
+	assert.Equal(t, "image_url", img["type"])
 	imageURL := img["image_url"].(map[string]string)
-	if want := "data:image/png;base64,QUJD"; imageURL["url"] != want {
-		t.Fatalf("expected url %q, got %q", want, imageURL["url"])
-	}
+	assert.Equal(t, "data:image/png;base64,QUJD", imageURL["url"])
 
 	body, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if !strings.Contains(string(body), `"image_url"`) {
-		t.Fatalf("expected image_url in wire body: %s", string(body))
-	}
-	if strings.Contains(string(body), `"images"`) {
-		t.Fatalf("images field must not leak into the wire body: %s", string(body))
-	}
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"image_url"`)
+	assert.NotContains(t, string(body), `"images"`)
 }
 
 func TestBuildRequestNoImagesKeepsStringContent(t *testing.T) {
@@ -60,19 +47,14 @@ func TestBuildRequestNoImagesKeepsStringContent(t *testing.T) {
 	req := BuildRequest(cfg, "", []llm.Message{{Role: llm.RoleUser, Content: "hi"}}, nil)
 
 	body, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+	require.NoError(t, err)
 	// content must stay a JSON string, not an array, when there are no images.
 	var raw struct {
 		Messages []struct {
 			Content json.RawMessage `json:"content"`
 		} `json:"messages"`
 	}
-	if err := json.Unmarshal(body, &raw); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if len(raw.Messages) != 1 || string(raw.Messages[0].Content) != `"hi"` {
-		t.Fatalf("expected string content \"hi\", got %s", string(raw.Messages[0].Content))
-	}
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.Len(t, raw.Messages, 1)
+	assert.Equal(t, `"hi"`, string(raw.Messages[0].Content))
 }

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -1,0 +1,78 @@
+package openai
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/pulseaiclub/phi/internal/llm"
+)
+
+func TestBuildRequestImages(t *testing.T) {
+	cfg := llm.ModelConfig{Name: "gpt-4o", APIKey: "k", BaseURL: "https://api.openai.com/v1"}
+	req := BuildRequest(cfg, "sys", []llm.Message{
+		{
+			Role:    llm.RoleUser,
+			Content: "what is this?",
+			Images: []llm.Image{
+				{Data: "QUJD", MimeType: "image/png"},
+			},
+		},
+	}, nil)
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("expected system + user messages, got %d", len(req.Messages))
+	}
+	parts, ok := req.Messages[1].Content.([]any)
+	if !ok {
+		t.Fatalf("expected content parts array with images, got %T", req.Messages[1].Content)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts (text + image), got %d", len(parts))
+	}
+	text := parts[0].(map[string]string)
+	if text["type"] != "text" || text["text"] != "what is this?" {
+		t.Fatalf("unexpected text part: %+v", text)
+	}
+	img := parts[1].(map[string]any)
+	if img["type"] != "image_url" {
+		t.Fatalf("expected image_url part, got %+v", img)
+	}
+	imageURL := img["image_url"].(map[string]string)
+	if want := "data:image/png;base64,QUJD"; imageURL["url"] != want {
+		t.Fatalf("expected url %q, got %q", want, imageURL["url"])
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(body), `"image_url"`) {
+		t.Fatalf("expected image_url in wire body: %s", string(body))
+	}
+	if strings.Contains(string(body), `"images"`) {
+		t.Fatalf("images field must not leak into the wire body: %s", string(body))
+	}
+}
+
+func TestBuildRequestNoImagesKeepsStringContent(t *testing.T) {
+	cfg := llm.ModelConfig{Name: "gpt-4o", APIKey: "k", BaseURL: "https://api.openai.com/v1"}
+	req := BuildRequest(cfg, "", []llm.Message{{Role: llm.RoleUser, Content: "hi"}}, nil)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// content must stay a JSON string, not an array, when there are no images.
+	var raw struct {
+		Messages []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(raw.Messages) != 1 || string(raw.Messages[0].Content) != `"hi"` {
+		t.Fatalf("expected string content \"hi\", got %s", string(raw.Messages[0].Content))
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -48,6 +48,14 @@ type Function struct {
 	Arguments string `json:"arguments"`
 }
 
+// Image is one base64-encoded image attached to a user message.
+// Mirrors the pi-ai ImageContent part: data is base64 bytes plus the MIME
+// type so each provider can build its own wire format (image_url / source).
+type Image struct {
+	Data     string `json:"data"`     // base64-encoded image bytes
+	MimeType string `json:"mimeType"` // e.g. "image/png", "image/jpeg"
+}
+
 // Message is one chat turn (OpenAI-compatible shape, normalized across
 // providers).
 type Message struct {
@@ -56,6 +64,9 @@ type Message struct {
 	ReasoningContent string     `json:"reasoning_content,omitempty"`
 	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string     `json:"tool_call_id,omitempty"`
+	// Images attaches base64 images to a user message. Providers that do not
+	// support images fall back to the text content only.
+	Images []Image `json:"images,omitempty"`
 
 	// Usage tracks token consumption for the turn. Excluded from the API
 	// request body; used by the session manager for compaction decisions.

--- a/internal/llm/types_test.go
+++ b/internal/llm/types_test.go
@@ -1,0 +1,45 @@
+package llm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMessageImageRoundTrip(t *testing.T) {
+	orig := Message{
+		Role:    RoleUser,
+		Content: "what is this?",
+		Images: []Image{
+			{Data: "QUJD", MimeType: "image/png"},
+		},
+	}
+	body, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(body), `"images"`) || !strings.Contains(string(body), `"mimeType"`) {
+		t.Fatalf("expected images in persisted JSON: %s", body)
+	}
+
+	var got Message
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Images) != 1 || got.Images[0].Data != "QUJD" || got.Images[0].MimeType != "image/png" {
+		t.Fatalf("unexpected round-trip: %+v", got.Images)
+	}
+	if got.Content != orig.Content || got.Role != orig.Role {
+		t.Fatalf("text fields changed in round-trip: %+v", got)
+	}
+}
+
+func TestMessageWithoutImagesMarshalsPlain(t *testing.T) {
+	body, err := json.Marshal(Message{Role: RoleUser, Content: "hi"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), `"images"`) {
+		t.Fatalf("expected no images key: %s", body)
+	}
+}

--- a/internal/llm/types_test.go
+++ b/internal/llm/types_test.go
@@ -2,8 +2,10 @@ package llm
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMessageImageRoundTrip(t *testing.T) {
@@ -15,31 +17,17 @@ func TestMessageImageRoundTrip(t *testing.T) {
 		},
 	}
 	body, err := json.Marshal(orig)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if !strings.Contains(string(body), `"images"`) || !strings.Contains(string(body), `"mimeType"`) {
-		t.Fatalf("expected images in persisted JSON: %s", body)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"images"`)
+	assert.Contains(t, string(body), `"mimeType"`)
 
 	var got Message
-	if err := json.Unmarshal(body, &got); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if len(got.Images) != 1 || got.Images[0].Data != "QUJD" || got.Images[0].MimeType != "image/png" {
-		t.Fatalf("unexpected round-trip: %+v", got.Images)
-	}
-	if got.Content != orig.Content || got.Role != orig.Role {
-		t.Fatalf("text fields changed in round-trip: %+v", got)
-	}
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, orig, got)
 }
 
 func TestMessageWithoutImagesMarshalsPlain(t *testing.T) {
 	body, err := json.Marshal(Message{Role: RoleUser, Content: "hi"})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if strings.Contains(string(body), `"images"`) {
-		t.Fatalf("expected no images key: %s", body)
-	}
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), `"images"`)
 }

--- a/internal/util/doc.go
+++ b/internal/util/doc.go
@@ -1,3 +1,4 @@
 // Package util holds shared helpers used across the project: unified diff
-// generation, hashline-compatible line hashing, and HTTP/SSE plumbing.
+// generation, hashline-compatible line hashing, HTTP/SSE plumbing, and image
+// file loading (subpackages: filesearch, githubrelease, image, update).
 package util

--- a/internal/util/image/image.go
+++ b/internal/util/image/image.go
@@ -1,0 +1,45 @@
+// Package image loads image files from disk: raw bytes plus a content-sniffed
+// MIME type. Callers (e.g. the TUI attach path) base64-encode the bytes into
+// their own message shape.
+package image
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// MaxBytes caps how large an attached image may be. Base64 inflates the
+// payload by ~33%, so an oversized file would dominate the context window.
+const MaxBytes = 10 << 20 // 10 MiB
+
+// Result is a loaded image file.
+type Result struct {
+	Data     []byte // raw file bytes
+	MimeType string // sniffed from content, e.g. "image/png"
+}
+
+// supportedMimeTypes is the set of raster formats vision APIs accept.
+var supportedMimeTypes = map[string]bool{
+	"image/png":  true,
+	"image/jpeg": true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+// Load reads an image file, sniffs its MIME type from the content (not the
+// extension), and returns the raw bytes plus that type.
+func Load(path string) (Result, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Result{}, err
+	}
+	if len(data) > MaxBytes {
+		return Result{}, fmt.Errorf("image too large: %d bytes (max %d)", len(data), MaxBytes)
+	}
+	mime := http.DetectContentType(data)
+	if !supportedMimeTypes[mime] {
+		return Result{}, fmt.Errorf("unsupported image type %q (want png, jpeg, gif, or webp)", mime)
+	}
+	return Result{Data: data, MimeType: mime}, nil
+}

--- a/internal/util/image/image_test.go
+++ b/internal/util/image/image_test.go
@@ -1,0 +1,39 @@
+package image
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// png1x1Base64 is a 1x1 transparent PNG.
+const png1x1Base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+
+func TestLoadPNG(t *testing.T) {
+	png, err := base64.StdEncoding.DecodeString(png1x1Base64)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "pixel.png")
+	require.NoError(t, os.WriteFile(path, png, 0o644))
+
+	res, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "image/png", res.MimeType)
+	assert.Equal(t, png, res.Data)
+}
+
+func TestLoadRejectsNonImage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.txt")
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0o644))
+
+	_, err := Load(path)
+	assert.ErrorContains(t, err, "unsupported image type")
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "nope.png"))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
llm.Message gains an Images field (base64 + MIME type), following the pi-ai ImageContent pattern. Provider adapters serialize attached images at the boundary:

- OpenAI-compatible: content becomes parts array with image_url data URLs; stays a plain string when no images are attached (wire shape unchanged).
- Anthropic: user content becomes blocks with base64 image sources; prompt-cache pin lands on the last non-image block since image blocks cannot carry cache_control.

Images persist through the session JSON round-trip. Input-side wiring (TUI attach command) is a follow-up.