### PR TITLE
refactor(ext): rename ToolDef/CommandDef to Tool/Command

### DIFF
--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -47,7 +47,7 @@ import (
 
 func main() {
 	m := sdk.New("hello", "0.1.0")
-	m.RegisterCommand("hello", ext.CommandDef{
+	m.RegisterCommand("hello", ext.Command{
 		Description: "Say hi",
 		Handler: func(args string, ctx *ext.Context) error {
 			m.Notify("info", "Hello!")
@@ -100,7 +100,7 @@ Tool loop order remains **ExtensionPre → Gate/Ask → Run → ExtensionPost**.
 
 | Path | Role |
 |------|------|
-| `ext/` | Shared types (`ToolDef`, events) |
+| `ext/` | Shared types (`Tool`, `Command`, events) |
 | `ext/pxb` | Binary wire protocol |
 | `ext/sdk` | Author SDK (`Module.Run`) |
 | `internal/extension` | Discover, spawn, Runner shims |

--- a/examples/extensions/hello/main.go
+++ b/examples/extensions/hello/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	m := sdk.New("hello", "0.1.0")
-	m.RegisterCommand("hello", ext.CommandDef{
+	m.RegisterCommand("hello", ext.Command{
 		Description: "Say hello via extension",
 		Handler: func(args string, _ *ext.Context) error {
 			msg := "Hello from PXB!"
@@ -23,7 +23,7 @@ func main() {
 			return nil
 		},
 	})
-	m.RegisterTool(ext.ToolDef{
+	m.RegisterTool(ext.Tool{
 		Name:        "ext_hello",
 		Description: "Greet someone by name (extension tool)",
 		Parameters: map[string]any{

--- a/ext/api.go
+++ b/ext/api.go
@@ -16,8 +16,8 @@ type API struct {
 	mu sync.Mutex
 
 	handlers map[string][]any
-	tools    []ToolDef
-	commands map[string]CommandDef
+	tools    []Tool
+	commands map[string]Command
 
 	// Bound by host after load.
 	ui           UI
@@ -36,7 +36,7 @@ type API struct {
 func NewAPI() *API {
 	return &API{
 		handlers: make(map[string][]any),
-		commands: make(map[string]CommandDef),
+		commands: make(map[string]Command),
 	}
 }
 
@@ -52,7 +52,7 @@ func (a *API) On(event string, handler any) {
 }
 
 // RegisterTool adds an LLM-callable tool.
-func (a *API) RegisterTool(t ToolDef) {
+func (a *API) RegisterTool(t Tool) {
 	if a == nil || t.Name == "" || t.Execute == nil {
 		return
 	}
@@ -62,7 +62,7 @@ func (a *API) RegisterTool(t ToolDef) {
 }
 
 // RegisterCommand adds a slash command (cannot override builtins at host level).
-func (a *API) RegisterCommand(name string, cmd CommandDef) {
+func (a *API) RegisterCommand(name string, cmd Command) {
 	if a == nil || name == "" || cmd.Handler == nil {
 		return
 	}
@@ -88,19 +88,19 @@ func (a *API) Handlers(event string) []any {
 }
 
 // Tools returns registered tools.
-func (a *API) Tools() []ToolDef {
+func (a *API) Tools() []Tool {
 	if a == nil {
 		return nil
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	out := make([]ToolDef, len(a.tools))
+	out := make([]Tool, len(a.tools))
 	copy(out, a.tools)
 	return out
 }
 
 // Commands returns registered slash commands.
-func (a *API) Commands() map[string]CommandDef {
+func (a *API) Commands() map[string]Command {
 	if a == nil {
 		return nil
 	}

--- a/ext/sdk/sdk.go
+++ b/ext/sdk/sdk.go
@@ -37,12 +37,12 @@ type Module struct {
 }
 
 type toolReg struct {
-	def ext.ToolDef
+	def ext.Tool
 }
 
 type cmdReg struct {
 	name string
-	def  ext.CommandDef
+	def  ext.Command
 }
 
 // HelloInfo is filled after hello_ack.
@@ -70,7 +70,7 @@ func (m *Module) Host() HelloInfo {
 }
 
 // RegisterTool adds an LLM-callable tool.
-func (m *Module) RegisterTool(t ext.ToolDef) {
+func (m *Module) RegisterTool(t ext.Tool) {
 	if t.Name == "" || t.Execute == nil {
 		return
 	}
@@ -80,7 +80,7 @@ func (m *Module) RegisterTool(t ext.ToolDef) {
 }
 
 // RegisterCommand adds a slash command.
-func (m *Module) RegisterCommand(name string, cmd ext.CommandDef) {
+func (m *Module) RegisterCommand(name string, cmd ext.Command) {
 	if name == "" || cmd.Handler == nil {
 		return
 	}
@@ -242,11 +242,11 @@ func (m *Module) Run() error {
 		return err
 	}
 
-	toolByName := make(map[string]ext.ToolDef, len(tools))
+	toolByName := make(map[string]ext.Tool, len(tools))
 	for _, t := range tools {
 		toolByName[t.def.Name] = t.def
 	}
-	cmdByName := make(map[string]ext.CommandDef, len(cmds))
+	cmdByName := make(map[string]ext.Command, len(cmds))
 	for _, c := range cmds {
 		cmdByName[c.name] = c.def
 	}

--- a/ext/types.go
+++ b/ext/types.go
@@ -107,8 +107,8 @@ type ToolResult struct {
 	Output  string
 }
 
-// ToolDef registers an LLM-callable tool.
-type ToolDef struct {
+// Tool registers an LLM-callable tool.
+type Tool struct {
 	Name        string
 	Label       string
 	Description string
@@ -124,8 +124,8 @@ type ToolInfo struct {
 	Source      string // builtin | extension
 }
 
-// CommandDef registers a slash command.
-type CommandDef struct {
+// Command registers a slash command.
+type Command struct {
 	Description string
 	Handler     func(args string, ctx *Context) error
 }

--- a/internal/extension/loader_test.go
+++ b/internal/extension/loader_test.go
@@ -100,7 +100,7 @@ import (
 
 func main() {
 	m := sdk.New("greet", "0.0.1")
-	m.RegisterTool(ext.ToolDef{
+	m.RegisterTool(ext.Tool{
 		Name:        "greet",
 		Description: "Greet someone",
 		Parameters: map[string]any{

--- a/internal/extension/proc.go
+++ b/internal/extension/proc.go
@@ -435,7 +435,7 @@ func (p *Proc) BuildAPI(api *ext.API) {
 		if len(t.SchemaJSON) > 0 {
 			_ = json.Unmarshal(t.SchemaJSON, &params)
 		}
-		api.RegisterTool(ext.ToolDef{
+		api.RegisterTool(ext.Tool{
 			Name:        name,
 			Description: t.Description,
 			Parameters:  params,
@@ -447,7 +447,7 @@ func (p *Proc) BuildAPI(api *ext.API) {
 	for _, c := range p.cmds {
 		name := c.Name
 		desc := c.Description
-		api.RegisterCommand(name, ext.CommandDef{
+		api.RegisterCommand(name, ext.Command{
 			Description: desc,
 			Handler: func(args string, _ *ext.Context) error {
 				resp, err := p.CallCommand(context.Background(), name, args)

--- a/internal/extension/runner.go
+++ b/internal/extension/runner.go
@@ -224,7 +224,7 @@ func (r *Runner) ExtensionTools() []tools.Tool {
 	return out
 }
 
-func toolFromDef(def ext.ToolDef) tools.Tool {
+func toolFromDef(def ext.Tool) tools.Tool {
 	params := schemaFromMap(def.Parameters)
 	exec := def.Execute
 	return tools.Tool{


### PR DESCRIPTION
SDK types now match the wire protocol naming (pxb.RegisterTool / RegisterCommand). Pure type rename, fields unchanged, so the host↔extension wire format is byte-identical.

Update examples, docs, and the loader test fixture to the new names.