### PR TITLE
refactor(tui): pass controller bus instead of publish callbacks

### DIFF
--- a/internal/tui/commands/commands_test.go
+++ b/internal/tui/commands/commands_test.go
@@ -151,17 +151,13 @@ func TestCommandRegistry_DispatchSlash(t *testing.T) {
 	r := NewBuiltinRegistry()
 	var sessions, cleared int
 	var resumeID string
-	var toastMsg string
+	bus := controller.NewBus(nil)
 
 	ctx := CommandContext{
 		ShowSessions:  func() { sessions++ },
 		ResumeSession: func(id string) { resumeID = id },
 		ClearSession:  func() { cleared++ },
-		Publish: func(m controller.Msg) {
-			if tm, ok := m.(controller.ToastMsg); ok {
-				toastMsg = tm.Message
-			}
-		},
+		Bus:           bus,
 	}
 
 	assert.True(t, r.DispatchSlash("/sessions", ctx))
@@ -171,7 +167,7 @@ func TestCommandRegistry_DispatchSlash(t *testing.T) {
 	assert.Equal(t, "abc", resumeID)
 
 	assert.True(t, r.DispatchSlash("/resume", ctx))
-	assert.Contains(t, toastMsg, "Usage:")
+	assert.Contains(t, drainToast(t, bus), "Usage:")
 
 	assert.True(t, r.DispatchSlash("/clear", ctx))
 	assert.Equal(t, 1, cleared)
@@ -242,4 +238,16 @@ func TestCommandRegistry_HookCommandsDoNotReplaceBuiltins(t *testing.T) {
 	r.clearHookCommands()
 	assert.Empty(t, r.LookupInsert("review"))
 	assert.Equal(t, "/clear", r.LookupInsert("clear"))
+}
+
+// drainToast returns the message of the last queued ToastMsg and empties the bus.
+func drainToast(t *testing.T, bus *controller.Bus) string {
+	t.Helper()
+	var msg string
+	for _, m := range bus.Drain() {
+		if tm, ok := m.(controller.ToastMsg); ok {
+			msg = tm.Message
+		}
+	}
+	return msg
 }

--- a/internal/tui/commands/hook_cmds.go
+++ b/internal/tui/commands/hook_cmds.go
@@ -34,7 +34,7 @@ type HookCommands struct {
 	Composer   hookComposer
 	Footer     hookFooter
 	Submitter  hookSubmitter
-	Publish    func(controller.Msg)
+	Bus        *controller.Bus
 	CommandCtx func() CommandContext
 
 	gen     atomic.Uint64
@@ -42,10 +42,10 @@ type HookCommands struct {
 }
 
 func (h *HookCommands) showToast(msg string, kind toast.ToastKind) {
-	if h == nil || h.Publish == nil {
+	if h == nil {
 		return
 	}
-	h.Publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: 3 * time.Second})
+	h.Bus.Publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: 3 * time.Second})
 }
 
 // Sync replaces hook-sourced slash commands from the current hooks.Manager.
@@ -93,7 +93,7 @@ func (h *HookCommands) run(name string, args []string) {
 		return
 	}
 	if !h.running.CompareAndSwap(false, true) {
-		h.Publish(controller.HookCommandResultMsg{
+		h.Bus.Publish(controller.HookCommandResultMsg{
 			Gen: h.gen.Load(),
 			Err: "A hook command is already running",
 		})
@@ -103,12 +103,12 @@ func (h *HookCommands) run(name string, args []string) {
 
 	gen := h.gen.Load()
 	if h.Ctrl == nil {
-		h.Publish(controller.HookCommandResultMsg{Gen: gen, Err: "hooks are not loaded"})
+		h.Bus.Publish(controller.HookCommandResultMsg{Gen: gen, Err: "hooks are not loaded"})
 		return
 	}
 	mgr := h.Ctrl.Hooks()
 	if mgr == nil {
-		h.Publish(controller.HookCommandResultMsg{Gen: gen, Err: "hooks are not loaded"})
+		h.Bus.Publish(controller.HookCommandResultMsg{Gen: gen, Err: "hooks are not loaded"})
 		return
 	}
 	res, err := mgr.RunCommand(context.Background(), name, hooks.CommandEvent{
@@ -120,10 +120,10 @@ func (h *HookCommands) run(name string, args []string) {
 		return
 	}
 	if err != nil {
-		h.Publish(controller.HookCommandResultMsg{Gen: gen, Err: err.Error()})
+		h.Bus.Publish(controller.HookCommandResultMsg{Gen: gen, Err: err.Error()})
 		return
 	}
-	h.Publish(controller.HookCommandResultMsg{
+	h.Bus.Publish(controller.HookCommandResultMsg{
 		Gen:       gen,
 		Submit:    res.Submit,
 		Toast:     res.Toast,

--- a/internal/tui/commands/registry.go
+++ b/internal/tui/commands/registry.go
@@ -12,12 +12,13 @@ import (
 )
 
 // CommandContext is the capability surface passed to command Run / palette
-// builders. Callers fill only what they need; nil funcs are no-ops.
+// builders. Callers fill only what they need; nil funcs are no-ops and a
+// nil Bus swallows publishes.
 // It must not hold *Editor (keeps commands free of the root widget).
 type CommandContext struct {
 	Args []string // slash args after the command name
 
-	Publish     func(controller.Msg)
+	Bus         *controller.Bus
 	PushSubmenu func(title string, cmds []palette.PaletteCommand)
 
 	ShowSessions  func()
@@ -38,9 +39,7 @@ type CommandContext struct {
 }
 
 func (ctx CommandContext) toast(msg string, kind toast.ToastKind, d time.Duration) {
-	if ctx.Publish != nil {
-		ctx.Publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: d})
-	}
+	ctx.Bus.Publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: d})
 }
 
 // Command is one registered slash and/or palette entry.

--- a/internal/tui/commands/session_cmds.go
+++ b/internal/tui/commands/session_cmds.go
@@ -17,7 +17,7 @@ type SessionCommands struct {
 	Ctrl       *controller.EngineController
 	Transcript *transcript.TranscriptPane
 	Footer     *footer.FooterChrome
-	Publish    func(controller.Msg)
+	Bus        *controller.Bus
 	SyncHooks  func()
 }
 
@@ -26,23 +26,23 @@ func NewSessionCommands(
 	ctrl *controller.EngineController,
 	transcript *transcript.TranscriptPane,
 	footer *footer.FooterChrome,
-	publish func(controller.Msg),
+	bus *controller.Bus,
 	syncHooks func(),
 ) *SessionCommands {
 	return &SessionCommands{
 		Ctrl:       ctrl,
 		Transcript: transcript,
 		Footer:     footer,
-		Publish:    publish,
+		Bus:        bus,
 		SyncHooks:  syncHooks,
 	}
 }
 
 func (s *SessionCommands) showToast(msg string, kind toast.ToastKind, d time.Duration) {
-	if s == nil || s.Publish == nil {
+	if s == nil {
 		return
 	}
-	s.Publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: d})
+	s.Bus.Publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: d})
 }
 
 // Show lists recent sessions for the current session directory.

--- a/internal/tui/composer/mention_search_test.go
+++ b/internal/tui/composer/mention_search_test.go
@@ -1,7 +1,6 @@
 package composer
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -40,16 +39,8 @@ func TestScheduleMentionSearchCancelsPrevious(t *testing.T) {
 // one between the generation check and the update.
 func TestSupersededSearchDoesNotPublish(t *testing.T) {
 	c := NewComposerPane(components.DefaultTheme(), "m", t.TempDir())
-
-	var mu sync.Mutex
-	var queries []string
-	c.publish = func(m controller.Msg) {
-		if res, ok := m.(controller.MentionResultsMsg); ok {
-			mu.Lock()
-			queries = append(queries, res.Query)
-			mu.Unlock()
-		}
-	}
+	bus := controller.NewBus(nil)
+	c.bus = bus
 
 	// Cancelled well inside the 100ms debounce, so no work should start.
 	c.scheduleMentionSearch("first")
@@ -57,8 +48,12 @@ func TestSupersededSearchDoesNotPublish(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	mu.Lock()
-	defer mu.Unlock()
+	var queries []string
+	for _, m := range bus.Drain() {
+		if res, ok := m.(controller.MentionResultsMsg); ok {
+			queries = append(queries, res.Query)
+		}
+	}
 	assert.NotContains(t, queries, "first", "a cancelled search must stay quiet")
 }
 

--- a/internal/tui/composer/pane.go
+++ b/internal/tui/composer/pane.go
@@ -45,7 +45,7 @@ type ComposerPane struct {
 	transcript *transcript.TranscriptPane
 	submitter  BusyChecker
 
-	publish  func(controller.Msg)
+	bus      *controller.Bus
 	drainBus func()
 	onRedraw func()
 
@@ -88,7 +88,7 @@ func (c *ComposerPane) Wire(
 	submitter BusyChecker,
 	commands *commands.CommandRegistry,
 	cwd string,
-	publish func(controller.Msg),
+	bus *controller.Bus,
 	drainBus func(),
 	onRedraw func(),
 	imageEnabled func() bool,
@@ -107,7 +107,7 @@ func (c *ComposerPane) Wire(
 	c.commands = commands
 	c.transcript = transcript
 	c.submitter = submitter
-	c.publish = publish
+	c.bus = bus
 	c.drainBus = drainBus
 	c.onRedraw = onRedraw
 	c.imageEnabled = imageEnabled
@@ -121,9 +121,7 @@ func (c *ComposerPane) Wire(
 
 	c.palette.FocusReturn = &c.Chat
 	c.Chat.OnSubmit = func(text string) {
-		if c.publish != nil {
-			c.publish(controller.SubmitMsg{Text: text})
-		}
+		c.bus.Publish(controller.SubmitMsg{Text: text})
 		if c.drainBus != nil {
 			c.drainBus()
 		}
@@ -570,9 +568,7 @@ func (c *ComposerPane) handleEscape(ctx *components.EventContext) bool {
 		return true
 	}
 	if c.submitter != nil && (c.submitter.RunningBash() || c.submitter.IsBusy()) {
-		if c.publish != nil {
-			c.publish(controller.CancelStreamMsg{})
-		}
+		c.bus.Publish(controller.CancelStreamMsg{})
 		if c.drainBus != nil {
 			c.drainBus()
 		}
@@ -686,7 +682,7 @@ func (c *ComposerPane) scheduleMentionSearch(query string) {
 	c.abandonMentionSearch()
 	gen := c.mentionGen
 	cwd := c.cwd
-	publish := c.publish
+	bus := c.bus
 
 	ctx, cancel := context.WithCancel(context.Background())
 	c.mentionCancel = cancel
@@ -717,9 +713,7 @@ func (c *ComposerPane) scheduleMentionSearch(query string) {
 				msg.ErrText = err.Error()
 			}
 		}
-		if publish != nil {
-			publish(msg)
-		}
+		bus.Publish(msg)
 	}()
 }
 
@@ -771,10 +765,10 @@ func (c *ComposerPane) warnImagesDisabled() {
 }
 
 func (c *ComposerPane) showToast(msg string, kind toast.ToastKind, d time.Duration) {
-	if c == nil || c.publish == nil {
+	if c == nil {
 		return
 	}
-	c.publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: d})
+	c.bus.Publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: d})
 }
 
 func (c *ComposerPane) tryAttachClipboardImage(ctx *components.EventContext) bool {
@@ -842,9 +836,7 @@ func (c *ComposerPane) acceptSlash(item mention.Item) {
 	c.slash.Hide()
 	c.Chat.SlashOpen = false
 	if !strings.HasSuffix(insert, " ") {
-		if c.publish != nil {
-			c.publish(controller.SubmitMsg{Text: strings.TrimSpace(insert)})
-		}
+		c.bus.Publish(controller.SubmitMsg{Text: strings.TrimSpace(insert)})
 		if c.drainBus != nil {
 			c.drainBus()
 		}

--- a/internal/tui/composer/pane_test.go
+++ b/internal/tui/composer/pane_test.go
@@ -19,18 +19,14 @@ const png1x1Base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42m
 
 func TestTryAttachClipboardImageBlockedWithoutModelSupport(t *testing.T) {
 	c := NewComposerPane(components.DefaultTheme(), "m", "/tmp")
-	var got string
-	c.publish = func(m controller.Msg) {
-		if tm, ok := m.(controller.ToastMsg); ok {
-			got = tm.Message
-		}
-	}
+	bus := controller.NewBus(nil)
+	c.bus = bus
 	c.imageEnabled = func() bool { return false }
 
 	ctx := &components.EventContext{}
 	require.True(t, c.tryAttachClipboardImage(ctx))
 	assert.True(t, ctx.Consume)
-	assert.Contains(t, got, "does not support images")
+	assert.Contains(t, drainToast(t, bus), "does not support images")
 }
 
 func TestTryAttachClipboardImageFallsThroughWhenSupported(t *testing.T) {
@@ -58,21 +54,29 @@ func TestAcceptMentionImageBlockedWithoutModelSupport(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, png, 0o644))
 
 	c := NewComposerPane(components.DefaultTheme(), "m", dir)
-	var got string
-	c.publish = func(m controller.Msg) {
-		if tm, ok := m.(controller.ToastMsg); ok {
-			got = tm.Message
-		}
-	}
+	bus := controller.NewBus(nil)
+	c.bus = bus
 	c.imageEnabled = func() bool { return false }
 	c.Chat.Value = "@pixel.png"
 	c.Chat.Cursor = len(c.Chat.Value)
 
 	c.acceptMention(mention.Item{Path: "pixel.png"})
 
-	assert.Contains(t, got, "does not support images")
+	assert.Contains(t, drainToast(t, bus), "does not support images")
 	assert.Empty(t, c.Chat.PendingImages)
 	assert.Equal(t, "@pixel.png ", c.Chat.Value)
+}
+
+// drainToast returns the message of the last queued ToastMsg and empties the bus.
+func drainToast(t *testing.T, bus *controller.Bus) string {
+	t.Helper()
+	var msg string
+	for _, m := range bus.Drain() {
+		if tm, ok := m.(controller.ToastMsg); ok {
+			msg = tm.Message
+		}
+	}
+	return msg
 }
 
 func TestAcceptMentionImageAttachesWhenSupported(t *testing.T) {

--- a/internal/tui/editor/bridge.go
+++ b/internal/tui/editor/bridge.go
@@ -13,7 +13,7 @@ import (
 )
 
 type commandBridge struct {
-	publish    func(controller.Msg)
+	bus        *controller.Bus
 	composer   *composer.ComposerPane
 	transcript *transcript.TranscriptPane
 	ctrl       *controller.EngineController
@@ -34,7 +34,7 @@ type commandBridge struct {
 }
 
 func newCommandBridge(
-	publish func(controller.Msg),
+	bus *controller.Bus,
 	composer *composer.ComposerPane,
 	transcript *transcript.TranscriptPane,
 	ctrl *controller.EngineController,
@@ -52,7 +52,7 @@ func newCommandBridge(
 	skillPath string,
 ) *commandBridge {
 	return &commandBridge{
-		publish:         publish,
+		bus:             bus,
 		composer:        composer,
 		transcript:      transcript,
 		ctrl:            ctrl,
@@ -76,7 +76,7 @@ func (b *commandBridge) context() commands.CommandContext {
 		return commands.CommandContext{}
 	}
 	return commands.CommandContext{
-		Publish: b.publish,
+		Bus: b.bus,
 		PushSubmenu: func(title string, cmds []palette.PaletteCommand) {
 			b.composer.PushPalette(title, cmds)
 		},
@@ -84,13 +84,11 @@ func (b *commandBridge) context() commands.CommandContext {
 		ResumeSession: b.sessions.Resume,
 		ClearSession: func() {
 			if b.submitter != nil && b.submitter.StreamActive() {
-				if b.publish != nil {
-					b.publish(controller.ToastMsg{
-						Message:  "Cannot clear while a reply or command is running",
-						Kind:     toast.ToastWarning,
-						Duration: 3 * time.Second,
-					})
-				}
+				b.bus.Publish(controller.ToastMsg{
+					Message:  "Cannot clear while a reply or command is running",
+					Kind:     toast.ToastWarning,
+					Duration: 3 * time.Second,
+				})
 				return
 			}
 			b.sessions.Clear()

--- a/internal/tui/editor/editor.go
+++ b/internal/tui/editor/editor.go
@@ -113,7 +113,7 @@ func NewEditor(
 		func(text string) bool {
 			return e.vx != nil && e.vx.CopyToClipboard(text) == nil
 		},
-		e.Publish,
+		e.bus,
 	)
 	e.hookCmds = &commands.HookCommands{
 		Registry: e.commands,
@@ -121,13 +121,13 @@ func NewEditor(
 		CWD:      e.cwd,
 		Composer: e.composer,
 		Footer:   e.footer,
-		Publish:  e.Publish,
+		Bus:      e.bus,
 	}
 	e.sessions = commands.NewSessionCommands(
 		e.ctrl,
 		e.transcript,
 		e.footer,
-		e.Publish,
+		e.bus,
 		e.hookCmds.Sync,
 	)
 
@@ -144,7 +144,7 @@ func NewEditor(
 			}
 			return bridge.context()
 		},
-		e.Publish,
+		e.bus,
 		e.overlays.PermissionActive,
 		e.overlays.ContinueActive,
 		e.overlays.ResolvePermission,
@@ -152,7 +152,7 @@ func NewEditor(
 	)
 	e.hookCmds.Submitter = e.submitter
 	bridge = newCommandBridge(
-		e.Publish,
+		e.bus,
 		e.composer,
 		e.transcript,
 		e.ctrl,
@@ -175,7 +175,7 @@ func NewEditor(
 		e.submitter,
 		e.commands,
 		e.cwd,
-		e.Publish,
+		e.bus,
 		e.drainBus,
 		func() {
 			if e.vx != nil {

--- a/internal/tui/submit/bash.go
+++ b/internal/tui/submit/bash.go
@@ -20,7 +20,7 @@ import (
 type BashRunner struct {
 	transcript *transcript.TranscriptPane
 	composer   composer.Input
-	publish    func(controller.Msg)
+	bus        *controller.Bus
 
 	running atomic.Bool
 	mu      sync.Mutex
@@ -30,12 +30,12 @@ type BashRunner struct {
 func newBashRunner(
 	transcript *transcript.TranscriptPane,
 	composer composer.Input,
-	publish func(controller.Msg),
+	bus *controller.Bus,
 ) *BashRunner {
 	return &BashRunner{
 		transcript: transcript,
 		composer:   composer,
-		publish:    publish,
+		bus:        bus,
 	}
 }
 
@@ -143,17 +143,17 @@ func (b *BashRunner) run(id, command string) {
 }
 
 func (b *BashRunner) publishSession(ev session.Event) {
-	if b == nil || b.publish == nil {
+	if b == nil {
 		return
 	}
-	b.publish(controller.SessionEventMsg{Event: ev})
+	b.bus.Publish(controller.SessionEventMsg{Event: ev})
 }
 
 func (b *BashRunner) showToast(msg string, kind toast.ToastKind, d time.Duration) {
-	if b == nil || b.publish == nil {
+	if b == nil {
 		return
 	}
-	b.publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: d})
+	b.bus.Publish(controller.ToastMsg{Message: msg, Kind: kind, Duration: d})
 }
 
 // Cancel aborts a running user "!cmd". Returns true if one was cancelled.

--- a/internal/tui/submit/submitter.go
+++ b/internal/tui/submit/submitter.go
@@ -23,7 +23,7 @@ type Submitter struct {
 	bash       *BashRunner
 
 	commandContext func() commands.CommandContext
-	publish        func(controller.Msg)
+	bus            *controller.Bus
 
 	permissionActive  func() bool
 	continueActive    func() bool
@@ -32,7 +32,7 @@ type Submitter struct {
 }
 
 // NewSubmitter builds a Submitter from explicit collaborators (no *Editor back-pointer).
-// BashRunner is composed internally from transcript/composer/publish.
+// BashRunner is composed internally from transcript/composer/bus.
 func NewSubmitter(
 	ctrl *controller.EngineController,
 	commands *commands.CommandRegistry,
@@ -40,7 +40,7 @@ func NewSubmitter(
 	activity *controller.ActivityHandler,
 	composer composer.Input,
 	commandContext func() commands.CommandContext,
-	publish func(controller.Msg),
+	bus *controller.Bus,
 	permissionActive func() bool,
 	continueActive func() bool,
 	resolvePermission func(controller.AskReply),
@@ -52,9 +52,9 @@ func NewSubmitter(
 		transcript:        transcript,
 		activity:          activity,
 		composer:          composer,
-		bash:              newBashRunner(transcript, composer, publish),
+		bash:              newBashRunner(transcript, composer, bus),
 		commandContext:    commandContext,
-		publish:           publish,
+		bus:               bus,
 		permissionActive:  permissionActive,
 		continueActive:    continueActive,
 		resolvePermission: resolvePermission,
@@ -163,11 +163,9 @@ func (s *Submitter) Cancel() {
 	s.transcript.ApplySession(session.CancelStreaming{})
 	s.transcript.Sync()
 	s.activity.Apply(controller.ActivityCancelled)
-	if s.publish != nil {
-		time.AfterFunc(1200*time.Millisecond, func() {
-			s.publish(controller.ClearIfActivityMsg{If: controller.ActivityCancelled})
-		})
-	}
+	time.AfterFunc(1200*time.Millisecond, func() {
+		s.bus.Publish(controller.ClearIfActivityMsg{If: controller.ActivityCancelled})
+	})
 }
 
 // RunningBash reports whether a local "!cmd" is in flight.

--- a/internal/tui/transcript/pane.go
+++ b/internal/tui/transcript/pane.go
@@ -51,7 +51,7 @@ type TranscriptPane struct {
 
 	onUsage func(session.TokenUsage)
 	copyFn  func(text string) bool
-	publish func(controller.Msg)
+	bus     *controller.Bus
 }
 
 // NewTranscriptPane builds an empty transcript view.
@@ -85,16 +85,16 @@ func (t *TranscriptPane) SetUsageCallback(fn func(session.TokenUsage)) {
 	}
 }
 
-// SetCopyHandlers wires clipboard copy; feedback toasts go through publish.
+// SetCopyHandlers wires clipboard copy; feedback toasts go through the bus.
 func (t *TranscriptPane) SetCopyHandlers(
 	copyFn func(text string) bool,
-	publish func(controller.Msg),
+	bus *controller.Bus,
 ) {
 	if t == nil {
 		return
 	}
 	t.copyFn = copyFn
-	t.publish = publish
+	t.bus = bus
 }
 
 // Snapshot returns the current session model (read-only use on UI goroutine).
@@ -416,13 +416,10 @@ func (t *TranscriptPane) copyResult(text, okMsg, failMsg string) {
 		return
 	}
 	ok := t.copyFn != nil && t.copyFn(text)
-	if t.publish == nil {
-		return
-	}
 	if ok {
-		t.publish(controller.ToastMsg{Message: okMsg, Kind: toast.ToastSuccess, Duration: 2 * time.Second})
+		t.bus.Publish(controller.ToastMsg{Message: okMsg, Kind: toast.ToastSuccess, Duration: 2 * time.Second})
 	} else {
-		t.publish(controller.ToastMsg{Message: failMsg, Kind: toast.ToastError, Duration: 2 * time.Second})
+		t.bus.Publish(controller.ToastMsg{Message: failMsg, Kind: toast.ToastError, Duration: 2 * time.Second})
 	}
 }
 


### PR DESCRIPTION
Bus.Publish is nil-safe, so the per-component publish func and its nil checks are redundant. Wire *controller.Bus directly through composer, commands, submit, transcript and the editor bridge, and let tests drain a real bus instead of stubbing the callback.