### PR TITLE
feat(tui): show role in agent tool detail lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- TUI: `agent_spawn` / `agent_wait` tool rows show role in the detail line (`explore · …`).
+
 ### Deprecated
 
 ### Removed

--- a/internal/tools/agenttool/agent.go
+++ b/internal/tools/agenttool/agent.go
@@ -137,7 +137,7 @@ Concurrency cap: at most %d sub-agents run concurrently; spawning more fails (jo
 				"dir":         info.Dir,
 				"result_path": info.ResultPath,
 			})
-			return tooldef.Result{Content: body, Detail: info.ID, Output: body}, nil
+			return tooldef.Result{Content: body, Detail: roleDetail(string(info.Role), info.ID), Output: body}, nil
 		},
 	}
 }
@@ -165,14 +165,21 @@ func spawnDetail(input json.RawMessage) string {
 		Role        string `json:"role"`
 	}
 	_ = json.Unmarshal(input, &in)
-	label := in.Description
+	label := strings.TrimSpace(in.Description)
 	if label == "" {
 		label = truncateRunes(in.Prompt, 80)
 	}
-	if r := strings.TrimSpace(in.Role); r != "" && r != "explore" {
-		return r + ": " + label
+	return roleDetail(in.Role, label)
+}
+
+// roleDetail is the one-line TUI suffix: "explore · find auth".
+func roleDetail(role, rest string) string {
+	r := string(job.NormalizeRole(role))
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return r
 	}
-	return label
+	return r + " · " + rest
 }
 
 func agentListTool(deps AgentDeps) tooldef.Tool {
@@ -250,7 +257,11 @@ Use agent_cancel to stop a running job.`,
 				"result_path": res.Info.ResultPath,
 				"summary":     summary,
 			})
-			return tooldef.Result{Content: body, Detail: string(res.Info.Status), Output: body}, nil
+			return tooldef.Result{
+				Content: body,
+				Detail:  roleDetail(string(res.Info.Role), string(res.Info.Status)),
+				Output:  body,
+			}, nil
 		},
 	}
 }

--- a/internal/tools/agenttool/agent_test.go
+++ b/internal/tools/agenttool/agent_test.go
@@ -47,12 +47,14 @@ func TestAgentToolsSpawnWaitForcesDepthAndParent(t *testing.T) {
 		JobID string `json:"job_id"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(spawnRes.Content), &spawned))
+	assert.Equal(t, "explore · "+spawned.JobID, spawnRes.Detail)
 
 	waitArgs, _ := json.Marshal(map[string]any{"job_id": spawned.JobID})
 	waitRes, err := reg["agent_wait"].Run(t.Context(), waitArgs)
 	require.NoError(t, err)
 	assert.Contains(t, waitRes.Content, "summary-ok")
 	assert.Contains(t, waitRes.Content, `"status": "completed"`)
+	assert.Equal(t, "explore · completed", waitRes.Detail)
 }
 
 func TestAgentToolsSpawnRoleWorker(t *testing.T) {
@@ -75,6 +77,8 @@ func TestAgentToolsSpawnRoleWorker(t *testing.T) {
 		"prompt": "implement x",
 		"role":   "worker",
 	})
+	assert.Equal(t, "worker · implement x", reg["agent_spawn"].DetailFromArgs(raw))
+
 	res, err := reg["agent_spawn"].Run(t.Context(), raw)
 	require.NoError(t, err)
 	assert.Contains(t, res.Content, `"role": "worker"`)
@@ -83,10 +87,35 @@ func TestAgentToolsSpawnRoleWorker(t *testing.T) {
 		JobID string `json:"job_id"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(res.Content), &spawned))
+	assert.Equal(t, "worker · "+spawned.JobID, res.Detail)
 	waitArgs, _ := json.Marshal(map[string]any{"job_id": spawned.JobID})
 	waitRes, err := reg["agent_wait"].Run(t.Context(), waitArgs)
 	require.NoError(t, err)
 	assert.Contains(t, waitRes.Content, `"status": "completed"`)
+	assert.Equal(t, "worker · completed", waitRes.Detail)
+}
+
+func TestAgentSpawnDetailAlwaysIncludesRole(t *testing.T) {
+	mgr, err := job.New(job.Options{
+		Root: t.TempDir(),
+		Runner: job.RunnerFunc(func(_ context.Context, _ job.RunEnv) (string, error) {
+			return "x", nil
+		}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr.Close(t.Context()) })
+
+	reg := tools.NewRegistry(tools.AgentTools(tools.AgentDeps{
+		Manager:  mgr,
+		ParentID: func() string { return "p" },
+		WorkDir:  func() string { return t.TempDir() },
+	}))
+	detail := reg["agent_spawn"].DetailFromArgs
+	require.NotNil(t, detail)
+
+	assert.Equal(t, "explore · find auth", detail([]byte(`{"prompt":"p","description":"find auth"}`)))
+	assert.Equal(t, "explore · do the thing", detail([]byte(`{"prompt":"do the thing"}`)))
+	assert.Equal(t, "review · check diff", detail([]byte(`{"prompt":"p","description":"check diff","role":"review"}`)))
 }
 
 func TestAgentToolsSpawnBadRole(t *testing.T) {


### PR DESCRIPTION
`agent_spawn`/`agent_wait` tool rows now prefix the detail with the normalized role (`explore · …`) instead of only for non-explore roles. Both paths route through a shared `roleDetail` helper that normalizes via `job.NormalizeRole`, fixing the old case-sensitive "explore" check.