### PR TITLE
refactor(agent): drop redundant nil guards on extension runner

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -49,9 +49,9 @@ type Engine struct {
 	ask           permission.AskFunc
 	continueAsk   ContinueFunc
 	jobs          *job.Manager
-	extensions    *extension.Runner
-	baseTools     []tools.Tool // nil = DefaultTools; preserved across rebind
-	omitExtTools  bool         // sub-agents: emit events but skip RegisterTool merge
+	extensions    *extension.Runner // nil = disabled; all methods are nil-safe no-ops
+	baseTools     []tools.Tool      // nil = DefaultTools; preserved across rebind
+	omitExtTools  bool              // sub-agents: emit events but skip RegisterTool merge
 	mcp           *mcp.Pool
 
 	session *Session
@@ -84,10 +84,8 @@ func NewEngine(model llm.ModelConfig, sess *Session, opts ...EngineOption) (*Eng
 		engine.maxRounds = cfg.maxRounds
 	}
 	engine.baseTools = cfg.tools
-	if engine.extensions != nil {
-		engine.extensions.SetBaseTools(engine.buildCoreTools(engine.baseTools))
-		engine.extensions.SetMeta(engine.SessionID(), engine.SessionCwd())
-	}
+	engine.extensions.SetBaseTools(engine.buildCoreTools(engine.baseTools))
+	engine.extensions.SetMeta(engine.SessionID(), engine.SessionCwd())
 	toolList := engine.buildToolList(engine.baseTools)
 	engine.client = llmclient.NewClient(model, tools.Definitions(toolList), engine.systemPrompt())
 	engine.bindExecutor(tools.NewRegistry(toolList))
@@ -96,7 +94,7 @@ func NewEngine(model llm.ModelConfig, sess *Session, opts ...EngineOption) (*Eng
 
 func (engine *Engine) buildToolList(base []tools.Tool) []tools.Tool {
 	out := engine.buildCoreTools(base)
-	if engine.extensions != nil && !engine.omitExtTools {
+	if !engine.omitExtTools {
 		if extTools := engine.extensions.ExtensionTools(); len(extTools) > 0 {
 			merged := make([]tools.Tool, 0, len(out)+len(extTools))
 			merged = append(merged, out...)
@@ -157,9 +155,7 @@ func (engine *Engine) SetJobs(jobs *job.Manager) {
 }
 
 func (engine *Engine) rebindTools() {
-	if engine.extensions != nil {
-		engine.extensions.SetBaseTools(engine.buildCoreTools(engine.baseTools))
-	}
+	engine.extensions.SetBaseTools(engine.buildCoreTools(engine.baseTools))
 	toolList := engine.buildToolList(engine.baseTools)
 	engine.client = llmclient.NewClient(
 		engine.modelCfg,
@@ -316,13 +312,11 @@ type LoopOpts struct {
 // the agent turn ends (final assistant with no tool_calls) — never mid-tool-loop.
 func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) iter.Seq2[session.Event, error] {
 	return func(yield func(session.Event, error) bool) {
-		content := prompt
-		if engine.extensions != nil {
-			var handled bool
-			content, handled = engine.extensions.EmitUserInput(content)
-			if handled {
-				return
-			}
+		// The extension runner is nil-safe (nil = disabled), so calls are
+		// unconditional no-ops when no extensions are loaded.
+		content, handled := engine.extensions.EmitUserInput(prompt)
+		if handled {
+			return
 		}
 		if instr := pendingSkillsInstruction(engine.skillPath, opts.PendingSkills); instr != "" {
 			if content == "" {
@@ -331,15 +325,13 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 				content = instr + "\n\n" + content
 			}
 		}
-		if engine.extensions != nil {
-			rewritten, extra := engine.extensions.EmitBeforeAgentStart(content)
-			content = rewritten
-			if extra != "" {
-				content = content + "\n\n" + extra
-			}
-			engine.extensions.EmitAgentStart()
-			defer engine.extensions.EmitAgentEnd()
+		rewritten, extra := engine.extensions.EmitBeforeAgentStart(content)
+		content = rewritten
+		if extra != "" {
+			content = content + "\n\n" + extra
 		}
+		engine.extensions.EmitAgentStart()
+		defer engine.extensions.EmitAgentEnd()
 		if err := engine.session.Append(llm.Message{
 			Role:    llm.RoleUser,
 			Content: content,
@@ -355,9 +347,7 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 				return
 			}
 
-			if engine.extensions != nil {
-				engine.extensions.EmitTurnStart(toolRounds)
-			}
+			engine.extensions.EmitTurnStart(toolRounds)
 
 			msgs := engine.session.BuildContext()
 
@@ -397,21 +387,19 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 			}
 
 			if len(msg.ToolCalls) == 0 {
-				if engine.extensions != nil {
-					engine.extensions.EmitTurnEnd(toolRounds)
-					if cont, steer := engine.extensions.EmitTurnStopping(toolRounds); cont {
-						steerMsg := steer
-						if steerMsg == "" {
-							steerMsg = "continue"
-						}
-						if err := engine.session.Append(
-							llm.Message{Role: llm.RoleUser, Content: steerMsg},
-						); err != nil {
-							yield(nil, err)
-							return
-						}
-						continue
+				engine.extensions.EmitTurnEnd(toolRounds)
+				if cont, steer := engine.extensions.EmitTurnStopping(toolRounds); cont {
+					steerMsg := steer
+					if steerMsg == "" {
+						steerMsg = "continue"
 					}
+					if err := engine.session.Append(
+						llm.Message{Role: llm.RoleUser, Content: steerMsg},
+					); err != nil {
+						yield(nil, err)
+						return
+					}
+					continue
 				}
 				// Turn finished — compact using this assistant's usage.
 				if err := engine.maybeCompact(ctx, yield, msg.Usage.TotalTokens); err != nil {
@@ -428,9 +416,7 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 				yield(nil, err)
 				return
 			}
-			if engine.extensions != nil {
-				engine.extensions.EmitTurnEnd(toolRounds - 1)
-			}
+			engine.extensions.EmitTurnEnd(toolRounds - 1)
 			if stop {
 				return
 			}
@@ -493,9 +479,7 @@ func (engine *Engine) maybeCompact(
 	if !yield(session.CompactionComplete{ID: id}, nil) {
 		return context.Canceled
 	}
-	if engine.extensions != nil {
-		engine.extensions.EmitSessionCompact("auto")
-	}
+	engine.extensions.EmitSessionCompact("auto")
 	return nil
 }
 

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -27,7 +27,7 @@ type Executor struct {
 	registry  tools.Registry
 	gate      permission.Gate
 	ask       permission.AskFunc
-	ext       *extension.Runner // nil = no extensions
+	ext       *extension.Runner // nil = disabled; methods are nil-safe no-ops
 	sessionID string
 	cwd       string
 }
@@ -52,16 +52,7 @@ func (e *Executor) SetMeta(sessionID, cwd string) {
 	}
 	e.sessionID = sessionID
 	e.cwd = cwd
-	if e.ext != nil {
-		e.ext.SetMeta(sessionID, cwd)
-	}
-}
-
-func (e *Executor) activeExt() *extension.Runner {
-	if e == nil {
-		return nil
-	}
-	return e.ext
+	e.ext.SetMeta(sessionID, cwd)
 }
 
 // Run executes tool calls in order, yielding ToolData updates via emit.
@@ -112,43 +103,34 @@ func (e *Executor) runOne(
 		return e.toolMessage(call.ID, errText), false, ""
 	}
 
-	extRunner := e.activeExt()
-	if extRunner != nil {
-		extRunner.EmitToolExecutionStart(call.Function.Name, call.ID, args)
-	}
+	e.ext.EmitToolExecutionStart(call.Function.Name, call.ID, args)
 
 	// ExtensionPre → Gate → Run → ExtensionPost. Pre runs before permission Ask
 	// so org policy can deny without prompting the user.
 	var preContext string
-	if extRunner != nil {
-		newArgs, blocked, reason, ctxText := extRunner.PreTool(ctx, call.Function.Name, call.ID, args)
-		preContext = ctxText
-		if blocked {
-			if reason == "" {
-				reason = "tool execution denied by extension"
-			}
-			reason = appendExtContext(reason, preContext)
-			if extRunner != nil {
-				extRunner.EmitToolExecutionEnd(call.Function.Name, call.ID, true)
-			}
-			return e.rejectResult(call, detail, reason, emit), false, ""
+	newArgs, blocked, reason, ctxText := e.ext.PreTool(ctx, call.Function.Name, call.ID, args)
+	preContext = ctxText
+	if blocked {
+		if reason == "" {
+			reason = "tool execution denied by extension"
 		}
-		if len(newArgs) > 0 {
-			args = newArgs
-			if tool.DetailFromArgs != nil {
-				if d := tool.DetailFromArgs(args); d != "" {
-					detail = d
-				}
-			} else {
-				detail = string(args)
+		reason = appendExtContext(reason, preContext)
+		e.ext.EmitToolExecutionEnd(call.Function.Name, call.ID, true)
+		return e.rejectResult(call, detail, reason, emit), false, ""
+	}
+	if len(newArgs) > 0 {
+		args = newArgs
+		if tool.DetailFromArgs != nil {
+			if d := tool.DetailFromArgs(args); d != "" {
+				detail = d
 			}
+		} else {
+			detail = string(args)
 		}
 	}
 
 	if msg, rejected := e.checkPermission(ctx, call, args, detail, emit); rejected {
-		if extRunner != nil {
-			extRunner.EmitToolExecutionEnd(call.Function.Name, call.ID, true)
-		}
+		e.ext.EmitToolExecutionEnd(call.Function.Name, call.ID, true)
 		return msg, false, ""
 	}
 
@@ -161,9 +143,7 @@ func (e *Executor) runOne(
 	)
 	if err != nil {
 		if ctx.Err() != nil {
-			if extRunner != nil {
-				extRunner.EmitToolExecutionEnd(call.Function.Name, call.ID, true)
-			}
+			e.ext.EmitToolExecutionEnd(call.Function.Name, call.ID, true)
 			return e.cancelResult(call, emit), false, ""
 		}
 		errText = err.Error()
@@ -184,25 +164,26 @@ func (e *Executor) runOne(
 		postStop    bool
 		postReason  string
 	)
-	if extRunner != nil {
-		newContent, ctxText, stop, reason := extRunner.PostTool(
-			ctx,
-			call.Function.Name,
-			call.ID,
-			args,
-			content,
-			err != nil,
-			errText,
-		)
-		postContext = ctxText
-		postStop = stop
-		postReason = reason
-		if newContent != "" {
-			content = newContent
-			output = newContent
-		}
-		extRunner.EmitToolExecutionEnd(call.Function.Name, call.ID, err != nil)
+	newContent, ctxText, stop, reason := e.ext.PostTool(
+		ctx,
+		call.Function.Name,
+		call.ID,
+		args,
+		content,
+		err != nil,
+		errText,
+	)
+	postContext = ctxText
+	postStop = stop
+	postReason = reason
+	// PostTool passes content through untouched when the runner is nil or no
+	// handler rewrites it; only a changed result is applied so tool Error/Output
+	// never duplicate (and nil behaves like an empty runner).
+	if newContent != "" && newContent != content {
+		content = newContent
+		output = newContent
 	}
+	e.ext.EmitToolExecutionEnd(call.Function.Name, call.ID, err != nil)
 
 	modelContent := appendExtContext(content, joinExtContexts(preContext, postContext))
 


### PR DESCRIPTION
*extension.Runner methods are nil-safe no-ops (documented in runner.go), so the repeated `engine.extensions != nil` / `extRunner != nil` guards in engine.go and executor.go duplicate that single source of truth. Call extension hooks unconditionally and remove the now-dead activeExt helper.

Apply the PostTool rewrite only when the content actually changed: the runner passes content through untouched when nil or when no handler rewrites it, so `newContent != ""` alone copied error text into the UI Output field (duplicating ToolRun.Error) on the nil-runner error path.