### PR TITLE
feat: bind Ctrl+A/E navigation and Ctrl+U clear to inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `Ctrl+A` / `Ctrl+E` move the composer cursor to the start/end of the current line.
+- `Ctrl+U` clears the composer input, pending images, and pending skills.
 - Per-model `image_enabled` config key; the composer blocks clipboard and `@` image attach and shows a warning when the active model does not support images.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ The editor supports:
 | `Ctrl+C`       | Quit phi                        |
 | `Esc`          | Cancel the running agent / close pickers |
 | `Ctrl+K`       | Toggle the command palette      |
+| `Ctrl+A`       | Jump to the start of the line   |
+| `Ctrl+E`       | Jump to the end of the line     |
+| `Ctrl+U`       | Clear the composer input, images, and skills |
 | `Ctrl+Shift+C` | Copy the selected transcript text |
 
 Themes: `Dark`, `Darcula`, `Pink`, and `Terminal` (default), switchable from

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,6 +223,9 @@ Anthropic Messages API；其余走 OpenAI 兼容的 `/chat/completions` 路径�
 | `Ctrl+C` | 退出 phi |
 | `Esc` | 取消正在运行的代理 / 关闭选择器 |
 | `Ctrl+K` | 开关命令面板 |
+| `Ctrl+A` | 光标跳到行首 |
+| `Ctrl+E` | 光标跳到行尾 |
+| `Ctrl+U` | 清空输入框（含图片和技能） |
 | `Ctrl+Shift+C` | 复制选中的对话文本 |
 
 主题：`Dark`、`Darcula`、`Pink` 和 `Terminal`（默认），可在面板的

--- a/internal/components/chat/chat_input.go
+++ b/internal/components/chat/chat_input.go
@@ -323,7 +323,26 @@ func (c *ChatInput) Handle(ctx *components.EventContext, ev xui.Event) {
 			}
 			return
 		case xui.KeyRune:
-			if e.Mods.Has(xui.ModCtrl) || e.Mods.Has(xui.ModAlt) || e.Mods.Has(xui.ModSuper) {
+			if e.Mods.Has(xui.ModCtrl) {
+				switch e.Rune {
+				case 'a', 'A':
+					// Ctrl+A jumps to the start of the current line.
+					c.Cursor = lineStart(c.Value, c.Cursor)
+					c.notifyCompleters()
+				case 'e', 'E':
+					// Ctrl+E jumps to the end of the current line.
+					c.Cursor = lineEnd(c.Value, c.Cursor)
+					c.notifyCompleters()
+				case 'u', 'U':
+					// Ctrl+U clears the composer, pending images, and pending skills.
+					c.clear()
+				default:
+					return
+				}
+				ctx.ConsumeAndRedraw()
+				return
+			}
+			if e.Mods.Has(xui.ModAlt) || e.Mods.Has(xui.ModSuper) {
 				return
 			}
 			if e.Rune >= 0x20 || e.Rune == '\t' {
@@ -409,6 +428,17 @@ func (c *ChatInput) notifyChange() {
 		c.OnChange(c.Value)
 	}
 	c.notifyCompleters()
+}
+
+// clear removes all composer text, pending images, and pending skills.
+func (c *ChatInput) clear() {
+	if c.Value != "" {
+		c.Value = ""
+		c.Cursor = 0
+		c.notifyChange()
+	}
+	c.ClearPendingImages()
+	c.ClearPendingSkills()
 }
 
 func (c *ChatInput) notifyCompleters() {

--- a/internal/components/chat/chat_test.go
+++ b/internal/components/chat/chat_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pulseaiclub/xui"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/layout"
 	"github.com/pulseaiclub/phi/internal/components/text"
@@ -71,6 +73,71 @@ func TestChatInputTyping(t *testing.T) {
 	if submitted != "hi" {
 		t.Fatalf("submit = %q", submitted)
 	}
+}
+
+func TestChatInputCtrlUClearsAll(t *testing.T) {
+	c := &ChatInput{MinBodyRows: 3, Value: "hello\nworld", Cursor: 5}
+	ctx := &components.EventContext{}
+	changed := 0
+	c.OnChange = func(string) { changed++ }
+	c.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'u', Mods: xui.ModCtrl, Press: true})
+	require.Empty(t, c.Value)
+	require.Zero(t, c.Cursor)
+	require.Equal(t, 1, changed)
+	require.True(t, ctx.Consume)
+	// A plain 'u' still types.
+	c.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'u', Press: true})
+	require.Equal(t, "u", c.Value)
+}
+
+func TestChatInputCtrlUEmptyDoesNotNotify(t *testing.T) {
+	c := &ChatInput{MinBodyRows: 3}
+	ctx := &components.EventContext{}
+	changed := 0
+	c.OnChange = func(string) { changed++ }
+	c.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'u', Mods: xui.ModCtrl, Press: true})
+	require.Zero(t, changed)
+	require.True(t, ctx.Consume)
+}
+
+func TestChatInputCtrlUClearsPendingAttachments(t *testing.T) {
+	c := &ChatInput{
+		MinBodyRows:   3,
+		Value:         "hello",
+		Cursor:        5,
+		PendingSkills: []string{"building-plugins"},
+		PendingImages: []imgutil.Attachment{
+			{Label: "a.png", Result: imgutil.Result{Data: []byte("x"), MimeType: "image/png"}},
+		},
+	}
+	ctx := &components.EventContext{}
+	c.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'u', Mods: xui.ModCtrl, Press: true})
+	require.Empty(t, c.Value)
+	require.Zero(t, c.Cursor)
+	require.Empty(t, c.PendingSkills)
+	require.Empty(t, c.PendingImages)
+	require.True(t, ctx.Consume)
+}
+
+func TestChatInputCtrlAEJumpLineBounds(t *testing.T) {
+	c := &ChatInput{MinBodyRows: 3, Value: "hello world", Cursor: 5}
+	ctx := &components.EventContext{}
+	// Ctrl+A jumps to the start of the current line.
+	c.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'a', Mods: xui.ModCtrl, Press: true})
+	require.Equal(t, 0, c.Cursor)
+	// Ctrl+E jumps to the end of the current line.
+	c.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'e', Mods: xui.ModCtrl, Press: true})
+	require.Equal(t, len("hello world"), c.Cursor)
+	require.True(t, ctx.Consume)
+}
+
+func TestChatInputCtrlAEStayOnCurrentLine(t *testing.T) {
+	c := &ChatInput{MinBodyRows: 3, Value: "alpha\nbeta gamma", Cursor: len("alpha\nbe")}
+	ctx := &components.EventContext{}
+	c.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'a', Mods: xui.ModCtrl, Press: true})
+	require.Equal(t, len("alpha\n"), c.Cursor)
+	c.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'e', Mods: xui.ModCtrl, Press: true})
+	require.Equal(t, len("alpha\nbeta gamma"), c.Cursor)
 }
 
 func TestChatInputMentionOpenDefersNav(t *testing.T) {

--- a/internal/components/input/input.go
+++ b/internal/components/input/input.go
@@ -79,7 +79,19 @@ func (t *TextField) Handle(ctx *components.EventContext, ev xui.Event) {
 			ctx.ConsumeAndRedraw()
 			return
 		case xui.KeyRune:
-			if e.Mods.Has(xui.ModCtrl) || e.Mods.Has(xui.ModAlt) {
+			if e.Mods.Has(xui.ModCtrl) {
+				// Ctrl+U clears the whole field; skip notify when already empty.
+				if e.Rune == 'u' || e.Rune == 'U' {
+					if t.Value != "" {
+						t.Value = ""
+						t.Cursor = 0
+						t.notify()
+					}
+					ctx.ConsumeAndRedraw()
+				}
+				return
+			}
+			if e.Mods.Has(xui.ModAlt) {
 				return
 			}
 			if e.Rune >= 0x20 || e.Rune == '\t' {

--- a/internal/components/input/input_test.go
+++ b/internal/components/input/input_test.go
@@ -3,9 +3,35 @@ package input
 import (
 	"testing"
 
+	"github.com/pulseaiclub/xui"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/layout"
 )
+
+func TestTextFieldCtrlUClears(t *testing.T) {
+	f := &TextField{Value: "ab", Cursor: 1}
+	ctx := &components.EventContext{}
+	changed := 0
+	f.OnChange = func(string) { changed++ }
+	f.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'u', Mods: xui.ModCtrl, Press: true})
+	require.Empty(t, f.Value)
+	require.Zero(t, f.Cursor)
+	require.Equal(t, 1, changed)
+	require.True(t, ctx.Consume)
+}
+
+func TestTextFieldCtrlUEmptyDoesNotNotify(t *testing.T) {
+	f := &TextField{}
+	ctx := &components.EventContext{}
+	changed := 0
+	f.OnChange = func(string) { changed++ }
+	f.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: 'u', Mods: xui.ModCtrl, Press: true})
+	require.Zero(t, changed)
+	require.True(t, ctx.Consume)
+}
 
 func TestDiffBlock(t *testing.T) {
 	d := &DiffBlock{Diff: "+added\n-removed\n context", Theme: components.DefaultTheme()}


### PR DESCRIPTION
- Ctrl+A / Ctrl+E move the composer cursor to the start/end of the current line, replacing the nonstandard Ctrl+B binding
- Ctrl+U clears the composer text plus pending images and skills
- Ctrl+U also clears single-line text fields
- update tests, README, and CHANGELOG