### PR TITLE
refactor(ext/rust): split phi SDK into module dir, add Schema builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Rust SDK: typed `phi::Schema` builder for tool parameters (replaces raw `Vec<u8>`), staying zero-dep instead of Codex-style `schemars`.
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -371,6 +371,19 @@ Install under `~/.phi/extensions/<name>/` with a `phi.yaml` pointing at the
 binary. In the TUI: `Ctrl+K` → **extensions**. Disable with
 `PHI_EXTENSIONS=off`. Full guide: [doc/extensions.md](doc/extensions.md).
 
+Codec throughput on Apple Silicon (release, single-threaded):
+
+| Implementation | Hello encode+decode | Frame write+read (in-memory) | Allocs |
+|---|---|---|---|
+| Rust PXB (`phi-ext`) | ~0.12 µs | ~0.06 µs | — |
+| Go PXB (`ext/go/pxb`) | ~0.11 µs | ~0.05 µs | 3 / op |
+| Go JSON lines | ~1.2 µs | — | 15 / op |
+
+The ~10× gap over JSON lines is the protocol (fixed header + tagged fields), not
+the language — Rust and Go are within noise on the same codec work. Real
+extension latency is dominated by process spawn and pipe RTT anyway. Re-probe:
+`cargo run --release --example bench` in [`ext/rust`](ext/rust).
+
 ## MCP
 
 **Configure 100 MCP servers. Pay ~0 schema tokens until you call one.**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -363,6 +363,18 @@ func main() {
 放到 `~/.phi/extensions/<name>/`，附带 `phi.yaml` 指向二进制。
 TUI：`Ctrl+K` → **extensions**。禁用：`PHI_EXTENSIONS=off`。完整指南见 [doc/extensions.md](doc/extensions.md)。
 
+Codec 吞吐（Apple Silicon，release，单线程）：
+
+| 实现 | Hello encode+decode | Frame write+read（内存） | Allocs |
+|---|---|---|---|
+| Rust PXB (`phi-ext`) | ~0.12 µs | ~0.06 µs | — |
+| Go PXB (`ext/go/pxb`) | ~0.11 µs | ~0.05 µs | 3 / op |
+| Go JSON lines | ~1.2 µs | — | 15 / op |
+
+相对 JSON lines 约 10× 来自协议本身（定长头 + tagged fields），不是语言——同套
+codec 工作下 Rust / Go 在噪声内。扩展真实延迟仍由进程 spawn 和 pipe RTT 主导。
+复测：在 [`ext/rust`](ext/rust) 里跑 `cargo run --release --example bench`。
+
 ## MCP
 
 **配 100 个 MCP 服务器，开场 schema 仍接近 0 token。**

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -39,6 +39,11 @@ length) and **tagged-field** payloads (`tag u16 | kind u8 | value`). Decoders
 skip unknown tags; new events are new `Ev*` codes; new frame types are skipped
 by `payload_len`. See `ext/go/pxb` package doc for the full evolution rules.
 
+On Apple Silicon (release), Hello encode+decode is ~0.11–0.12 µs for Go and
+Rust PXB vs ~1.2 µs for a comparable JSON-lines object — see the table in the
+root [README](../README.md#extensions). Re-probe with
+`cargo run --release --example bench` under `ext/rust`.
+
 ## Layout
 
 | Location | Scope |

--- a/ext/rust/README.md
+++ b/ext/rust/README.md
@@ -15,7 +15,7 @@ against `ext/go/pxb/testdata/*.bin` (`tests/pxb_test.rs`).
 | Path | Role |
 |------|------|
 | `src/pxb/` | Wire protocol: frames (`codec`), tagged fields (`fields`), message codecs (`msg`), types/events (`types`) |
-| `src/phi/` | Author SDK: `Extension`, `Tool`, `Command`, `Context` |
+| `src/phi/` | Author SDK: `Extension`, `Tool`, `Command`, `Context`, `Schema` |
 | `examples/` | Runnable extensions: `hello` (commands, intercepts, subscribe), `full` (tool, confirm, submit) |
 | `tests/` | Golden byte-compat + end-to-end fake-host tests |
 
@@ -67,24 +67,9 @@ cp target/release/examples/hello phi.yaml ~/.phi/extensions/hello/
 
 Reload in the TUI: **Ctrl+K → extensions → reload**.
 
-## Performance
-
-Codec throughput on Apple Silicon (release build, single-threaded):
-
-| Implementation | Hello payload encode+decode | Frame write+read (in-memory) | Allocs |
-|---|---|---|---|
-| Rust PXB (`phi-ext`) | ~0.12 µs | ~0.06 µs | — |
-| Go PXB (`ext/go/pxb`) | ~0.11 µs | ~0.05 µs | 3 / op |
-| Go JSON lines (marshal+unmarshal) | ~1.2 µs | — | 15 / op |
-
-The ~10× gap over JSON lines comes from the protocol itself — fixed binary
-header + tagged fields, no JSON parsing or reflection (see
-`doc/extensions.md`, "Why not JSON lines?"). The language choice is within
-noise: Rust and Go are at parity on identical codec work.
-
-Codec CPU is not the bottleneck anyway: an extension's latency is dominated
-by process spawn (~ms) and pipe round trips (~µs), identical for both SDKs.
-Re-run the probe with `cargo run --release --example bench`.
+PXB codec numbers (vs Go / JSON lines) live in the root
+[README](../../README.md#extensions). Re-run the probe with
+`cargo run --release --example bench`.
 
 ## Development
 

--- a/ext/rust/examples/full.rs
+++ b/ext/rust/examples/full.rs
@@ -8,8 +8,9 @@ fn main() -> Result<(), phi::Error> {
     m.register_tool(phi::Tool::new(
         "echo",
         "Echo the input back",
-        br#"{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}"#
-            .to_vec(),
+        phi::Schema::object()
+            .property("text", phi::Schema::string())
+            .required(["text"]),
         |args| {
             let text = String::from_utf8_lossy(args);
             Ok(phi::ToolResult {

--- a/ext/rust/src/phi/mod.rs
+++ b/ext/rust/src/phi/mod.rs
@@ -30,6 +30,9 @@ use crate::pxb;
 
 pub use crate::pxb::Error;
 
+mod schema;
+pub use schema::Schema;
+
 type Rd = io::StdinLock<'static>;
 type Wr = io::StdoutLock<'static>;
 type EventHandlers = HashMap<u16, Box<dyn FnMut(pxb::EventNotify)>>;
@@ -44,13 +47,13 @@ pub struct HostInfo {
     pub phi_version: String,
 }
 
-/// An LLM-callable tool. `schema` is raw JSON Schema bytes
-/// (`type`/`object`/`properties`/`required`).
+/// An LLM-callable tool. `schema` is a typed JSON Schema for parameters
+/// (same role as Go's `Parameters` / Codex's schemars-generated input schema).
 #[allow(clippy::type_complexity)] // execute signature mirrors the Go SDK contract
 pub struct Tool {
     pub name: String,
     pub description: String,
-    pub schema: Vec<u8>,
+    pub schema: Schema,
     pub execute: Box<dyn FnMut(&[u8]) -> Result<ToolResult, String>>,
 }
 
@@ -58,13 +61,13 @@ impl Tool {
     pub fn new(
         name: impl Into<String>,
         description: impl Into<String>,
-        schema: Vec<u8>,
+        schema: impl Into<Schema>,
         execute: impl FnMut(&[u8]) -> Result<ToolResult, String> + 'static,
     ) -> Self {
         Self {
             name: name.into(),
             description: description.into(),
-            schema,
+            schema: schema.into(),
             execute: Box::new(execute),
         }
     }
@@ -377,7 +380,7 @@ impl Extension {
             let body = pxb::encode_register_tool(&pxb::RegisterTool {
                 name: tool.name.clone(),
                 description: tool.description.clone(),
-                schema_json: tool.schema.clone(),
+                schema_json: tool.schema.to_json_bytes(),
             });
             pxb::write_frame(&mut wr, pxb::TYPE_REGISTER_TOOL, 0, 0, &body)?;
         }

--- a/ext/rust/src/phi/schema.rs
+++ b/ext/rust/src/phi/schema.rs
@@ -1,0 +1,346 @@
+//! Typed JSON Schema for tool parameters.
+//!
+//! Codex generates these via `schemars` from Rust argument structs. This crate
+//! stays dependency-free, so authors build an equivalent schema with the
+//! builders below; the wire still carries opaque JSON Schema bytes (same as
+//! Go's `Parameters map[string]any` after `json.Marshal`).
+
+use std::collections::BTreeMap;
+
+/// JSON Schema body for an LLM tool's parameters
+/// (`type` / `properties` / `required` / …).
+#[derive(Debug, Clone)]
+pub struct Schema {
+    inner: SchemaInner,
+}
+
+#[derive(Debug, Clone)]
+enum SchemaInner {
+    Built(Node),
+    /// Escape hatch for hand-written JSON Schema bytes.
+    Raw(Vec<u8>),
+}
+
+#[derive(Debug, Clone)]
+struct Node {
+    kind: Kind,
+    description: Option<String>,
+    properties: BTreeMap<String, Node>,
+    required: Vec<String>,
+    additional_properties: Option<bool>,
+    enum_values: Vec<String>,
+    items: Option<Box<Node>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Object,
+    String,
+    Number,
+    Integer,
+    Boolean,
+    Array,
+}
+
+impl Default for Node {
+    fn default() -> Self {
+        Self {
+            kind: Kind::Object,
+            description: None,
+            properties: BTreeMap::new(),
+            required: Vec::new(),
+            additional_properties: None,
+            enum_values: Vec::new(),
+            items: None,
+        }
+    }
+}
+
+impl Schema {
+    fn from_node(node: Node) -> Self {
+        Self {
+            inner: SchemaInner::Built(node),
+        }
+    }
+
+    /// Object schema (`{"type":"object",…}`). Default for tool parameters.
+    pub fn object() -> Self {
+        Self::from_node(Node {
+            kind: Kind::Object,
+            ..Node::default()
+        })
+    }
+
+    pub fn string() -> Self {
+        Self::from_node(Node {
+            kind: Kind::String,
+            ..Node::default()
+        })
+    }
+
+    pub fn number() -> Self {
+        Self::from_node(Node {
+            kind: Kind::Number,
+            ..Node::default()
+        })
+    }
+
+    pub fn integer() -> Self {
+        Self::from_node(Node {
+            kind: Kind::Integer,
+            ..Node::default()
+        })
+    }
+
+    pub fn boolean() -> Self {
+        Self::from_node(Node {
+            kind: Kind::Boolean,
+            ..Node::default()
+        })
+    }
+
+    /// Array schema. `items` must be a builder schema (not [`Schema::raw`]).
+    pub fn array(items: Schema) -> Self {
+        let SchemaInner::Built(items_node) = items.inner else {
+            panic!("Schema::array requires a builder schema, not Schema::raw");
+        };
+        Self::from_node(Node {
+            kind: Kind::Array,
+            items: Some(Box::new(items_node)),
+            ..Node::default()
+        })
+    }
+
+    /// Opaque JSON Schema bytes (the previous `Vec<u8>` API).
+    pub fn raw(json: impl Into<Vec<u8>>) -> Self {
+        Self {
+            inner: SchemaInner::Raw(json.into()),
+        }
+    }
+
+    pub fn description(mut self, d: impl Into<String>) -> Self {
+        if let SchemaInner::Built(n) = &mut self.inner {
+            n.description = Some(d.into());
+        }
+        self
+    }
+
+    /// Add an object property. No-op on non-object / raw schemas.
+    pub fn property(mut self, name: impl Into<String>, schema: Schema) -> Self {
+        if let SchemaInner::Built(n) = &mut self.inner {
+            if n.kind == Kind::Object {
+                if let SchemaInner::Built(child) = schema.inner {
+                    n.properties.insert(name.into(), child);
+                }
+            }
+        }
+        self
+    }
+
+    /// Mark object property names as required.
+    pub fn required<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        if let SchemaInner::Built(n) = &mut self.inner {
+            if n.kind == Kind::Object {
+                n.required.extend(names.into_iter().map(Into::into));
+            }
+        }
+        self
+    }
+
+    pub fn additional_properties(mut self, allow: bool) -> Self {
+        if let SchemaInner::Built(n) = &mut self.inner {
+            if n.kind == Kind::Object {
+                n.additional_properties = Some(allow);
+            }
+        }
+        self
+    }
+
+    /// Restrict a string schema to an enum (Codex-style compact enums).
+    pub fn enum_values<I, S>(mut self, values: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        if let SchemaInner::Built(n) = &mut self.inner {
+            if n.kind == Kind::String {
+                n.enum_values.extend(values.into_iter().map(Into::into));
+            }
+        }
+        self
+    }
+
+    /// Serialize to JSON Schema bytes for `RegisterTool`.
+    pub fn to_json_bytes(&self) -> Vec<u8> {
+        match &self.inner {
+            SchemaInner::Raw(b) => b.clone(),
+            SchemaInner::Built(n) => {
+                let mut s = String::new();
+                write_node(&mut s, n);
+                s.into_bytes()
+            }
+        }
+    }
+}
+
+impl From<Vec<u8>> for Schema {
+    fn from(json: Vec<u8>) -> Self {
+        Schema::raw(json)
+    }
+}
+
+impl From<&[u8]> for Schema {
+    fn from(json: &[u8]) -> Self {
+        Schema::raw(json.to_vec())
+    }
+}
+
+fn write_node(out: &mut String, n: &Node) {
+    out.push('{');
+    let mut first = true;
+    push_key(out, &mut first, "type");
+    push_json_string(out, kind_str(n.kind));
+
+    if let Some(d) = &n.description {
+        push_key(out, &mut first, "description");
+        push_json_string(out, d);
+    }
+
+    if n.kind == Kind::Object {
+        push_key(out, &mut first, "properties");
+        out.push('{');
+        let mut pfirst = true;
+        for (name, child) in &n.properties {
+            if !pfirst {
+                out.push(',');
+            }
+            pfirst = false;
+            push_json_string(out, name);
+            out.push(':');
+            write_node(out, child);
+        }
+        out.push('}');
+
+        if !n.required.is_empty() {
+            push_key(out, &mut first, "required");
+            out.push('[');
+            for (i, name) in n.required.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                push_json_string(out, name);
+            }
+            out.push(']');
+        }
+
+        if let Some(allow) = n.additional_properties {
+            push_key(out, &mut first, "additionalProperties");
+            out.push_str(if allow { "true" } else { "false" });
+        }
+    }
+
+    if n.kind == Kind::String && !n.enum_values.is_empty() {
+        push_key(out, &mut first, "enum");
+        out.push('[');
+        for (i, v) in n.enum_values.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            push_json_string(out, v);
+        }
+        out.push(']');
+    }
+
+    if n.kind == Kind::Array {
+        if let Some(items) = &n.items {
+            push_key(out, &mut first, "items");
+            write_node(out, items);
+        }
+    }
+
+    out.push('}');
+}
+
+fn kind_str(k: Kind) -> &'static str {
+    match k {
+        Kind::Object => "object",
+        Kind::String => "string",
+        Kind::Number => "number",
+        Kind::Integer => "integer",
+        Kind::Boolean => "boolean",
+        Kind::Array => "array",
+    }
+}
+
+fn push_key(out: &mut String, first: &mut bool, key: &str) {
+    if !*first {
+        out.push(',');
+    }
+    *first = false;
+    push_json_string(out, key);
+    out.push(':');
+}
+
+fn push_json_string(out: &mut String, s: &str) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn object_with_required_string_prop() {
+        let s = Schema::object()
+            .property("text", Schema::string().description("input text"))
+            .required(["text"]);
+        assert_eq!(
+            String::from_utf8(s.to_json_bytes()).unwrap(),
+            r#"{"type":"object","properties":{"text":{"type":"string","description":"input text"}},"required":["text"]}"#
+        );
+    }
+
+    #[test]
+    fn string_enum_and_additional_properties() {
+        let s = Schema::object()
+            .property(
+                "mode",
+                Schema::string().enum_values(["read-only", "workspace-write"]),
+            )
+            .additional_properties(false);
+        let json = String::from_utf8(s.to_json_bytes()).unwrap();
+        assert!(json.contains(r#""enum":["read-only","workspace-write"]"#));
+        assert!(json.contains(r#""additionalProperties":false"#));
+    }
+
+    #[test]
+    fn array_of_strings() {
+        let s = Schema::object().property("tags", Schema::array(Schema::string()));
+        assert_eq!(
+            String::from_utf8(s.to_json_bytes()).unwrap(),
+            r#"{"type":"object","properties":{"tags":{"type":"array","items":{"type":"string"}}}}"#
+        );
+    }
+
+    #[test]
+    fn raw_passthrough() {
+        let raw = br#"{"type":"object"}"#;
+        assert_eq!(Schema::raw(raw.to_vec()).to_json_bytes(), raw);
+    }
+}


### PR DESCRIPTION
- Replace monolithic ext/rust/src/phi.rs with ext/rust/src/phi/ module directory
- Add typed phi::Schema builder for tool parameters (replaces raw Vec<u8> JSON schema bytes, zero-dep)
- Update full.rs example and READMEs to use Schema builder
- Move codec throughput benchmarks to root README (shared across SDKs)