### PR TITLE
fix(composer): cancel in-flight @ searches and hint at truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Composer caret uses a reverse-video block cursor instead of the terminal hardware cursor, fixing hollow/blinking carets in some terminals (e.g. `xterm-256color`).
+- `@` file picker: cancel in-flight `fd` searches on each keystroke / close, surface timeouts as actionable hints, and note when the match list is truncated.
 
 ### Security
 

--- a/internal/tui/composer/mention_search_test.go
+++ b/internal/tui/composer/mention_search_test.go
@@ -1,0 +1,138 @@
+package composer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/tui/controller"
+)
+
+// Each keystroke must cancel the search in flight. Without this every
+// keystroke leaves an fd process walking the tree, and on a large tree they
+// pile up faster than they finish.
+func TestScheduleMentionSearchCancelsPrevious(t *testing.T) {
+	c := NewComposerPane(components.DefaultTheme(), "m", t.TempDir())
+
+	c.scheduleMentionSearch("a")
+	require.NotNil(t, c.mentionCancel, "a search must be cancellable")
+
+	// Capture the first search's context by canceling through the stored
+	// func, then confirm a second schedule installs a different one.
+	firstDone := make(chan struct{})
+	first := c.mentionCancel
+	c.mentionCancel = func() { close(firstDone); first() }
+
+	c.scheduleMentionSearch("ab")
+
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("scheduling a new search must cancel the previous one")
+	}
+}
+
+// A superseded search must not publish, or a stale list can overwrite a newer
+// one between the generation check and the update.
+func TestSupersededSearchDoesNotPublish(t *testing.T) {
+	c := NewComposerPane(components.DefaultTheme(), "m", t.TempDir())
+
+	var mu sync.Mutex
+	var queries []string
+	c.publish = func(m controller.Msg) {
+		if res, ok := m.(controller.MentionResultsMsg); ok {
+			mu.Lock()
+			queries = append(queries, res.Query)
+			mu.Unlock()
+		}
+	}
+
+	// Cancelled well inside the 100ms debounce, so no work should start.
+	c.scheduleMentionSearch("first")
+	c.scheduleMentionSearch("second")
+
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.NotContains(t, queries, "first", "a cancelled search must stay quiet")
+}
+
+// A truncated result must say so. Otherwise a missing file reads as "not
+// there" when it is really "past the limit".
+func TestApplyMentionResultsReportsTruncation(t *testing.T) {
+	c := NewComposerPane(components.DefaultTheme(), "m", t.TempDir())
+	c.mention.Show()
+
+	paths := make([]string, mentionSearchLimit)
+	for i := range paths {
+		paths[i] = "file.go"
+	}
+	c.ApplyMentionResults(controller.MentionResultsMsg{
+		Gen: c.mentionGen, Paths: paths, Truncated: true,
+	})
+
+	assert.Contains(t, c.mention.Status, "type more to narrow")
+	assert.Len(t, c.mention.Items, mentionSearchLimit)
+}
+
+// A complete list must not claim to be partial.
+func TestApplyMentionResultsQuietWhenComplete(t *testing.T) {
+	c := NewComposerPane(components.DefaultTheme(), "m", t.TempDir())
+	c.mention.Show()
+
+	c.ApplyMentionResults(controller.MentionResultsMsg{
+		Gen: c.mentionGen, Paths: []string{"a.go", "b.go"},
+	})
+
+	assert.Empty(t, c.mention.Status, "a full result needs no warning")
+	assert.Len(t, c.mention.Items, 2)
+}
+
+// Canceling the picker must stop the search, not leave it running.
+func TestHideCompletersCancelsSearch(t *testing.T) {
+	c := NewComposerPane(components.DefaultTheme(), "m", t.TempDir())
+
+	c.scheduleMentionSearch("q")
+	require.NotNil(t, c.mentionCancel)
+
+	done := make(chan struct{})
+	inner := c.mentionCancel
+	c.mentionCancel = func() { close(done); inner() }
+
+	c.CloseMentionSlash()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("closing the picker must cancel the search in flight")
+	}
+}
+
+func TestApplyMentionResultsEmpty(t *testing.T) {
+	c := NewComposerPane(components.DefaultTheme(), "m", t.TempDir())
+	c.mention.Show()
+
+	c.ApplyMentionResults(controller.MentionResultsMsg{Gen: c.mentionGen})
+
+	assert.Equal(t, "No matching files", c.mention.Status)
+}
+
+// The picker shows this text, so it must describe the search, not the child
+// process. "fd: signal: killed" is not something a user can act on.
+func TestTimeoutTextIsActionable(t *testing.T) {
+	c := NewComposerPane(components.DefaultTheme(), "m", t.TempDir())
+	c.mention.Show()
+
+	c.ApplyMentionResults(controller.MentionResultsMsg{
+		Gen: c.mentionGen, ErrText: "Search timed out — type more of the path",
+	})
+
+	assert.NotContains(t, c.mention.Status, "signal:")
+	assert.NotContains(t, c.mention.Status, "fd:")
+	assert.Contains(t, c.mention.Status, "type more of the path")
+}

--- a/internal/tui/composer/pane.go
+++ b/internal/tui/composer/pane.go
@@ -38,7 +38,9 @@ type ComposerPane struct {
 	palette  palette.CommandPalette
 
 	mentionGen int
-	commands   *commands.CommandRegistry
+	// mentionCancel stops the search in flight; nil before the first search.
+	mentionCancel context.CancelFunc
+	commands      *commands.CommandRegistry
 
 	transcript *transcript.TranscriptPane
 	submitter  BusyChecker
@@ -148,7 +150,7 @@ func (c *ComposerPane) HideCompleters() {
 	}
 	c.mention.Hide()
 	c.Chat.MentionOpen = false
-	c.mentionGen++
+	c.abandonMentionSearch()
 	c.slash.Hide()
 	c.Chat.SlashOpen = false
 	c.question.Hide()
@@ -218,7 +220,7 @@ func (c *ComposerPane) CloseMentionSlash() {
 	}
 	c.mention.Hide()
 	c.Chat.MentionOpen = false
-	c.mentionGen++
+	c.abandonMentionSearch()
 	c.slash.Hide()
 	c.Chat.SlashOpen = false
 	c.question.Hide()
@@ -349,8 +351,13 @@ func (c *ComposerPane) ApplyMentionResults(msg controller.MentionResultsMsg) {
 		items = append(items, mention.Item{Path: p})
 	}
 	status := ""
-	if len(items) == 0 {
+	switch {
+	case len(items) == 0:
 		status = "No matching files"
+	case msg.Truncated:
+		// Say the list is partial, so a missing file reads as "narrow the
+		// query" rather than "the file is not there".
+		status = fmt.Sprintf("First %d matches — type more to narrow", len(items))
 	}
 	c.mention.SetResults(items, status)
 }
@@ -483,7 +490,7 @@ func (c *ComposerPane) Handle(ctx *components.EventContext, ev xui.Event) {
 			if c.mention.Open {
 				c.mention.Cancel()
 				c.Chat.MentionOpen = false
-				c.mentionGen++
+				c.abandonMentionSearch()
 				ctx.ConsumeAndRedraw()
 				return
 			}
@@ -543,6 +550,7 @@ func (c *ComposerPane) Handle(ctx *components.EventContext, ev xui.Event) {
 			c.mention.Handle(ctx, ev)
 			if !c.mention.Open {
 				c.Chat.MentionOpen = false
+				c.abandonMentionSearch()
 			}
 			return
 		}
@@ -583,7 +591,7 @@ func (c *ComposerPane) onMentionChange(active bool, query string) {
 	if !active {
 		c.mention.Hide()
 		c.Chat.MentionOpen = false
-		c.mentionGen++
+		c.abandonMentionSearch()
 		return
 	}
 	if c.slash.Open || c.Chat.SlashOpen || c.question.Open || c.Chat.QuestionOpen {
@@ -612,7 +620,7 @@ func (c *ComposerPane) onSlashChange(active bool, query string) {
 	c.Chat.QuestionOpen = false
 	c.mention.Hide()
 	c.Chat.MentionOpen = false
-	c.mentionGen++
+	c.abandonMentionSearch()
 	items := []mention.Item{}
 	if c.commands != nil {
 		items = c.commands.FilterSlash(query)
@@ -637,7 +645,7 @@ func (c *ComposerPane) onQuestionChange(active bool, query string) {
 	}
 	c.mention.Hide()
 	c.Chat.MentionOpen = false
-	c.mentionGen++
+	c.abandonMentionSearch()
 	c.slash.Hide()
 	c.Chat.SlashOpen = false
 	items := filterQuestionItems(query, questionShortcutItems())
@@ -650,22 +658,61 @@ func (c *ComposerPane) onQuestionChange(active bool, query string) {
 	c.Chat.QuestionOpen = true
 }
 
+// mentionSearchLimit is how many file rows the picker shows.
+const mentionSearchLimit = 20
+
+// abandonMentionSearch drops any result still in flight and stops the work
+// behind it. Bumping the generation alone only makes the UI ignore the answer;
+// the fd process keeps walking the tree. Every path that closes the picker or
+// starts a new query goes through here, so the two always happen together.
+func (c *ComposerPane) abandonMentionSearch() {
+	c.mentionGen++
+	if c.mentionCancel != nil {
+		c.mentionCancel()
+		c.mentionCancel = nil
+	}
+}
+
+// scheduleMentionSearch debounces, then searches. Each call cancels the search
+// in flight: without that, every keystroke leaves an fd process walking the
+// tree, and on a large one they pile up faster than they finish.
 func (c *ComposerPane) scheduleMentionSearch(query string) {
 	if c == nil {
 		return
 	}
-	c.mentionGen++
+	c.abandonMentionSearch()
 	gen := c.mentionGen
 	cwd := c.cwd
 	publish := c.publish
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c.mentionCancel = cancel
+
 	go func() {
-		time.Sleep(100 * time.Millisecond)
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
-		paths, err := filesearch.Search(ctx, cwd, query, 20)
-		msg := controller.MentionResultsMsg{Gen: gen, Query: query, Paths: paths}
+		// Debounce. A newer keystroke cancels this before any work starts.
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-ctx.Done():
+			return
+		}
+
+		searchCtx, searchCancel := context.WithTimeout(ctx, 3*time.Second)
+		defer searchCancel()
+		paths, truncated, err := filesearch.Search(searchCtx, cwd, query, mentionSearchLimit)
+
+		// A superseded search has nothing useful to report.
+		if ctx.Err() != nil {
+			return
+		}
+
+		msg := controller.MentionResultsMsg{Gen: gen, Query: query, Paths: paths, Truncated: truncated}
 		if err != nil {
-			msg.ErrText = err.Error()
+			if errors.Is(err, filesearch.ErrTimeout) {
+				msg.ErrText = "Search timed out — type more of the path"
+			} else {
+				msg.ErrText = err.Error()
+			}
 		}
 		if publish != nil {
 			publish(msg)
@@ -681,7 +728,7 @@ func (c *ComposerPane) acceptMention(item mention.Item) {
 	if !ok {
 		start, end = c.Chat.Cursor, c.Chat.Cursor
 	}
-	c.mentionGen++
+	c.abandonMentionSearch()
 	c.mention.Hide()
 	c.Chat.MentionOpen = false
 

--- a/internal/tui/controller/msg.go
+++ b/internal/tui/controller/msg.go
@@ -46,10 +46,13 @@ func (ClearIfActivityMsg) isMsg() {}
 
 // MentionResultsMsg delivers async @-file search results to the UI goroutine.
 type MentionResultsMsg struct {
-	Gen     int
-	Query   string
-	Paths   []string
-	ErrText string
+	Gen   int
+	Query string
+	Paths []string
+	// Truncated reports that more matches exist than Paths holds, so the
+	// picker can say the list is partial instead of looking complete.
+	Truncated bool
+	ErrText   string
 }
 
 func (MentionResultsMsg) isMsg() {}

--- a/internal/util/filesearch/fd.go
+++ b/internal/util/filesearch/fd.go
@@ -41,34 +41,53 @@ func ResetResolveFDForTest() {
 	fdPathErr = nil
 }
 
-// Search runs fd under cwd and returns relative paths (slash-separated), at most limit.
+// ErrTimeout reports that the search did not finish in time. A large tree with
+// no match forces fd to walk everything, which can outlast the caller's
+// deadline. Callers show a hint rather than a child-process error.
+var ErrTimeout = errors.New("file search timed out")
+
+// Search runs fd under cwd and returns relative paths (slash-separated), at
+// most limit. truncated reports that fd found at least limit matches and more
+// probably exist, so the caller can say the list is partial.
 // An empty query lists files without a name filter.
-func Search(ctx context.Context, cwd, query string, limit int) ([]string, error) {
+func Search(ctx context.Context, cwd, query string, limit int) (paths []string, truncated bool, err error) {
 	if limit <= 0 {
 		limit = 20
 	}
 	bin, err := ResolveFD()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if cwd == "" {
 		cwd, err = os.Getwd()
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
+	// Ask for one more than needed: if fd returns limit+1, more matches exist
+	// and the caller can say so instead of silently cutting the list.
 	args := []string{
 		"--type", "f",
 		"--color", "never",
-		"--max-results", strconv.Itoa(limit),
+		"--max-results", strconv.Itoa(limit + 1),
 	}
 	query = strings.TrimSpace(query)
 	if query != "" {
-		// Match against the full relative path; escape regex metacharacters
-		// so the query is treated as a literal substring.
+		// Match against the full path; escape regex metacharacters so the
+		// query is treated as a literal substring.
 		args = append(args, "--full-path", "--", escapeRegex(query))
+	} else {
+		// A root with no pattern is read as the pattern, so ask for
+		// match-all explicitly.
+		args = append(args, "--", ".")
 	}
+	// Pass the root explicitly rather than relying on cmd.Dir. With cmd.Dir
+	// fd emits "./"-relative paths and --full-path then rebuilds a full path
+	// for every file, which on a large tree costs about 4x (5.3s vs 1.3s on
+	// 363k files). An absolute root needs no such work. Results are the same
+	// either way; the prefix is stripped below.
+	args = append(args, cwd)
 
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = cwd
@@ -76,15 +95,23 @@ func Search(ctx context.Context, cwd, query string, limit int) ([]string, error)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		// A cancelled context kills the child, which surfaces as "signal:
+		// killed" with empty stderr. Report the cause, not the symptom.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				return nil, false, ErrTimeout
+			}
+			return nil, false, ctxErr
+		}
 		// fd exits 1 when there are no matches.
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && exitErr.ExitCode() == 1 && stdout.Len() == 0 {
-			return nil, nil
+			return nil, false, nil
 		}
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
 			msg = err.Error()
 		}
-		return nil, fmt.Errorf("fd: %s", msg)
+		return nil, false, fmt.Errorf("fd: %s", msg)
 	}
 
 	lines := strings.Split(stdout.String(), "\n")
@@ -94,14 +121,22 @@ func Search(ctx context.Context, cwd, query string, limit int) ([]string, error)
 		if line == "" || line == "." {
 			continue
 		}
+		// fd echoes the root it was given, so strip it back to a path
+		// relative to cwd.
+		line = strings.TrimPrefix(line, cwd)
+		line = strings.TrimPrefix(line, string(os.PathSeparator))
 		line = strings.TrimPrefix(line, "./")
 		line = filepath.ToSlash(line)
+		if line == "" {
+			continue
+		}
 		out = append(out, line)
-		if len(out) >= limit {
-			break
+		if len(out) > limit {
+			// The extra match proves more exist; drop it and say so.
+			return out[:limit], true, nil
 		}
 	}
-	return out, nil
+	return out, false, nil
 }
 
 func escapeRegex(s string) string {

--- a/internal/util/filesearch/fd_test.go
+++ b/internal/util/filesearch/fd_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveFD(t *testing.T) {
@@ -15,12 +18,9 @@ func TestResolveFD(t *testing.T) {
 	if err != nil {
 		t.Skip("fd not installed:", err)
 	}
-	if bin == "" {
-		t.Fatal("empty fd path")
-	}
-	if _, err := os.Stat(bin); err != nil {
-		t.Fatalf("fd path %q not usable: %v", bin, err)
-	}
+	require.NotEmpty(t, bin)
+	_, err = os.Stat(bin)
+	require.NoError(t, err)
 }
 
 func TestSearch(t *testing.T) {
@@ -33,12 +33,8 @@ func TestSearch(t *testing.T) {
 	mustWrite := func(rel, body string) {
 		t.Helper()
 		p := filepath.Join(dir, filepath.FromSlash(rel))
-		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
 	}
 	mustWrite("go.mod", "module x\n")
 	mustWrite("internal/session/manager.go", "package session\n")
@@ -48,45 +44,67 @@ func TestSearch(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
-	all, err := Search(ctx, dir, "", 20)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(all) < 4 {
-		t.Fatalf("expected >=4 files, got %v", all)
-	}
+	all, truncated, err := Search(ctx, dir, "", 20)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(all), 4)
+	assert.False(t, truncated, "4 files under a limit of 20 must not report truncation: %v", all)
 
-	hits, err := Search(ctx, dir, "manager", 10)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(hits) == 0 {
-		t.Fatal("expected manager hits")
-	}
+	hits, _, err := Search(ctx, dir, "manager", 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, hits)
 	for _, h := range hits {
-		if !strings.Contains(h, "manager") {
-			t.Fatalf("unexpected hit %q", h)
-		}
-		if strings.Contains(h, "\\") {
-			t.Fatalf("path should use slashes: %q", h)
-		}
+		assert.Contains(t, h, "manager")
+		assert.NotContains(t, h, "\\")
 	}
 
-	limited, err := Search(ctx, dir, "", 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(limited) > 2 {
-		t.Fatalf("limit exceeded: %v", limited)
+	// 4 files, limit 2: the list is cut and the caller must be told.
+	limited, truncated, err := Search(ctx, dir, "", 2)
+	require.NoError(t, err)
+	require.Len(t, limited, 2)
+	assert.True(t, truncated, "more files exist beyond the limit, so truncated must be true")
+
+	// Exactly at the limit is not truncation: there is nothing more to show.
+	exact, truncated, err := Search(ctx, dir, "manager", 2)
+	require.NoError(t, err)
+	require.Len(t, exact, 2)
+	assert.False(t, truncated, "a full page with no further matches must not report truncation")
+
+	none, truncated, err := Search(ctx, dir, "zzz-no-such-file-xyz", 10)
+	require.NoError(t, err)
+	assert.Empty(t, none)
+	assert.False(t, truncated)
+}
+
+// A deadline must surface as ErrTimeout, not as the child's "signal: killed".
+// The picker shows this text, so it has to be about the search, not the process.
+func TestSearchTimeoutIsTyped(t *testing.T) {
+	ResetResolveFDForTest()
+	if _, err := ResolveFD(); err != nil {
+		t.Skip("fd not installed:", err)
 	}
 
-	none, err := Search(ctx, dir, "zzz-no-such-file-xyz", 10)
-	if err != nil {
-		t.Fatal(err)
+	// Already past the deadline, so fd is killed immediately.
+	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond)
+
+	_, _, err := Search(ctx, t.TempDir(), "anything", 10)
+	require.ErrorIs(t, err, ErrTimeout)
+	assert.NotContains(t, err.Error(), "signal:")
+}
+
+// A cancelled search reports the cancellation, not a process failure.
+func TestSearchCancelled(t *testing.T) {
+	ResetResolveFDForTest()
+	if _, err := ResolveFD(); err != nil {
+		t.Skip("fd not installed:", err)
 	}
-	if len(none) != 0 {
-		t.Fatalf("expected empty, got %v", none)
-	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := Search(ctx, t.TempDir(), "anything", 10)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestSearchMissingFD(t *testing.T) {
@@ -94,8 +112,48 @@ func TestSearchMissingFD(t *testing.T) {
 	if _, err := ResolveFD(); err == nil {
 		t.Skip("fd is installed")
 	}
-	_, err := Search(t.Context(), t.TempDir(), "", 5)
-	if err == nil {
-		t.Fatal("expected error when fd missing")
+	_, _, err := Search(t.Context(), t.TempDir(), "", 5)
+	require.Error(t, err)
+}
+
+// The root is passed to fd as an argument, which makes fd read a missing
+// pattern as the pattern itself. An empty query must still list files, and
+// results must stay relative to cwd rather than leaking the absolute root.
+func TestSearchEmptyQueryListsRelativePaths(t *testing.T) {
+	ResetResolveFDForTest()
+	if _, err := ResolveFD(); err != nil {
+		t.Skip("fd not installed:", err)
 	}
+
+	dir := t.TempDir()
+	for _, rel := range []string{"a.go", "sub/b.go"} {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("x"), 0o644))
+	}
+
+	got, _, err := Search(t.Context(), dir, "", 20)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, p := range got {
+		assert.False(t, filepath.IsAbs(p) || strings.HasPrefix(p, dir), "path must be relative to cwd, got %q", p)
+	}
+}
+
+// A query must match against the path, not just the file name, and the result
+// must still be relative.
+func TestSearchMatchesDirectorySegment(t *testing.T) {
+	ResetResolveFDForTest()
+	if _, err := ResolveFD(); err != nil {
+		t.Skip("fd not installed:", err)
+	}
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "internal", "session", "manager.go")
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte("x"), 0o644))
+
+	got, _, err := Search(t.Context(), dir, "session", 20)
+	require.NoError(t, err)
+	require.Equal(t, []string{"internal/session/manager.go"}, got)
 }


### PR DESCRIPTION
Cancel the fd search in flight on every keystroke and whenever the picker closes, so searches no longer pile up on large trees. Timeouts surface as actionable hints instead of child-process errors, and a truncated match list says so instead of looking complete.