### PR TITLE
feat(extension): add phi plugin install from github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - **Yaegi extensions:** Go extensions under `~/.phi/extensions` and `<cwd>/.phi/extensions` (`*.go` / `*/index.go`). Public API `ext`, runtime `internal/extension`. Supports `On` events, `RegisterTool`, `RegisterCommand`, session/tool lifecycle. See [doc/extensions.md](doc/extensions.md). Palette: **extensions → list/reload**. Disable with `PHI_EXTENSIONS=off`.
+- `phi plugin install <github-repo[@tag]>`: shallow-clone a GitHub repo into `~/.phi/extensions/<repo>/` (`index.go` or a single root `*.go`). No registry.
 
 ### Changed
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,8 @@ phi config         open the HTML config editor (local web server)
 phi update         install the latest release (see 'phi update --help')
 phi run -p "..."   run one agent loop headlessly (see 'phi run --help')
 phi sessions list  list persisted sessions for this directory
-phi mcp …          manage MCP servers (see 'phi mcp --help')`,
+phi mcp …          manage MCP servers (see 'phi mcp --help')
+phi plugin install install an extension from GitHub (see 'phi plugin --help')`,
 	}
 	r.Run = func(args []string, _ cli.Flags) error {
 		if len(args) > 0 {
@@ -54,6 +55,7 @@ phi mcp …          manage MCP servers (see 'phi mcp --help')`,
 		&runCommand,
 		&sessionsCommand,
 		&mcpCommand,
+		&pluginCommand,
 		&configCommand,
 		&updateCommand,
 	)

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	cli "github.com/pulseaiclub/pli"
+
+	"github.com/pulseaiclub/phi/internal/extension"
+	"github.com/pulseaiclub/phi/internal/project"
+)
+
+var (
+	pluginCommand = cli.Command{
+		Name: "plugin",
+		Desc: "manage extensions (install from GitHub)",
+		Long: `Install a published Go extension (yaegi) from a GitHub repo into ~/.phi/extensions/<repo>/.
+
+The repo root must contain index.go, or exactly one non-test *.go file.
+
+Examples:
+  phi plugin install alice/greet
+  phi plugin install alice/greet@v1.2.3
+  phi plugin install github.com/alice/greet@main
+
+Security: extensions run with your full process permissions.`,
+	}
+
+	pluginInstallCommand = cli.Command{
+		Name:    "install",
+		ArgsUse: "<github-repo[@tag]>",
+		Desc:    "git clone a GitHub repo into ~/.phi/extensions",
+	}
+)
+
+func init() {
+	pluginInstallCommand.Run = func(args []string, _ cli.Flags) error {
+		return pluginInstall(args)
+	}
+	pluginCommand.Add(&pluginInstallCommand)
+}
+
+func pluginInstall(args []string) error {
+	if len(args) != 1 {
+		return pluginInstallCommand.Usagef("expected <github-repo[@tag]>")
+	}
+	spec, err := extension.ParseSpec(args[0])
+	if err != nil {
+		return err
+	}
+	proj := project.GetDefaultProject()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	return extension.Install(ctx, extension.InstallOptions{
+		Dir:    proj.Global().ExtensionsDir(),
+		Spec:   spec,
+		Stdout: os.Stdout,
+	})
+}

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -10,10 +10,22 @@ Extensions are Go source files loaded with [yaegi](https://github.com/pulseaiclu
 |----------|-------|
 | `~/.phi/extensions/*.go` | Global (all projects) |
 | `~/.phi/extensions/*/index.go` | Global (subdirectory) |
+| `~/.phi/extensions/*/<sole>.go` | Global (subdir with exactly one `*.go`) |
 | `<cwd>/.phi/extensions/*.go` | Project-local |
 | `<cwd>/.phi/extensions/*/index.go` | Project-local (subdirectory) |
+| `<cwd>/.phi/extensions/*/<sole>.go` | Project-local (subdir with exactly one `*.go`) |
 
 Same extension id (file stem or directory name): project replaces user. Disable all with `PHI_EXTENSIONS=off`.
+
+## Install from GitHub
+
+```bash
+phi plugin install alice/greet
+phi plugin install alice/greet@v1.2.3
+phi plugin install github.com/alice/greet@main
+```
+
+Clones into `~/.phi/extensions/<repo>/` (shallow). The repo root must have `index.go` or exactly one non-test `*.go`. Requires `git` on `PATH`. No registry — pass an explicit GitHub repo. Reload in TUI: **Ctrl+K → extensions → reload**.
 
 ## Quick start
 
@@ -113,5 +125,6 @@ Shell `plugin.json` hooks under `~/.phi/hooks` / `.phi/hooks` are **removed**. R
 | Path | Role |
 |------|------|
 | `ext/` | Public types + `API` for authors |
-| `internal/extension/` | Discover, yaegi loader, Runner |
+| `internal/extension/` | Discover, yaegi loader, Runner, `plugin install` |
+| `cmd/plugin.go` | `phi plugin install` |
 | `.phi/extensions/` | Project samples (`hello.go`, `guard_bash.go`) |

--- a/internal/extension/discover.go
+++ b/internal/extension/discover.go
@@ -48,6 +48,7 @@ func ExtensionsDisabled() bool {
 //
 //	<dir>/*.go
 //	<dir>/*/index.go
+//	<dir>/*/<sole>.go  (exactly one non-test *.go when index.go is absent)
 func Discover(userDir, projectDir string) ([]Discovered, []Warning, error) {
 	if ExtensionsDisabled() {
 		return nil, nil, nil
@@ -120,18 +121,15 @@ func scanDir(dir, source string) ([]Discovered, []Warning, error) {
 		}
 		full := filepath.Join(dir, name)
 		if ent.IsDir() {
-			index := filepath.Join(full, "index.go")
-			st, err := os.Stat(index)
+			entry, err := dirEntryFile(full)
 			if err != nil {
-				if !os.IsNotExist(err) {
-					warnings = append(warnings, Warning{Path: index, Message: err.Error()})
-				}
+				warnings = append(warnings, Warning{Path: full, Message: err.Error()})
 				continue
 			}
-			if st.IsDir() {
+			if entry == "" {
 				continue
 			}
-			add(name, index)
+			add(name, entry)
 			continue
 		}
 		if filepath.Ext(name) != ".go" {
@@ -144,6 +142,44 @@ func scanDir(dir, source string) ([]Discovered, []Warning, error) {
 		add(id, full)
 	}
 	return out, warnings, nil
+}
+
+// dirEntryFile returns the extension entry under a plugin subdirectory:
+// index.go if present, otherwise the sole non-test *.go at that directory's root.
+func dirEntryFile(dir string) (string, error) {
+	index := filepath.Join(dir, "index.go")
+	st, err := os.Stat(index)
+	if err == nil && !st.IsDir() {
+		return index, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	return soleRootGoFile(dir)
+}
+
+// soleRootGoFile returns the only non-test *.go file in dir, or ("", nil) if
+// there is not exactly one.
+func soleRootGoFile(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var found string
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		name := ent.Name()
+		if filepath.Ext(name) != ".go" || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if found != "" {
+			return "", nil
+		}
+		found = filepath.Join(dir, name)
+	}
+	return found, nil
 }
 
 // FormatDiscovered returns a one-line status for palette / logs.

--- a/internal/extension/install.go
+++ b/internal/extension/install.go
@@ -1,0 +1,132 @@
+package extension
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// InstallOptions configures Install.
+type InstallOptions struct {
+	// Dir is the extensions directory (typically ~/.phi/extensions).
+	Dir string
+	// Spec is the GitHub plugin to install.
+	Spec   Spec
+	Stdout io.Writer
+	// Git, if set, overrides the git executable lookup (tests).
+	Git string
+	// RunGit, if set, replaces the real git invocation (tests).
+	RunGit func(ctx context.Context, gitBin string, args ...string) error
+}
+
+func (o InstallOptions) out() io.Writer {
+	if o.Stdout != nil {
+		return o.Stdout
+	}
+	return io.Discard
+}
+
+// Install clones a GitHub repo into Dir/<repo>/ and verifies it looks like an
+// extension (index.go or a single *.go at the repo root).
+func Install(ctx context.Context, opts InstallOptions) error {
+	if opts.Dir == "" {
+		return errors.New("extensions directory is required")
+	}
+	if opts.Spec.Owner == "" || opts.Spec.Repo == "" {
+		return errors.New("invalid plugin spec: missing owner/repo")
+	}
+
+	dest := filepath.Join(opts.Dir, opts.Spec.ID())
+	if _, err := os.Stat(dest); err == nil {
+		return fmt.Errorf("plugin %q already exists at %s (remove it first)", opts.Spec.ID(), dest)
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", dest, err)
+	}
+
+	if err := os.MkdirAll(opts.Dir, 0o755); err != nil {
+		return fmt.Errorf("create extensions dir %s: %w", opts.Dir, err)
+	}
+
+	gitBin := opts.Git
+	if gitBin == "" {
+		var err error
+		gitBin, err = exec.LookPath("git")
+		if err != nil {
+			return errors.New("git not found in PATH (required to install plugins)")
+		}
+	}
+
+	args := []string{"clone", "--depth", "1"}
+	if opts.Spec.Ref != "" {
+		args = append(args, "--branch", opts.Spec.Ref)
+	}
+	args = append(args, opts.Spec.CloneURL(), dest)
+
+	run := opts.RunGit
+	if run == nil {
+		run = defaultRunGit
+	}
+	if err := run(ctx, gitBin, args...); err != nil {
+		_ = os.RemoveAll(dest)
+		return err
+	}
+
+	entry, err := findInstallEntry(dest)
+	if err != nil {
+		_ = os.RemoveAll(dest)
+		return err
+	}
+
+	refNote := "default branch"
+	if opts.Spec.Ref != "" {
+		refNote = opts.Spec.Ref
+	}
+	_, _ = fmt.Fprintf(opts.out(), "installed %s/%s (%s) → %s\n", opts.Spec.Owner, opts.Spec.Repo, refNote, dest)
+	_, _ = fmt.Fprintf(opts.out(), "entry: %s\n", entry)
+	_, _ = fmt.Fprintln(
+		opts.out(),
+		"warning: extensions run with your full process permissions; only install from sources you trust",
+	)
+	_, _ = fmt.Fprintln(opts.out(), "reload: Ctrl+K → extensions → reload (or restart phi)")
+	return nil
+}
+
+func defaultRunGit(ctx context.Context, gitBin string, args ...string) error {
+	cmd := exec.CommandContext(ctx, gitBin, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			msg = err.Error()
+		}
+		return fmt.Errorf("git %s: %s", strings.Join(args, " "), msg)
+	}
+	return nil
+}
+
+// findInstallEntry returns the absolute path of the extension entry file in a
+// freshly cloned plugin directory.
+func findInstallEntry(dir string) (string, error) {
+	index := filepath.Join(dir, "index.go")
+	if st, err := os.Stat(index); err == nil && !st.IsDir() {
+		return index, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+
+	sole, err := soleRootGoFile(dir)
+	if err != nil {
+		return "", err
+	}
+	if sole != "" {
+		return sole, nil
+	}
+	return "", errors.New(
+		"cloned repo has no extension entry (need index.go or a single *.go at the repo root)",
+	)
+}

--- a/internal/extension/spec.go
+++ b/internal/extension/spec.go
@@ -1,0 +1,79 @@
+package extension
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Spec is a GitHub plugin install target: owner/repo with an optional ref (tag or branch).
+type Spec struct {
+	Owner string
+	Repo  string
+	Ref   string // empty = remote default branch
+}
+
+// CloneURL returns the HTTPS git clone URL for the spec.
+func (s Spec) CloneURL() string {
+	return fmt.Sprintf("https://github.com/%s/%s.git", s.Owner, s.Repo)
+}
+
+// ID is the on-disk extension directory name (repo name).
+func (s Spec) ID() string { return s.Repo }
+
+// ParseSpec parses owner/repo[@ref], github.com/owner/repo[@ref], or
+// https://github.com/owner/repo[.git][@ref]. SSH git@host URLs are rejected.
+func ParseSpec(raw string) (Spec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Spec{}, errors.New("empty plugin spec")
+	}
+	if strings.HasPrefix(raw, "git@") {
+		return Spec{}, errors.New("SSH git URLs are not supported; use owner/repo or https://github.com/owner/repo")
+	}
+
+	pathPart, ref := raw, ""
+	if i := strings.LastIndex(raw, "@"); i >= 0 {
+		before, after := raw[:i], raw[i+1:]
+		// ref must be a single path segment (tag/branch), not owner/repo.
+		if after != "" && !strings.Contains(after, "/") && !strings.Contains(after, ":") {
+			pathPart, ref = before, after
+		}
+	}
+
+	owner, repo, err := splitOwnerRepo(pathPart)
+	if err != nil {
+		return Spec{}, err
+	}
+	return Spec{Owner: owner, Repo: repo, Ref: ref}, nil
+}
+
+func splitOwnerRepo(s string) (owner, repo string, err error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, ".git")
+
+	if strings.Contains(s, "://") {
+		u, perr := url.Parse(s)
+		if perr != nil {
+			return "", "", fmt.Errorf("invalid plugin URL %q: %w", s, perr)
+		}
+		host := strings.ToLower(u.Host)
+		if host != "github.com" && host != "www.github.com" {
+			return "", "", fmt.Errorf("only github.com repos are supported (got %q)", u.Host)
+		}
+		s = strings.Trim(u.Path, "/")
+	} else {
+		s = strings.TrimPrefix(s, "github.com/")
+		s = strings.TrimPrefix(s, "www.github.com/")
+	}
+
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("want owner/repo[@tag], got %q", s)
+	}
+	if strings.Contains(parts[0], "..") || strings.Contains(parts[1], "..") {
+		return "", "", fmt.Errorf("invalid owner/repo %q", s)
+	}
+	return parts[0], parts[1], nil
+}

--- a/internal/extension/spec_test.go
+++ b/internal/extension/spec_test.go
@@ -1,0 +1,130 @@
+package extension_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulseaiclub/phi/internal/extension"
+)
+
+func TestParseSpec(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in      string
+		owner   string
+		repo    string
+		ref     string
+		wantErr bool
+	}{
+		{in: "alice/greet", owner: "alice", repo: "greet"},
+		{in: "alice/greet@v1.2.3", owner: "alice", repo: "greet", ref: "v1.2.3"},
+		{in: "github.com/alice/greet", owner: "alice", repo: "greet"},
+		{in: "github.com/alice/greet@main", owner: "alice", repo: "greet", ref: "main"},
+		{in: "https://github.com/alice/greet", owner: "alice", repo: "greet"},
+		{in: "https://github.com/alice/greet.git", owner: "alice", repo: "greet"},
+		{in: "https://github.com/alice/greet@v1", owner: "alice", repo: "greet", ref: "v1"},
+		{in: "https://github.com/alice/greet.git@v1", owner: "alice", repo: "greet", ref: "v1"},
+		{in: "", wantErr: true},
+		{in: "just-repo", wantErr: true},
+		{in: "git@github.com:alice/greet.git", wantErr: true},
+		{in: "https://gitlab.com/alice/greet", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := extension.ParseSpec(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.owner, got.Owner)
+			assert.Equal(t, tc.repo, got.Repo)
+			assert.Equal(t, tc.ref, got.Ref)
+			assert.Equal(t, "https://github.com/"+tc.owner+"/"+tc.repo+".git", got.CloneURL())
+			assert.Equal(t, tc.repo, got.ID())
+		})
+	}
+}
+
+func TestDiscoverSoleGoInSubdir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "greet")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "greet.go"), []byte("package main\n"), 0o644))
+
+	found, warns, err := extension.Discover(dir, "")
+	require.NoError(t, err)
+	assert.Empty(t, warns)
+	require.Len(t, found, 1)
+	assert.Equal(t, "greet", found[0].ID)
+	assert.Equal(t, filepath.Join(sub, "greet.go"), found[0].Path)
+}
+
+func TestInstallClonesAndValidates(t *testing.T) {
+	dir := t.TempDir()
+	spec := extension.Spec{Owner: "alice", Repo: "greet", Ref: "v1"}
+	var sawArgs []string
+	err := extension.Install(t.Context(), extension.InstallOptions{
+		Dir:  dir,
+		Spec: spec,
+		Git:  "git",
+		RunGit: func(_ context.Context, gitBin string, args ...string) error {
+			assert.Equal(t, "git", gitBin)
+			sawArgs = append([]string{}, args...)
+			dest := args[len(args)-1]
+			require.NoError(t, os.MkdirAll(dest, 0o755))
+			return os.WriteFile(filepath.Join(dest, "index.go"), []byte("package main\n"), 0o644)
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		[]string{"clone", "--depth", "1", "--branch", "v1", spec.CloneURL(), filepath.Join(dir, "greet")},
+		sawArgs,
+	)
+
+	found, _, err := extension.Discover(dir, "")
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	assert.Equal(t, "greet", found[0].ID)
+}
+
+func TestInstallRejectsMissingEntry(t *testing.T) {
+	dir := t.TempDir()
+	err := extension.Install(t.Context(), extension.InstallOptions{
+		Dir:  dir,
+		Spec: extension.Spec{Owner: "alice", Repo: "empty"},
+		Git:  "git",
+		RunGit: func(_ context.Context, _ string, args ...string) error {
+			dest := args[len(args)-1]
+			return os.MkdirAll(dest, 0o755)
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no extension entry")
+	_, err = os.Stat(filepath.Join(dir, "empty"))
+	assert.True(t, os.IsNotExist(err), "failed install should clean up dest")
+}
+
+func TestInstallRejectsExisting(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "greet")
+	require.NoError(t, os.Mkdir(dest, 0o755))
+	err := extension.Install(t.Context(), extension.InstallOptions{
+		Dir:  dir,
+		Spec: extension.Spec{Owner: "alice", Repo: "greet"},
+		Git:  "git",
+		RunGit: func(context.Context, string, ...string) error {
+			t.Fatal("git should not run")
+			return nil
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}


### PR DESCRIPTION
Add `phi plugin install <github-repo[@ref]>` that shallow-clones a repo into ~/.phi/extensions/<repo>/ and validates it has an extension entry (index.go or a single non-test *.go at the repo root). Accept owner/repo[@ref], github.com/owner/repo[@ref], and https URLs; reject SSH and non-github.com hosts. Failed installs clean up the destination dir.

Extend Discover to load a subdir's sole non-test *.go when index.go is absent, so installed single-file plugins work without renaming.