### PR TITLE
refactor(agent): switch engine and session to functional options

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -147,13 +147,15 @@ func TestSelectedBuiltinToolsStillAppendExternalTools(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, jobs.Close(t.Context())) })
 
-	engine, err := agent.NewEngine(agent.EngineOpts{
-		Model:       llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
-		SessionOpts: agent.SessionOpts{Cwd: t.TempDir()},
-		Tools:       selected,
-		MCP:         pool,
-		Jobs:        jobs,
-	})
+	sess, err := agent.NewSession(agent.WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	engine, err := agent.NewEngine(
+		llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
+		sess,
+		agent.WithTools(selected),
+		agent.WithMCP(pool),
+		agent.WithJobs(jobs),
+	)
 	require.NoError(t, err)
 	assert.True(t, engine.HasTool("read"))
 	assert.False(t, engine.HasTool("bash"))
@@ -171,15 +173,17 @@ func TestRunLoopTimeoutCancelsLLMRequest(t *testing.T) {
 	defer server.Close()
 	defer close(block)
 
-	engine, err := agent.NewEngine(agent.EngineOpts{
-		Model: llm.ModelConfig{
+	sess, err := agent.NewSession(agent.WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	engine, err := agent.NewEngine(
+		llm.ModelConfig{
 			Name:    "fake",
 			BaseURL: server.URL,
 			APIKey:  "test",
 		},
-		SessionOpts: agent.SessionOpts{Cwd: t.TempDir()},
-		Gate:        permission.AllowAll{},
-	})
+		sess,
+		agent.WithGate(permission.AllowAll{}),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)

--- a/cmd/runloop.go
+++ b/cmd/runloop.go
@@ -63,31 +63,22 @@ func runHeadless(opts runOptions) error {
 		resumeID = opts.session
 	}
 
-	engineOpts := agent.EngineOpts{
-		Model: bs.Config.Model(),
-		SessionOpts: agent.SessionOpts{
-			Cwd:        bs.Cwd,
-			SessionDir: bs.SessionDir,
-			Persist:    true,
-			ResumeID:   resumeID,
-			ResumePath: resumePath,
-		},
-		Gate: bs.Gate,
-		// Ask is nil: in headless mode any Ask decision is denied, so no
-		// approval UI is ever reachable (Ask≡Deny even if the config mode
-		// does not fold Ask).
-		Ask:        nil,
-		Extensions: loadRunExtensions(bs),
-		Tools:      opts.builtinTools,
+	// Ask stays nil: in headless mode any Ask decision is denied, so no
+	// approval UI is ever reachable (Ask≡Deny even if the config mode
+	// does not fold Ask).
+	extRunner := loadRunExtensions(bs)
+	engineOpts := []agent.EngineOption{
+		agent.WithGate(bs.Gate),
+		agent.WithExtensions(extRunner),
+		agent.WithTools(opts.builtinTools),
 	}
 	if pool, err := mcp.LoadPool(bs.Proj.MCPConfigFile()); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: mcp:", err)
 	} else if pool != nil {
-		engineOpts.MCP = pool
+		engineOpts = append(engineOpts, agent.WithMCP(pool))
 		defer func() { _ = pool.Close() }()
 	}
 	if bs.Config.Agents.Enabled {
-		extRunner := engineOpts.Extensions
 		jobs, jobErr := agent.NewJobManager(bs.Proj.JobsDir(), bs.Config.Model(), nil, func() *extension.Runner {
 			return extRunner
 		})
@@ -96,10 +87,26 @@ func runHeadless(opts runOptions) error {
 			return exitCode(ExitUsage)
 		}
 		defer func() { _ = jobs.Close(context.Background()) }()
-		engineOpts.Jobs = jobs
+		engineOpts = append(engineOpts, agent.WithJobs(jobs))
 	}
 
-	engine, err := agent.NewEngine(engineOpts)
+	sessionOpts := []agent.SessionOption{
+		agent.WithCwd(bs.Cwd),
+		agent.WithSessionDir(bs.SessionDir),
+		agent.WithPersist(true),
+	}
+	if resumePath != "" {
+		sessionOpts = append(sessionOpts, agent.WithResumePath(resumePath))
+	} else if resumeID != "" {
+		sessionOpts = append(sessionOpts, agent.WithResumeID(resumeID))
+	}
+	sess, err := agent.NewSession(sessionOpts...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "phi run:", err)
+		return exitCode(ExitUsage)
+	}
+
+	engine, err := agent.NewEngine(bs.Config.Model(), sess, engineOpts...)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "phi run:", err)
 		return exitCode(ExitUsage)

--- a/doc/mcp.md
+++ b/doc/mcp.md
@@ -153,5 +153,5 @@ Logs: `~/.phi/logs/mcp/<name>.log` (override with `PHI_MCP_LOG_DIR`).
 | --- | --- |
 | `internal/mcp/` | config, Client, session, stdio/http transports, Pool |
 | `internal/tools/mcptool/` | `mcp_list` / `mcp_inspect` / `mcp_call` |
-| `internal/agent/engine.go` | `EngineOpts.MCP` wires meta-tools |
+| `internal/agent/engine.go` | `WithMCP` wires meta-tools |
 | `cmd/mcp.go` | `phi mcp` subcommand |

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -57,52 +57,39 @@ type Engine struct {
 	session *Session
 }
 
-// EngineOpts configures NewEngine.
-type EngineOpts struct {
-	Model              llm.ModelConfig
-	SessionOpts        SessionOpts
-	Gate               permission.Gate    // nil = allow all
-	Ask                permission.AskFunc // nil = deny on Ask
-	ContinueAsk        ContinueFunc       // nil = ErrMaxRounds on budget exhaust
-	Tools              []tools.Tool       // nil = tools.DefaultTools(); sub-agents use ChildTools()
-	MaxRounds          int                // 0 = package default
-	Jobs               *job.Manager       // if set, register agent_* tools on this engine
-	Extensions         *extension.Runner  // nil = no extensions; child engines inherit parent Runner
-	OmitExtensionTools bool               // when true, Runner events still fire but RegisterTool tools are not merged
-	MCP                *mcp.Pool          // if set, register mcp_list/inspect/call meta-tools
-}
-
-// NewEngine wires an LLM client, tool executor, and session store.
-func NewEngine(opts EngineOpts) (*Engine, error) {
-	sess, err := NewSession(opts.SessionOpts)
-	if err != nil {
-		return nil, err
+// NewEngine wires an LLM client, tool executor, and an externally created session.
+func NewEngine(model llm.ModelConfig, sess *Session, opts ...EngineOption) (*Engine, error) {
+	if sess == nil {
+		return nil, errors.New("agent: session is required")
 	}
-	cfg := opts.Model
+	var cfg engineConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	engine := &Engine{
 		maxRounds:     defaultMaxToolRounds,
-		skillPath:     cfg.SkillPath,
-		contextWindow: cfg.ContextWindow,
-		modelCfg:      cfg,
+		skillPath:     model.SkillPath,
+		contextWindow: model.ContextWindow,
+		modelCfg:      model,
 		session:       sess,
-		gate:          opts.Gate,
-		ask:           opts.Ask,
-		continueAsk:   opts.ContinueAsk,
-		jobs:          opts.Jobs,
-		extensions:    opts.Extensions,
-		omitExtTools:  opts.OmitExtensionTools,
-		mcp:           opts.MCP,
+		gate:          cfg.gate,
+		ask:           cfg.ask,
+		continueAsk:   cfg.continueAsk,
+		jobs:          cfg.jobs,
+		extensions:    cfg.extensions,
+		omitExtTools:  cfg.omitExtTools,
+		mcp:           cfg.mcp,
 	}
-	if opts.MaxRounds > 0 {
-		engine.maxRounds = opts.MaxRounds
+	if cfg.maxRounds > 0 {
+		engine.maxRounds = cfg.maxRounds
 	}
-	engine.baseTools = opts.Tools
+	engine.baseTools = cfg.tools
 	if engine.extensions != nil {
 		engine.extensions.SetBaseTools(engine.buildCoreTools(engine.baseTools))
 		engine.extensions.SetMeta(engine.SessionID(), engine.SessionCwd())
 	}
 	toolList := engine.buildToolList(engine.baseTools)
-	engine.client = llmclient.NewClient(cfg, tools.Definitions(toolList), engine.systemPrompt())
+	engine.client = llmclient.NewClient(model, tools.Definitions(toolList), engine.systemPrompt())
 	engine.bindExecutor(tools.NewRegistry(toolList))
 	return engine, nil
 }
@@ -294,10 +281,9 @@ func (engine *Engine) SessionCwd() string {
 }
 
 // ReplaceSession swaps the session store (used by /resume).
-func (engine *Engine) ReplaceSession(opts SessionOpts) error {
-	sess, err := NewSession(opts)
-	if err != nil {
-		return err
+func (engine *Engine) ReplaceSession(sess *Session) error {
+	if sess == nil {
+		return errors.New("agent: session is required")
 	}
 	engine.session = sess
 	if engine.executor != nil {

--- a/internal/agent/engine_jobs_test.go
+++ b/internal/agent/engine_jobs_test.go
@@ -22,11 +22,13 @@ func TestNewEngineRegistersJobs(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = mgr.Close(t.Context()) })
 
-	eng, err := agent.NewEngine(agent.EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: "http://127.0.0.1:9", APIKey: "x"},
-		SessionOpts: agent.SessionOpts{Cwd: t.TempDir()},
-		Jobs:        mgr,
-	})
+	sess, err := agent.NewSession(agent.WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	eng, err := agent.NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: "http://127.0.0.1:9", APIKey: "x"},
+		sess,
+		agent.WithJobs(mgr),
+	)
 	require.NoError(t, err)
 	assert.Same(t, mgr, eng.Jobs())
 	assert.True(t, eng.HasTool("agent_spawn"))
@@ -46,10 +48,12 @@ func TestSetJobsTogglesAgentTools(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = mgr.Close(t.Context()) })
 
-	eng, err := agent.NewEngine(agent.EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: "http://127.0.0.1:9", APIKey: "x"},
-		SessionOpts: agent.SessionOpts{Cwd: t.TempDir()},
-	})
+	sess, err := agent.NewSession(agent.WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	eng, err := agent.NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: "http://127.0.0.1:9", APIKey: "x"},
+		sess,
+	)
 	require.NoError(t, err)
 	assert.False(t, eng.HasTool("agent_spawn"))
 

--- a/internal/agent/engine_mcp_test.go
+++ b/internal/agent/engine_mcp_test.go
@@ -13,14 +13,15 @@ func TestEngineRegistersMCPMetaTools(t *testing.T) {
 		"echo": {Command: []string{"true"}},
 	})
 
-	eng, err := agent.NewEngine(agent.EngineOpts{
-		Model: llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
-		SessionOpts: agent.SessionOpts{
-			Cwd:     t.TempDir(),
-			Persist: false,
-		},
-		MCP: pool,
-	})
+	sess, err := agent.NewSession(agent.WithCwd(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng, err := agent.NewEngine(
+		llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
+		sess,
+		agent.WithMCP(pool),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,14 +32,15 @@ func TestEngineRegistersMCPMetaTools(t *testing.T) {
 	}
 
 	// Explicit child tool list without MCP → no meta tools (sub-agent path).
-	eng2, err := agent.NewEngine(agent.EngineOpts{
-		Model: llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
-		SessionOpts: agent.SessionOpts{
-			Cwd:     t.TempDir(),
-			Persist: false,
-		},
-		Tools: agent.ChildTools(),
-	})
+	sess2, err := agent.NewSession(agent.WithCwd(t.TempDir()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng2, err := agent.NewEngine(
+		llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
+		sess2,
+		agent.WithTools(agent.ChildTools()),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/engine_runner.go
+++ b/internal/agent/engine_runner.go
@@ -76,21 +76,22 @@ func (r EngineRunner) Run(ctx context.Context, env job.RunEnv) (string, error) {
 	}
 
 	sessionDir := filepath.Join(env.Job.Dir, "session")
-	engine, err := NewEngine(EngineOpts{
-		Model:              model,
-		Gate:               gate,
-		Ask:                nil,
-		Tools:              toolList,
-		MaxRounds:          r.MaxRounds,
-		Extensions:         extRunner,
-		OmitExtensionTools: true,
-		SessionOpts: SessionOpts{
-			Cwd:        cwd,
-			SessionDir: sessionDir,
-			Persist:    true,
-			ParentID:   env.Job.ParentID,
-		},
-	})
+	sess, err := NewSession(
+		WithCwd(cwd),
+		WithSessionDir(sessionDir),
+		WithPersist(true),
+		WithParentID(env.Job.ParentID),
+	)
+	if err != nil {
+		return "", err
+	}
+	engine, err := NewEngine(model, sess,
+		WithGate(gate),
+		WithTools(toolList),
+		WithMaxRounds(r.MaxRounds),
+		WithExtensions(extRunner),
+		WithOmitExtensionTools(true),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -88,12 +88,14 @@ func countingTool(runs *atomic.Int32) tools.Tool {
 
 func newRoundTestEngine(t *testing.T, serverURL string, runs *atomic.Int32) *Engine {
 	t.Helper()
-	engine, err := NewEngine(EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: serverURL, APIKey: "x"},
-		SessionOpts: SessionOpts{Cwd: t.TempDir()},
-		Gate:        permission.AllowAll{},
-		Tools:       []tools.Tool{countingTool(runs)},
-	})
+	sess, err := NewSession(WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	engine, err := NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: serverURL, APIKey: "x"},
+		sess,
+		WithGate(permission.AllowAll{}),
+		WithTools([]tools.Tool{countingTool(runs)}),
+	)
 	require.NoError(t, err)
 	return engine
 }
@@ -160,15 +162,17 @@ func TestLoopContinueAskGrantsAnotherBudget(t *testing.T) {
 	defer server.Close()
 
 	var asks atomic.Int32
-	engine, err := NewEngine(EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
-		SessionOpts: SessionOpts{Cwd: t.TempDir()},
-		Gate:        permission.AllowAll{},
-		ContinueAsk: func(context.Context, int) (bool, error) {
+	sess, err := NewSession(WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	engine, err := NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
+		sess,
+		WithGate(permission.AllowAll{}),
+		WithContinueAsk(func(context.Context, int) (bool, error) {
 			// Approve once so the loop can start a second budget window, then stop.
 			return asks.Add(1) == 1, nil
-		},
-	})
+		}),
+	)
 	require.NoError(t, err)
 	require.NoError(t, engine.SetMaxRounds(1))
 
@@ -189,14 +193,16 @@ func TestLoopContinueAskDeclineReturnsErrMaxRounds(t *testing.T) {
 	server, _ := fakeToolSequenceServer(-1)
 	defer server.Close()
 
-	engine, err := NewEngine(EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
-		SessionOpts: SessionOpts{Cwd: t.TempDir()},
-		Gate:        permission.AllowAll{},
-		ContinueAsk: func(context.Context, int) (bool, error) {
+	sess, err := NewSession(WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	engine, err := NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
+		sess,
+		WithGate(permission.AllowAll{}),
+		WithContinueAsk(func(context.Context, int) (bool, error) {
 			return false, nil
-		},
-	})
+		}),
+	)
 	require.NoError(t, err)
 	require.NoError(t, engine.SetMaxRounds(1))
 
@@ -212,11 +218,13 @@ func TestLoopContinueAskDeclineReturnsErrMaxRounds(t *testing.T) {
 }
 
 func TestSetMaxRoundsRejectsNonPositive(t *testing.T) {
-	engine, err := NewEngine(EngineOpts{
-		Model:       llm.ModelConfig{Name: "fake", BaseURL: "http://unused", APIKey: "x"},
-		SessionOpts: SessionOpts{Cwd: t.TempDir()},
-		Gate:        permission.AllowAll{},
-	})
+	sess, err := NewSession(WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	engine, err := NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: "http://unused", APIKey: "x"},
+		sess,
+		WithGate(permission.AllowAll{}),
+	)
 	require.NoError(t, err)
 	require.Error(t, engine.SetMaxRounds(0))
 	require.Error(t, engine.SetMaxRounds(-1))

--- a/internal/agent/option.go
+++ b/internal/agent/option.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"github.com/pulseaiclub/phi/internal/extension"
+	"github.com/pulseaiclub/phi/internal/job"
+	"github.com/pulseaiclub/phi/internal/mcp"
+	"github.com/pulseaiclub/phi/internal/permission"
+	"github.com/pulseaiclub/phi/internal/tools"
+)
+
+// EngineOption configures optional NewEngine dependencies.
+type EngineOption func(*engineConfig)
+
+type engineConfig struct {
+	gate         permission.Gate
+	ask          permission.AskFunc
+	continueAsk  ContinueFunc
+	tools        []tools.Tool
+	maxRounds    int
+	jobs         *job.Manager
+	extensions   *extension.Runner
+	omitExtTools bool
+	mcp          *mcp.Pool
+}
+
+// WithGate sets the permission gate (nil = allow all).
+func WithGate(gate permission.Gate) EngineOption {
+	return func(c *engineConfig) { c.gate = gate }
+}
+
+// WithAsk sets the ask callback (nil = deny on Ask).
+func WithAsk(ask permission.AskFunc) EngineOption {
+	return func(c *engineConfig) { c.ask = ask }
+}
+
+// WithContinueAsk sets the max-rounds continuation prompt (nil = ErrMaxRounds).
+func WithContinueAsk(fn ContinueFunc) EngineOption {
+	return func(c *engineConfig) { c.continueAsk = fn }
+}
+
+// WithTools sets the base tool list (nil = tools.DefaultTools(); sub-agents use ChildTools()).
+func WithTools(list []tools.Tool) EngineOption {
+	return func(c *engineConfig) { c.tools = list }
+}
+
+// WithMaxRounds sets the tool-round budget (0 = package default).
+func WithMaxRounds(n int) EngineOption {
+	return func(c *engineConfig) { c.maxRounds = n }
+}
+
+// WithJobs registers agent_* tools against the given job manager.
+func WithJobs(jobs *job.Manager) EngineOption {
+	return func(c *engineConfig) { c.jobs = jobs }
+}
+
+// WithExtensions attaches an extension runner (nil = no extensions).
+func WithExtensions(runner *extension.Runner) EngineOption {
+	return func(c *engineConfig) { c.extensions = runner }
+}
+
+// WithOmitExtensionTools keeps Runner events but skips RegisterTool merge (sub-agents).
+func WithOmitExtensionTools(omit bool) EngineOption {
+	return func(c *engineConfig) { c.omitExtTools = omit }
+}
+
+// WithMCP registers mcp_list/inspect/call meta-tools against the pool.
+func WithMCP(pool *mcp.Pool) EngineOption {
+	return func(c *engineConfig) { c.mcp = pool }
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -19,30 +19,66 @@ type Session struct {
 	contextCacheValid bool
 }
 
-// SessionOpts configures how the engine binds a session store.
-type SessionOpts struct {
-	Cwd        string // written to SessionHeader.Cwd; usually process cwd
-	SessionDir string // ~/.phi/session; required when Persist is true
-	Persist    bool   // false → in-memory (tests default)
-	ResumePath string // open this jsonl; ignores "new session"
-	ResumeID   string // resolve under SessionDir (mutually exclusive with ResumePath)
-	ParentID   string // reserved for sub-agents; passed to WithParent
+// SessionOption configures NewSession.
+type SessionOption func(*sessionConfig)
+
+type sessionConfig struct {
+	cwd        string
+	sessionDir string
+	persist    bool
+	resumePath string
+	resumeID   string
+	parentID   string
+}
+
+// WithCwd sets the cwd written to SessionHeader (usually process cwd).
+func WithCwd(cwd string) SessionOption {
+	return func(c *sessionConfig) { c.cwd = cwd }
+}
+
+// WithSessionDir sets ~/.phi/session (required when Persist is true or resuming by id).
+func WithSessionDir(dir string) SessionOption {
+	return func(c *sessionConfig) { c.sessionDir = dir }
+}
+
+// WithPersist enables JSONL persistence (false → in-memory; tests default).
+func WithPersist(persist bool) SessionOption {
+	return func(c *sessionConfig) { c.persist = persist }
+}
+
+// WithResumePath opens this jsonl path (mutually exclusive with WithResumeID).
+func WithResumePath(path string) SessionOption {
+	return func(c *sessionConfig) { c.resumePath = path }
+}
+
+// WithResumeID resolves a session under SessionDir (mutually exclusive with WithResumePath).
+func WithResumeID(id string) SessionOption {
+	return func(c *sessionConfig) { c.resumeID = id }
+}
+
+// WithParentID links a new persisted session to a parent (sub-agents).
+func WithParentID(id string) SessionOption {
+	return func(c *sessionConfig) { c.parentID = id }
 }
 
 // NewSession creates a session wrapper according to opts.
-func NewSession(opts SessionOpts) (*Session, error) {
-	if opts.ResumePath != "" && opts.ResumeID != "" {
+func NewSession(opts ...SessionOption) (*Session, error) {
+	var cfg sessionConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.resumePath != "" && cfg.resumeID != "" {
 		return nil, errors.New("agent: ResumePath and ResumeID are mutually exclusive")
 	}
 
-	if opts.ResumePath != "" || opts.ResumeID != "" {
-		path := opts.ResumePath
+	if cfg.resumePath != "" || cfg.resumeID != "" {
+		path := cfg.resumePath
 		if path == "" {
-			if opts.SessionDir == "" {
+			if cfg.sessionDir == "" {
 				return nil, errors.New("agent: SessionDir required to resume by id")
 			}
 			var err error
-			path, err = session.FindSessionFile(opts.SessionDir, opts.ResumeID)
+			path, err = session.FindSessionFile(cfg.sessionDir, cfg.resumeID)
 			if err != nil {
 				return nil, err
 			}
@@ -54,14 +90,14 @@ func NewSession(opts SessionOpts) (*Session, error) {
 		return &Session{manager: m, lastID: m.LeafID()}, nil
 	}
 
-	if opts.Persist {
-		if opts.SessionDir == "" {
+	if cfg.persist {
+		if cfg.sessionDir == "" {
 			return nil, errors.New("agent: SessionDir required when Persist is true")
 		}
-		m, err := session.NewSessionManager(opts.Cwd,
-			session.WithSessionDir(opts.SessionDir),
+		m, err := session.NewSessionManager(cfg.cwd,
+			session.WithSessionDir(cfg.sessionDir),
 			session.WithShouldFlush(true),
-			session.WithParent(opts.ParentID),
+			session.WithParent(cfg.parentID),
 		)
 		if err != nil {
 			return nil, err
@@ -69,7 +105,7 @@ func NewSession(opts SessionOpts) (*Session, error) {
 		return &Session{manager: m}, nil
 	}
 
-	return &Session{manager: session.NewManager(opts.Cwd)}, nil
+	return &Session{manager: session.NewManager(cfg.cwd)}, nil
 }
 
 // Fork creates a new Session that shares the same underlying manager state

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -13,11 +13,11 @@ import (
 
 func TestSessionPersistFlush(t *testing.T) {
 	dir := t.TempDir()
-	sess, err := NewSession(SessionOpts{
-		Cwd:        dir,
-		SessionDir: dir,
-		Persist:    true,
-	})
+	sess, err := NewSession(
+		WithCwd(dir),
+		WithSessionDir(dir),
+		WithPersist(true),
+	)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sess.ID())
 	assert.NotEmpty(t, sess.File())
@@ -42,7 +42,7 @@ func TestSessionPersistFlush(t *testing.T) {
 }
 
 func TestSessionPersistFalseNoDisk(t *testing.T) {
-	sess, err := NewSession(SessionOpts{Persist: false, Cwd: t.TempDir()})
+	sess, err := NewSession(WithCwd(t.TempDir()))
 	require.NoError(t, err)
 	assert.Empty(t, sess.File())
 	require.NoError(t, sess.Append(llm.Message{Role: llm.RoleUser, Content: "a"}))
@@ -52,14 +52,16 @@ func TestSessionPersistFalseNoDisk(t *testing.T) {
 
 func TestEngineSetModelKeepsSession(t *testing.T) {
 	dir := t.TempDir()
-	eng, err := NewEngine(EngineOpts{
-		Model: llm.ModelConfig{Name: "model-a", APIKey: "k", BaseURL: "http://example"},
-		SessionOpts: SessionOpts{
-			Cwd:        dir,
-			SessionDir: dir,
-			Persist:    true,
-		},
-	})
+	sess, err := NewSession(
+		WithCwd(dir),
+		WithSessionDir(dir),
+		WithPersist(true),
+	)
+	require.NoError(t, err)
+	eng, err := NewEngine(
+		llm.ModelConfig{Name: "model-a", APIKey: "k", BaseURL: "http://example"},
+		sess,
+	)
 	require.NoError(t, err)
 
 	id := eng.SessionID()

--- a/internal/tui/controller/controller.go
+++ b/internal/tui/controller/controller.go
@@ -111,20 +111,22 @@ func NewController(bus *Bus, proj *project.Project, cwd string) (*EngineControll
 		c.mcpPool = pool
 	}
 
-	eng, err := agent.NewEngine(agent.EngineOpts{
-		Model: c.modelCfg,
-		SessionOpts: agent.SessionOpts{
-			Cwd:        cwd,
-			SessionDir: c.sessionDir,
-			Persist:    true,
-		},
-		Gate:        c.gate,
-		Ask:         c.askPermission,
-		ContinueAsk: c.askContinue,
-		Jobs:        c.engineJobs(),
-		Extensions:  extRunner,
-		MCP:         c.mcpPool,
-	})
+	sess, err := agent.NewSession(
+		agent.WithCwd(cwd),
+		agent.WithSessionDir(c.sessionDir),
+		agent.WithPersist(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+	eng, err := agent.NewEngine(c.modelCfg, sess,
+		agent.WithGate(c.gate),
+		agent.WithAsk(c.askPermission),
+		agent.WithContinueAsk(c.askContinue),
+		agent.WithJobs(c.engineJobs()),
+		agent.WithExtensions(extRunner),
+		agent.WithMCP(c.mcpPool),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -515,21 +517,23 @@ func (c *EngineController) Resume(id string) (cwdWarning string, err error) {
 
 	extRunner := loadExtensions(c.proj)
 	c.extRunner.Store(extRunner)
-	eng, err := agent.NewEngine(agent.EngineOpts{
-		Model: cfg,
-		SessionOpts: agent.SessionOpts{
-			Cwd:        c.cwd,
-			SessionDir: c.sessionDir,
-			Persist:    true,
-			ResumeID:   id,
-		},
-		Gate:        c.gate,
-		Ask:         c.askPermission,
-		ContinueAsk: c.askContinue,
-		Jobs:        c.engineJobs(),
-		Extensions:  extRunner,
-		MCP:         c.mcpPool,
-	})
+	sess, err := agent.NewSession(
+		agent.WithCwd(c.cwd),
+		agent.WithSessionDir(c.sessionDir),
+		agent.WithPersist(true),
+		agent.WithResumeID(id),
+	)
+	if err != nil {
+		return "", err
+	}
+	eng, err := agent.NewEngine(cfg, sess,
+		agent.WithGate(c.gate),
+		agent.WithAsk(c.askPermission),
+		agent.WithContinueAsk(c.askContinue),
+		agent.WithJobs(c.engineJobs()),
+		agent.WithExtensions(extRunner),
+		agent.WithMCP(c.mcpPool),
+	)
 	if err != nil {
 		return "", err
 	}
@@ -572,20 +576,22 @@ func (c *EngineController) Clear() error {
 	}
 
 	extRunner := c.Extensions()
-	engine, err := agent.NewEngine(agent.EngineOpts{
-		Model: cfg,
-		SessionOpts: agent.SessionOpts{
-			Cwd:        c.cwd,
-			SessionDir: c.sessionDir,
-			Persist:    true,
-		},
-		Gate:        c.gate,
-		Ask:         c.askPermission,
-		ContinueAsk: c.askContinue,
-		Jobs:        c.engineJobs(),
-		Extensions:  extRunner,
-		MCP:         c.mcpPool,
-	})
+	sess, err := agent.NewSession(
+		agent.WithCwd(c.cwd),
+		agent.WithSessionDir(c.sessionDir),
+		agent.WithPersist(true),
+	)
+	if err != nil {
+		return err
+	}
+	engine, err := agent.NewEngine(cfg, sess,
+		agent.WithGate(c.gate),
+		agent.WithAsk(c.askPermission),
+		agent.WithContinueAsk(c.askContinue),
+		agent.WithJobs(c.engineJobs()),
+		agent.WithExtensions(extRunner),
+		agent.WithMCP(c.mcpPool),
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
replace EngineOpts/SessionOpts with With* options (WithGate, WithMCP, WithJobs, ... / WithCwd, WithPersist, WithResumeID, ...). NewEngine now takes the model config plus an externally created *Session, and ReplaceSession swaps a *Session directly.

session creation moves to callers (phi run, tui controller), so the engine no longer owns it and constructors take explicit parameters instead of opts bags.