### PR TITLE
refactor(hooks): drop unimplemented and unused fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - **Breaking:** `plugin.json` hooks use an event-map shape (`PreToolUse`, `PostToolUse`, … + `type: "command"` shell commands). Legacy flat `pre_tool` / `run` manifests are no longer accepted. Phi extensions: `SessionShutdown` (leaving the active session; `SessionEnd` is a deprecated alias), `SessionBeforeSwitch`, `PostTurn`, and `Command` slash hooks. See [doc/hooks.md](doc/hooks.md).
+- Hooks: drop unimplemented `plugin.json` fields (`if`, `once`, `statusMessage`, `asyncRewake`) until needed.
 
 ### Deprecated
 

--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -160,11 +160,8 @@ Top-level object with a `hooks` map: event name → array of matchers.
           {
             "type": "command",
             "command": "./lint.sh",
-            "if": "Bash(git *)",
             "timeout": 30,
-            "statusMessage": "checking",
-            "once": true,
-            "asyncRewake": true
+            "async": true
           }
         ]
       }
@@ -183,13 +180,9 @@ Top-level object with a `hooks` map: event name → array of matchers.
 | --- | --- | --- | --- |
 | `type` | string | `command` | Only `command` is supported |
 | `command` | string | required | Shell command (may include args, e.g. `./lint.sh --strict`) |
-| `if` | string | — | Permission-rule filter (not yet enforced at runtime) |
 | `shell` | string | bash | `bash` (uses `$SHELL`), `powershell`, or `pwsh` |
 | `timeout` | number | `5` | Seconds; capped at `60` |
-| `statusMessage` | string | — | Reserved for future spinner text |
-| `once` | boolean | `false` | Reserved (run once then remove) |
 | `async` | boolean | `false` | Fire-and-forget; result ignored |
-| `asyncRewake` | boolean | `false` | Async; exit `2` may wake the model (implies `async`) |
 
 | Field (matcher) | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -402,8 +395,6 @@ In `permissions.mode: readonly`, all loaded hooks still run (there is no `fail_c
 
 ## Limitations
 
-- `if` conditions are parsed but not enforced yet
-- `once`, `statusMessage`, and `asyncRewake` are parsed but not enforced yet (`async` background spawn works)
 - No file-watch hot reload (use palette reload or restart)
 - Hooks cannot register new tools (use `tooldef.Tool`)
 - Only `type: "command"` hooks (no prompt / agent / http yet)

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -48,15 +48,11 @@ type hookMatcherRaw struct {
 }
 
 type commandHookRaw struct {
-	Type          string `json:"type"`                    // always "command"
-	Command       string `json:"command"`                 // shell command to execute
-	If            string `json:"if,omitempty"`            // permission-rule filter, e.g. "Bash(git *)"
-	Shell         string `json:"shell,omitempty"`         // "bash" (default, uses $SHELL) | "powershell" (pwsh)
-	Timeout       int    `json:"timeout,omitempty"`       // seconds, must be > 0
-	StatusMessage string `json:"statusMessage,omitempty"` // spinner text while running
-	Once          bool   `json:"once,omitempty"`          // run once, then removed
-	Async         bool   `json:"async,omitempty"`         // run in background without blocking
-	AsyncRewake   bool   `json:"asyncRewake,omitempty"`   // background; exit 2 wakes the model (implies async)
+	Type    string `json:"type"`              // always "command"
+	Command string `json:"command"`           // shell command to execute
+	Shell   string `json:"shell,omitempty"`   // "bash" (default, uses $SHELL) | "powershell" (pwsh)
+	Timeout int    `json:"timeout,omitempty"` // seconds, must be > 0
+	Async   bool   `json:"async,omitempty"`   // run in background without blocking
 }
 
 // Hook is one event's matchers from a plugin.json.
@@ -76,15 +72,10 @@ type HookMatcher struct {
 // paths are resolved at exec time against Dir (shell cwd), not Abs'd here—
 // the value may include args (e.g. "./lint.sh --strict").
 type CommandHook struct {
-	Type          string
-	Command       string
-	If            string
-	Shell         string
-	Timeout       int
-	StatusMessage string
-	Once          bool
-	Async         bool
-	AsyncRewake   bool
+	Command string
+	Shell   string
+	Timeout int
+	Async   bool
 }
 
 // ParsePlugin reads a hooks plugin.json and returns one Hook per event.
@@ -207,16 +198,10 @@ func normalizeCommandHook(h commandHookRaw) (CommandHook, error) {
 		return CommandHook{}, fmt.Errorf("timeout must be > 0, got %d", h.Timeout)
 	}
 
-	async := h.Async || h.AsyncRewake
 	return CommandHook{
-		Type:          typ,
-		Command:       command,
-		If:            strings.TrimSpace(h.If),
-		Shell:         shell,
-		Timeout:       h.Timeout,
-		StatusMessage: strings.TrimSpace(h.StatusMessage),
-		Once:          h.Once,
-		Async:         async,
-		AsyncRewake:   h.AsyncRewake,
+		Command: command,
+		Shell:   shell,
+		Timeout: h.Timeout,
+		Async:   h.Async,
 	}, nil
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -21,11 +21,8 @@ func TestParsePluginOK(t *testing.T) {
           {
             "type": "command",
             "command": "./guard.sh",
-            "if": "Bash(git *)",
             "timeout": 30,
-            "statusMessage": "checking",
-            "once": true,
-            "asyncRewake": true
+            "async": true
           }
         ]
       }
@@ -48,14 +45,9 @@ func TestParsePluginOK(t *testing.T) {
 	require.Len(t, hooks[0].Matchers[0].Hooks, 1)
 
 	cmd := hooks[0].Matchers[0].Hooks[0]
-	assert.Equal(t, "command", cmd.Type)
 	assert.Equal(t, "./guard.sh", cmd.Command)
-	assert.Equal(t, "Bash(git *)", cmd.If)
 	assert.Equal(t, 30, cmd.Timeout)
-	assert.Equal(t, "checking", cmd.StatusMessage)
-	assert.True(t, cmd.Once)
-	assert.True(t, cmd.Async, "asyncRewake implies async")
-	assert.True(t, cmd.AsyncRewake)
+	assert.True(t, cmd.Async)
 	assert.Equal(t, dir, hooks[0].Dir)
 
 	assert.Equal(t, EventSessionStart, hooks[1].Event)

--- a/internal/hooks/run.go
+++ b/internal/hooks/run.go
@@ -65,7 +65,6 @@ type syncHookOutput struct {
 }
 
 type preToolSpecific struct {
-	HookEventName            string          `json:"hookEventName"`
 	PermissionDecision       string          `json:"permissionDecision"`
 	PermissionDecisionReason string          `json:"permissionDecisionReason"`
 	UpdatedInput             json.RawMessage `json:"updatedInput"`
@@ -73,16 +72,12 @@ type preToolSpecific struct {
 }
 
 type postToolSpecific struct {
-	HookEventName        string `json:"hookEventName"`
 	AdditionalContext    string `json:"additionalContext"`
 	UpdatedMCPToolOutput string `json:"updatedMCPToolOutput"`
 }
 
 type sessionStartSpecific struct {
-	HookEventName      string   `json:"hookEventName"`
-	AdditionalContext  string   `json:"additionalContext"`
-	InitialUserMessage string   `json:"initialUserMessage"`
-	WatchPaths         []string `json:"watchPaths"`
+	InitialUserMessage string `json:"initialUserMessage"`
 }
 
 func (b binding) run(ctx context.Context, in hookInput) (syncHookOutput, int, string, error) {


### PR DESCRIPTION
Remove the never-enforced plugin.json command-hook fields `if`, `once`, `statusMessage`, and `asyncRewake` from parsing, docs, and tests until they are actually needed. Also drop dead hook-output fields (`hookEventName` in specific outputs, session-start `additionalContext` and `watchPaths`) that were parsed but never read.