### PR TITLE
fix(agent): stop duplicating tool error text in UI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Tool errors no longer duplicate the error text in the TUI (Error and Output shown the same message twice).
+
 ### Security
 
 <!-- Released section -->

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -160,7 +160,6 @@ func (e *Executor) runOne(ctx context.Context, call llm.ToolCall, emit func(sess
 		}
 		errText = err.Error()
 		content = errText
-		output = errText
 	} else {
 		content = result.Content
 		output = result.Output
@@ -250,7 +249,7 @@ func (e *Executor) rejectResult(
 	detail, reason string,
 	emit func(session.ToolData) bool,
 ) llm.Message {
-	_ = emit(session.ToolData{Run: e.toolRun(call, session.ToolRejected, detail, reason, reason)})
+	_ = emit(session.ToolData{Run: e.toolRun(call, session.ToolRejected, detail, reason, "")})
 	return e.toolMessage(call.ID, reason)
 }
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -441,3 +441,37 @@ func (g *recordingGate) Check(_ context.Context, req permission.Request) (permis
 	g.last = req
 	return permission.Allow, ""
 }
+
+func TestExecutorToolErrorKeepsOutputEmptyForUI(t *testing.T) {
+	const errMsg = "2 lines have changed since last read"
+	reg := tools.Registry{
+		"edit": {
+			Definition: llm.ToolDefinition{Name: "edit"},
+			Run: func(context.Context, json.RawMessage) (tools.Result, error) {
+				return tools.Result{}, &staticError{msg: errMsg}
+			},
+		},
+	}
+
+	ex := NewExecutor(reg, permission.AllowAll{}, nil, nil)
+	var last session.ToolRun
+	msgs := ex.Run(t.Context(), []llm.ToolCall{{
+		ID:       "c1",
+		Function: llm.Function{Name: "edit", Arguments: `{}`},
+	}}, func(td session.ToolData) bool {
+		if td.Run.Status == session.ToolError {
+			last = td.Run
+		}
+		return true
+	})
+
+	require.Len(t, msgs, 1)
+	assert.Equal(t, errMsg, msgs[0].Content)
+	assert.Equal(t, session.ToolError, last.Status)
+	assert.Equal(t, errMsg, last.Error)
+	assert.Empty(t, last.Output, "UI Error and Output must not duplicate the same text")
+}
+
+type staticError struct{ msg string }
+
+func (e *staticError) Error() string { return e.msg }


### PR DESCRIPTION
On tool failure the executor set output to the error text, so the UI showed the same message twice (Error + Output). Leave output empty on the error path and pass "" on rejection, matching the rejection flow. Add a regression test covering the error path.