### PR TITLE
refactor(tui): drop clipboard-copy-last palette command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+- Palette command `clipboard copy last message` (`Ctrl+Shift+C`); the key chord still copies selection / last message via the transcript handler.
+
 ### Fixed
 
 ### Security

--- a/doc/tui.md
+++ b/doc/tui.md
@@ -197,7 +197,7 @@ Composer input is blocked while an overlay is active (`OverlayBlocksComposer`).
   → ExtCommands (async) → ExtCommandResultMsg → palette push / toast
 ```
 
-`commandBridge` in `editor` builds `commands.CommandContext` for builtins (model switch, theme, permissions, copy last message, …).
+`commandBridge` in `editor` builds `commands.CommandContext` for builtins (model switch, theme, permissions, …).
 
 ### 6. Background chrome
 

--- a/internal/tui/commands/builtins.go
+++ b/internal/tui/commands/builtins.go
@@ -97,23 +97,6 @@ func registerBuiltinCommands(r *CommandRegistry) {
 			return SkillsCommand(ctx.SkillPath, ctx.AddSkill)
 		},
 	})
-	r.Register(Command{
-		Name: "clipboard-copy-last",
-		PaletteRoot: func(ctx CommandContext) palette.PaletteCommand {
-			return palette.PaletteCommand{
-				ID:       "clipboard-copy-last",
-				Noun:     "clipboard",
-				Verb:     "copy last message",
-				Keywords: []string{"yank", "selection"},
-				Shortcut: "Ctrl+Shift+C",
-				Run: func() {
-					if ctx.CopyLastMessage != nil {
-						ctx.CopyLastMessage()
-					}
-				},
-			}
-		},
-	})
 }
 
 // modelSettingsCommand returns settings → model submenu.

--- a/internal/tui/commands/registry.go
+++ b/internal/tui/commands/registry.go
@@ -32,7 +32,6 @@ type CommandContext struct {
 	ReloadExtensions func()
 	ListExtensions   func() []palette.PaletteCommand
 	AddSkill         func(name string)
-	CopyLastMessage  func()
 
 	ModelNames []string
 	SkillPath  string

--- a/internal/tui/editor/bridge.go
+++ b/internal/tui/editor/bridge.go
@@ -27,7 +27,6 @@ type commandBridge struct {
 	setPermissions   func(bool)
 	setAgents        func(bool)
 	addSkill         func(string)
-	copyLastMessage  func()
 
 	modelNames []string
 	skillPath  string
@@ -49,7 +48,6 @@ func newCommandBridge(
 	setPermissions func(bool),
 	setAgents func(bool),
 	addSkill func(string),
-	copyLastMessage func(),
 ) *commandBridge {
 	return &commandBridge{
 		bus:              bus,
@@ -65,7 +63,6 @@ func newCommandBridge(
 		setPermissions:   setPermissions,
 		setAgents:        setAgents,
 		addSkill:         addSkill,
-		copyLastMessage:  copyLastMessage,
 		modelNames:       append([]string(nil), modelNames...),
 		skillPath:        skillPath,
 	}
@@ -100,7 +97,6 @@ func (b *commandBridge) context() commands.CommandContext {
 		ReloadExtensions: b.reloadExtensions,
 		ListExtensions:   b.listExtensions,
 		AddSkill:         b.addSkill,
-		CopyLastMessage:  b.copyLastMessage,
 		ModelNames:       b.modelNames,
 		SkillPath:        b.skillPath,
 	}

--- a/internal/tui/editor/editor.go
+++ b/internal/tui/editor/editor.go
@@ -172,7 +172,6 @@ func NewEditor(
 		e.setPermissions,
 		e.setAgents,
 		e.addPendingSkill,
-		e.copyLastMessage,
 	)
 	e.extCmds.CommandCtx = bridge.context
 	e.composer.Wire(
@@ -489,10 +488,6 @@ func (e *Editor) reloadExtensions() {
 func (e *Editor) listExtensions() []palette.PaletteCommand {
 	found, warns, err := e.ctrl.ListExtensions()
 	return commands.ExtensionListEntries(found, warns, err)
-}
-
-func (e *Editor) copyLastMessage() {
-	e.transcript.CopyBlock(e.transcript.LastCopyText())
 }
 
 // SubmitPrompt publishes a user prompt onto the bus.


### PR DESCRIPTION
Ctrl+Shift+C still copies selection / last message via the transcript handler, so this only removes the redundant palette entry and its CommandContext plumbing (bridge, editor, registry).