### PR TITLE
fix(session): replay tool executions on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- `/resume` and `/clear` now replay tool executions (with their styled rows) instead of dropping them.
+
 ### Security
 
 <!-- Released section -->

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -521,10 +521,8 @@ func (engine *Engine) toolCallsToBlocks(calls []llm.ToolCall) []session.ContentB
 	out := make([]session.ContentBlock, 0, len(calls))
 	for _, c := range calls {
 		input := c.Function.Arguments
-		if tool, ok := engine.executor.registry[c.Function.Name]; ok && tool.DetailFromArgs != nil {
-			if d := tool.DetailFromArgs(json.RawMessage(c.Function.Arguments)); d != "" {
-				input = d
-			}
+		if d := engine.ToolDetail(c.Function.Name, c.Function.Arguments); d != "" {
+			input = d
 		}
 		out = append(out, session.ContentBlock{
 			Type:     session.BlockToolUse,
@@ -535,6 +533,22 @@ func (engine *Engine) toolCallsToBlocks(calls []llm.ToolCall) []session.ContentB
 		})
 	}
 	return out
+}
+
+// ToolDetail resolves a friendly one-line detail for a tool call's raw JSON
+// arguments via the tool's DetailFromArgs, matching the live executor. It is
+// used both when building live tool_use blocks and by UI transcript replay so
+// resumed sessions show the same detail (e.g. "read foo.go:10-20") instead of
+// raw JSON. Returns "" when the tool is unknown or has no detail formatter.
+func (engine *Engine) ToolDetail(name, args string) string {
+	if engine == nil || engine.executor == nil {
+		return ""
+	}
+	tool, ok := engine.executor.registry[name]
+	if !ok || tool.DetailFromArgs == nil {
+		return ""
+	}
+	return tool.DetailFromArgs(json.RawMessage(args))
 }
 
 func buildContent(thinking, text string, tools []session.ContentBlock) []session.ContentBlock {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -227,7 +227,7 @@ func TestBuildSessionContext(t *testing.T) {
 func TestReplaySnapshotEmpty(t *testing.T) {
 	m := NewManager(t.TempDir())
 
-	snap := ReplaySnapshot(m.BuildContext())
+	snap := ReplaySnapshot(m.BuildContext(), nil)
 
 	assert.Empty(t, snap.Messages)
 	assert.Empty(t, snap.Tools)
@@ -251,7 +251,7 @@ func TestReplaySnapshotMessages(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	snap := ReplaySnapshot(m.BuildContext())
+	snap := ReplaySnapshot(m.BuildContext(), nil)
 	require.Len(t, snap.Messages, 2)
 
 	user := snap.Messages[0]
@@ -271,6 +271,64 @@ func TestReplaySnapshotMessages(t *testing.T) {
 	}, asst.Content)
 }
 
+func TestReplaySnapshotTools(t *testing.T) {
+	m := NewManager(t.TempDir())
+
+	_, err := m.Append(llm.Message{Role: llm.RoleUser, Content: "read the file"})
+	require.NoError(t, err)
+
+	_, err = m.Append(llm.Message{
+		Role:    llm.RoleAssistant,
+		Content: "calling tool",
+		ToolCalls: []llm.ToolCall{{
+			ID:   "t1",
+			Type: "function",
+			Function: llm.Function{
+				Name:      "Read",
+				Arguments: `{"path":"a.go"}`,
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	_, err = m.Append(llm.Message{
+		Role:       llm.RoleTool,
+		ToolCallID: "t1",
+		Content:    "package main",
+	})
+	require.NoError(t, err)
+
+	detail := func(toolName, _ string) string {
+		if toolName == "Read" {
+			return "read a.go"
+		}
+		return ""
+	}
+	snap := ReplaySnapshot(m.BuildContext(), detail)
+	require.Len(t, snap.Messages, 2)
+
+	asst := snap.Messages[1]
+	assert.Equal(t, StateComplete, asst.State)
+	assert.Equal(t, StopToolUse, asst.StopReason)
+	assert.Equal(t, []ContentBlock{
+		{Type: BlockText, Text: "calling tool"},
+		{Type: BlockToolUse, ID: "t1", Name: "Read", Input: "read a.go", Complete: true},
+	}, asst.Content)
+
+	run, ok := snap.Tools["t1"]
+	require.True(t, ok)
+	assert.Equal(t, "Read", run.Name)
+	assert.Equal(t, ToolDone, run.Status)
+	assert.Equal(t, "read a.go", run.Detail)
+	assert.Equal(t, "package main", run.Output)
+
+	items := Project(snap)
+	require.Len(t, items, 3)
+	assert.Equal(t, ItemTool, items[2].Kind)
+	assert.Equal(t, "Read", items[2].ToolName)
+	assert.Equal(t, "package main", items[2].ToolRun.Output)
+}
+
 func TestReplaySnapshotCompactionDropsOldMessages(t *testing.T) {
 	m := NewManager(t.TempDir())
 
@@ -286,7 +344,7 @@ func TestReplaySnapshotCompactionDropsOldMessages(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	snap := ReplaySnapshot(m.BuildContext())
+	snap := ReplaySnapshot(m.BuildContext(), nil)
 	require.Len(t, snap.Messages, 2)
 
 	assert.Equal(t, compactionID, snap.Messages[0].ID)

--- a/internal/session/replay.go
+++ b/internal/session/replay.go
@@ -6,45 +6,101 @@ import (
 	"github.com/pulseaiclub/phi/internal/llm"
 )
 
-// ReplaySnapshot builds a UI transcript snapshot from context path entries
-// (user/assistant text; tool rows simplified away). Used to re-render the
-// transcript after resume/clear without re-streaming.
-func ReplaySnapshot(entries []MessageEntry) Snapshot {
+// ToolDetail resolves a friendly one-line display detail for a tool call's raw
+// JSON arguments, mirroring the live executor's DetailFromArgs. It returns ""
+// when no friendly detail is available, in which case replay falls back to the
+// raw arguments. nil means always use the raw arguments.
+type ToolDetail func(toolName, args string) string
+
+// ReplaySnapshot rebuilds a UI transcript snapshot from context path entries
+// (user/assistant text, thinking, tool runs, compaction markers) so /resume
+// and /clear render the same styled rows as the live session without
+// re-streaming. detail resolves tool-call arguments into the same friendly
+// one-line detail the live turn shows (e.g. "read foo.go:10-20" instead of raw
+// JSON); pass nil to keep raw arguments.
+func ReplaySnapshot(entries []MessageEntry, detail ToolDetail) Snapshot {
 	var snap Snapshot
 	for _, entry := range entries {
 		switch entry.GetType() {
 		case EntryCompaction:
 			snap = Apply(snap, CompactionComplete{ID: entry.GetID()})
 		case EntryMessage:
-			msg := entry.(SessionMessageEntry).Message
-			switch msg.Role {
-			case llm.RoleUser:
-				images := make([]llm.Image, 0, len(msg.Images))
-				snap = Apply(snap, UserAppend{
-					ID:     entry.GetID(),
-					Text:   msg.Content,
-					Images: append(images, msg.Images...),
-				})
-			case llm.RoleAssistant:
-				text := msg.Content
-				var blocks []ContentBlock
-				if strings.TrimSpace(msg.ReasoningContent) != "" {
-					blocks = append(
-						blocks,
-						ContentBlock{Type: BlockThinking, Text: msg.ReasoningContent},
-					)
-				}
-				if text != "" {
-					blocks = append(blocks, ContentBlock{Type: BlockText, Text: text})
-				}
-				snap = Apply(snap, AssistantMessageUpdate{Message: Message{
-					ID:      entry.GetID(),
-					State:   StateComplete,
-					Text:    text,
-					Content: blocks,
-				}})
-			}
+			snap = replayEntry(snap, entry.(SessionMessageEntry), detail)
 		}
 	}
 	return snap
+}
+
+func replayEntry(snap Snapshot, entry SessionMessageEntry, detail ToolDetail) Snapshot {
+	msg := entry.Message
+	switch msg.Role {
+	case llm.RoleUser:
+		images := make([]llm.Image, 0, len(msg.Images))
+		return Apply(snap, UserAppend{
+			ID:     entry.GetID(),
+			Text:   msg.Content,
+			Images: append(images, msg.Images...),
+		})
+	case llm.RoleAssistant:
+		return Apply(snap, AssistantMessageUpdate{Message: replayAssistant(entry.GetID(), msg, detail)})
+	case llm.RoleTool:
+		// The persisted result is the model-facing content; Name/Detail of the
+		// run are carried over from the tool_use block by Apply's merge.
+		return Apply(snap, ToolData{Run: ToolRun{
+			ToolUseID: msg.ToolCallID,
+			Status:    ToolDone,
+			Output:    msg.Content,
+		}})
+	}
+	return snap
+}
+
+// replayAssistant converts a persisted assistant llm.Message into a session
+// Message. Tool calls become tool_use content blocks so the snapshot carries
+// the same tool runs (and thus styled tool rows) as the original turn.
+func replayAssistant(id string, msg llm.Message, detail ToolDetail) Message {
+	text := msg.Content
+	var blocks []ContentBlock
+	if strings.TrimSpace(msg.ReasoningContent) != "" {
+		blocks = append(blocks, ContentBlock{Type: BlockThinking, Text: msg.ReasoningContent})
+	}
+	if text != "" {
+		blocks = append(blocks, ContentBlock{Type: BlockText, Text: text})
+	}
+	for _, call := range msg.ToolCalls {
+		blocks = append(blocks, ContentBlock{
+			Type:     BlockToolUse,
+			ID:       call.ID,
+			Name:     call.Function.Name,
+			Input:    replayToolInput(call, detail),
+			Complete: true,
+		})
+	}
+	return Message{
+		ID:         id,
+		State:      StateComplete,
+		StopReason: replayStopReason(blocks),
+		Text:       text,
+		Content:    blocks,
+	}
+}
+
+// replayToolInput prefers the friendly detail (matching the live turn) and
+// falls back to the raw JSON arguments.
+func replayToolInput(call llm.ToolCall, detail ToolDetail) string {
+	if detail != nil {
+		if d := detail(call.Function.Name, call.Function.Arguments); d != "" {
+			return d
+		}
+	}
+	return call.Function.Arguments
+}
+
+func replayStopReason(blocks []ContentBlock) StopReason {
+	for _, b := range blocks {
+		if b.Type == BlockToolUse {
+			return StopToolUse
+		}
+	}
+	return StopNone
 }

--- a/internal/tui/controller/controller.go
+++ b/internal/tui/controller/controller.go
@@ -543,13 +543,14 @@ func (c *EngineController) Clear() error {
 	return nil
 }
 
-// ReplaySnapshot builds a UI transcript snapshot from the engine session
-// (user/assistant text; tool rows simplified away).
+// ReplaySnapshot builds a UI transcript snapshot from the engine session,
+// resolving tool-call details through the live tool registry so resumed tool
+// rows match the original rendering.
 func (c *EngineController) ReplaySnapshot() session.Snapshot {
 	if c.engine == nil || c.engine.Session() == nil {
 		return session.Snapshot{}
 	}
-	return session.ReplaySnapshot(c.engine.Session().PathEntries())
+	return session.ReplaySnapshot(c.engine.Session().PathEntries(), c.engine.ToolDetail)
 }
 
 // StartPrompt cancels any in-flight stream and starts a new agent loop.


### PR DESCRIPTION
ReplaySnapshot only rebuilt user/assistant/compaction entries, so /resume and /clear dropped every tool row from the transcript.

Reconstruct tool_use blocks from persisted assistant ToolCalls and tool results from role=tool entries, so the snapshot carries tool runs and the transcript renders the same styled rows (BashBlock/ToolBlock/ AgentBlock) as the live session.

Tool-call details now resolve through the registry's DetailFromArgs via Engine.ToolDetail, shared with the live path, so resumed rows show the same friendly one-line detail (e.g. "read a.go") instead of raw JSON arguments.