### PR TITLE
docs: add GetMerged maintainer review scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A minimal terminal coding agent harness in Go — a sibling to Pi.
   <a href="https://github.com/pulseaiclub/phi/actions"><img src="https://img.shields.io/github/actions/workflow/status/pulseaiclub/phi/ci.yml?style=flat&colorA=222222&colorB=3FB950" alt="CI"></a>
   <a href="https://go.dev"><img src="https://img.shields.io/badge/Go-1.26-00ADD8?style=flat&colorA=222222&logo=go&logoColor=white" alt="Go"></a>
   <a href="https://github.com/pulseaiclub/phi/releases"><img src="https://img.shields.io/github/v/release/pulseaiclub/phi?style=flat&colorA=222222&colorB=8957E5" alt="Release"></a>
+  <a href="https://getmerged.abhishekco.de/pulseaiclub/phi"><img src="https://getmerged.abhishekco.de/api/badge/pulseaiclub/phi" alt="GetMerged Scorecard"></a>
 </p>
 
 ![phi welcome](assets/phi.png)


### PR DESCRIPTION
Hey maintainers! 👋

I'm Abhishek, building [GetMerged](https://getmerged.abhishekco.de).

Like many developers, I spent years opening pull requests to popular open-source repos only to watch them sit unanswered for months. GitHub stars measure hype, not whether maintainers are actually active today.

I started GetMerged to fix that: we score projects based on real pull request review speed, newcomer acceptance, and merge rates.

Your project ranked in the **S-Tier** on our index with exceptional review turnaround. 

This PR adds your live GetMerged scorecard badge to `README.md` to signal to prospective contributors that their work won't get lost in a backlog.

[![GetMerged Scorecard](https://getmerged.abhishekco.de/api/badge/pulseaiclub/phi)](https://getmerged.abhishekco.de/pulseaiclub/phi)

*(Feel free to adjust the placement in your README or check your full scorecard at https://getmerged.abhishekco.de/pulseaiclub/phi)*
