### PR TITLE
fix(extension): close runner on resume/quit to stop subprocess leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `phi plugin install <github-repo[@tag]>`: shallow-clone a GitHub repo into `~/.phi/extensions/<repo>/` (requires `phi.yaml` + compiled binary).
 - Extension full chain: `user_input`, `turn_stopping`, `session_compact` intercepts/events; `SubscribeEvent` with payload; `SendUserMessage` host request.
 - Extension **Confirm** dialog (blocking RPC).
-- Example extension [examples/extensions/showcase](examples/extensions/showcase): aggregate demo of Confirm, Submit, intercepts, and tools.
 
 ### Changed
 
@@ -32,6 +31,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- `/resume` closes the previous extension runner and rebinds host UI (was leaking subprocesses and dropping Notify/Confirm).
+- Controller `Close` and headless `phi run` shut down extension subprocesses; TUI defers `ctrl.Close()` on exit.
 - Extension `Notify` / status frames now reach the TUI (`Proc.onNotify` wired in `Runner.Bind`).
 - Slash-command `Submit` from PXB `CommandResponse` is delivered to the composer.
 - Extension handshake registration respects the handshake timeout (no longer only checked between blocking reads).

--- a/cmd/runloop.go
+++ b/cmd/runloop.go
@@ -67,6 +67,9 @@ func runHeadless(opts runOptions) error {
 	// approval UI is ever reachable (Ask≡Deny even if the config mode
 	// does not fold Ask).
 	extRunner := loadRunExtensions(bs)
+	if extRunner != nil {
+		defer extRunner.Close()
+	}
 	engineOpts := []agent.EngineOption{
 		agent.WithGate(bs.Gate),
 		agent.WithExtensions(extRunner),

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -79,6 +79,7 @@ func runTUI() error {
 		fmt.Fprintln(os.Stderr, "phi:", err)
 		return exitCode(ExitError)
 	}
+	defer ctrl.Close()
 	ui := editor.NewEditor(
 		application,
 		bus,

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -122,10 +122,6 @@ mkdir -p ~/.phi/extensions/hello
 cp hello phi.yaml ~/.phi/extensions/hello/
 ```
 
-Samples:
-- [examples/extensions/hello](../examples/extensions/hello) — minimal slash + notify
-- [examples/extensions/showcase](../examples/extensions/showcase) — Confirm, intercepts, tools
-
 Reload: **Ctrl+K → extensions → reload**.
 
 ## Install from GitHub

--- a/internal/tui/controller/controller.go
+++ b/internal/tui/controller/controller.go
@@ -255,10 +255,7 @@ func (c *EngineController) ReloadExtensions() (loaded int, warns []extension.War
 		return 0, warns, err
 	}
 	logExtensionWarnings(warns)
-	if prev := c.extRunner.Swap(r); prev != nil {
-		prev.Close()
-	}
-	c.bindExtensionHost(r)
+	c.swapExtensionRunner(r)
 	if c.engine != nil {
 		c.engine.SetExtensions(r)
 	}
@@ -266,6 +263,18 @@ func (c *EngineController) ReloadExtensions() (loaded int, warns []extension.War
 		return 0, warns, nil
 	}
 	return len(r.Loaded()), warns, nil
+}
+
+// swapExtensionRunner replaces the live runner, closing the previous one and
+// rebinding host UI callbacks onto the replacement.
+func (c *EngineController) swapExtensionRunner(r *extension.Runner) {
+	if c == nil {
+		return
+	}
+	if prev := c.extRunner.Swap(r); prev != nil {
+		prev.Close()
+	}
+	c.bindExtensionHost(r)
 }
 
 // ListExtensions returns the current on-disk discovery (does not swap the runner).
@@ -551,7 +560,9 @@ func (c *EngineController) Resume(id string) (cwdWarning string, err error) {
 	}
 
 	extRunner := loadExtensions(c.proj)
-	c.extRunner.Store(extRunner)
+	// Close the previous runner before attaching the new one so UI host
+	// callbacks and subprocesses do not leak across /resume.
+	c.swapExtensionRunner(extRunner)
 	sess, err := agent.NewSession(
 		agent.WithCwd(c.cwd),
 		agent.WithSessionDir(c.sessionDir),
@@ -672,7 +683,7 @@ func (c *EngineController) Cancel() {
 	}
 }
 
-// Close cancels the stream and shuts down the job manager.
+// Close cancels the stream and shuts down jobs, MCP, and extensions.
 func (c *EngineController) Close() {
 	c.sessionShutdown("quit", c.SessionID())
 	c.Cancel()
@@ -686,6 +697,9 @@ func (c *EngineController) Close() {
 	if c.mcpPool != nil {
 		_ = c.mcpPool.Close()
 		c.mcpPool = nil
+	}
+	if prev := c.extRunner.Swap(nil); prev != nil {
+		prev.Close()
 	}
 }
 

--- a/internal/tui/controller/controller_ext_test.go
+++ b/internal/tui/controller/controller_ext_test.go
@@ -1,0 +1,48 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulseaiclub/phi/internal/extension"
+	"github.com/pulseaiclub/phi/internal/project"
+)
+
+func TestSwapExtensionRunner_ClosesPrevious(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("PHI_MODEL", "test-model")
+	t.Setenv("PHI_API_KEY", "test-key")
+	t.Setenv("PHI_BASE_URL", "http://127.0.0.1:9")
+	t.Setenv(extension.EnvExtensions, "off")
+
+	cwd := t.TempDir()
+	proj, err := project.Discover(cwd)
+	require.NoError(t, err)
+	require.NoError(t, proj.LoadConfig())
+
+	ctrl, err := NewController(NewBus(nil), proj, cwd)
+	require.NoError(t, err)
+
+	first, _, err := extension.Load(t.TempDir(), "")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	ctrl.swapExtensionRunner(first)
+	assert.Same(t, first, ctrl.Extensions())
+
+	second, _, err := extension.Load(t.TempDir(), "")
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	ctrl.swapExtensionRunner(second)
+	assert.Same(t, second, ctrl.Extensions())
+	// Previous runner must be closed; a second Close is a safe no-op.
+	first.Close()
+
+	ctrl.Close()
+	assert.Nil(t, ctrl.Extensions())
+	// Idempotent.
+	ctrl.Close()
+}


### PR DESCRIPTION
Controller.Close, headless `phi run`, and TUI exit now shut down extension subprocesses. /resume swaps via swapExtensionRunner, which closes the previous runner and rebinds host UI instead of a bare Store (leaked subprocesses, dropped Notify/Confirm).

Drop stale showcase example refs from CHANGELOG and extensions.md. Add swap/close idempotency test.