### PR TITLE
fix(composer): use block cursor instead of hardware caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Composer caret uses a reverse-video block cursor instead of the terminal hardware cursor, fixing hollow/blinking carets in some terminals (e.g. `xterm-256color`).
+
 ### Security
 
 <!-- Released section -->

--- a/internal/components/chat/chat_input.go
+++ b/internal/components/chat/chat_input.go
@@ -42,7 +42,7 @@ type ChatInput struct {
 	BorderStyle    xui.Style
 	TextStyle      xui.Style
 	CursorStyle    xui.Style // visual block when terminal cursor unavailable
-	UseBlockCursor bool      // paint reverse cell in addition to terminal cursor
+	UseBlockCursor bool      // paint reverse cell; hides the terminal hardware cursor
 
 	// Theme styles the pending-skills chip row (Muted label, Success names).
 	Theme components.Theme
@@ -654,8 +654,9 @@ func (c *ChatInput) Draw(ctx components.DrawContext) components.Surface {
 			}
 		}
 		s.SetCell(cx, cy, xui.Cell{Char: ch, Width: width, Style: cursorSt})
+	} else {
+		s.Cursor = &components.Point{X: cx, Y: cy}
 	}
-	s.Cursor = &components.Point{X: cx, Y: cy}
 
 	if debuglog.Enabled() && c.dumpNextDraw {
 		c.dumpNextDraw = false

--- a/internal/components/chat/chat_test.go
+++ b/internal/components/chat/chat_test.go
@@ -46,7 +46,7 @@ func TestChatInputBorderLabels(t *testing.T) {
 	bot := rowString(s, 4)
 	assert.Contains(t, bot, "5% of 128k")
 	assert.Contains(t, bot, "examples")
-	require.NotNil(t, s.Cursor, "expected cursor")
+	require.Nil(t, s.Cursor, "block cursor hides hardware cursor")
 }
 
 func TestChatInputTyping(t *testing.T) {
@@ -203,8 +203,8 @@ func TestChatInputCJKPasteNoContinuationReverse(t *testing.T) {
 	ctx := &components.EventContext{}
 	c.Handle(ctx, xui.PasteEvent{Text: "已修复中文粘贴"})
 	s := c.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: 10}, Method: xui.WidthUnicode})
-	require.NotNil(t, s.Cursor, "expected cursor")
-	cy := s.Cursor.Y
+	require.Nil(t, s.Cursor, "block cursor hides hardware cursor")
+	cy := blockCursorRow(s)
 	revPrimaries := 0
 	for x := 0; x < s.Size.Width; {
 		cell := s.Buffer[cy*s.Size.Width+x]
@@ -289,6 +289,24 @@ func TestChatInputAddPendingSkillDedup(t *testing.T) {
 	require.Equal(t, "building-plugins", c.PendingSkills[0])
 }
 
+func blockCursorRow(s components.Surface) int {
+	_, y := blockCursorCell(s)
+	return y
+}
+
+func blockCursorCell(s components.Surface) (x, y int) {
+	for y := 0; y < s.Size.Height; y++ {
+		for x := 0; x < s.Size.Width; x++ {
+			cell := s.Buffer[y*s.Size.Width+x]
+			if cell.Style.Reverse {
+				return x, y
+			}
+		}
+	}
+	require.FailNow(nil, "expected reverse block cursor cell")
+	return 0, 0
+}
+
 func rowString(s components.Surface, y int) string {
 	var b strings.Builder
 	for x := 0; x < s.Size.Width; x++ {
@@ -311,8 +329,8 @@ func TestChatInputCJKBlockCursorKeepsWidth(t *testing.T) {
 		CursorStyle:    xui.Style{Reverse: true},
 	}
 	s := c.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: 10}, Method: xui.WidthUnicode})
-	require.NotNil(t, s.Cursor, "expected cursor")
-	cx, cy := s.Cursor.X, s.Cursor.Y
+	require.Nil(t, s.Cursor, "block cursor hides hardware cursor")
+	cx, cy := blockCursorCell(s)
 	cell := s.Buffer[cy*s.Size.Width+cx]
 	require.Equal(t, "中", cell.Char)
 	require.EqualValues(t, 2, cell.Width)

--- a/internal/tui/composer/pane.go
+++ b/internal/tui/composer/pane.go
@@ -803,7 +803,7 @@ func newChatInput(theme components.Theme, model, cwd string) chat.ChatInput {
 	return chat.ChatInput{
 		MinBodyRows:    3,
 		MaxBodyRows:    8,
-		UseBlockCursor: false,
+		UseBlockCursor: true,
 		PaddingX:       1,
 		Theme:          theme,
 		BorderStyle:    theme.Border,


### PR DESCRIPTION
When UseBlockCursor is set, ChatInput paints a reverse-video cell and no longer exposes Surface.Cursor, so the hollow/blinking terminal hardware caret (e.g. xterm-256color) is hidden.

ChatInput now defaults to the block cursor; tests assert the block cell instead of Surface.Cursor.