### PR TITLE
refactor(tui): extract chrome package, unify glyphs and hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- TUI chrome consistency: shared glyph/hint dialect (`internal/components/chrome`), unified ask/continue/confirm option rows, `Theme.Identity` for model/user/bash chrome (separate from Success status), and aligned transcript expand indent / status suffixes. Permission/continue/confirm overlays navigate with arrows only (no Alt+N accelerators). Sessions list picker uses a wider panel (~90% / up to 112 cols) so previews truncate less.
+
 ### Deprecated
 
 ### Removed

--- a/internal/components/block/agent_block.go
+++ b/internal/components/block/agent_block.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/components/status"
 	"github.com/pulseaiclub/phi/internal/components/text"
 	"github.com/pulseaiclub/phi/internal/components/tree"
@@ -83,7 +84,7 @@ func (a *AgentBlock) CopyText() string {
 	for i, c := range a.Children {
 		b.WriteByte('\n')
 		b.WriteString(tree.PrefixForSiblings(len(a.Children), i, st))
-		b.WriteString(childIcon(c.Status))
+		b.WriteString(chrome.ChildIcon(c.Status))
 		b.WriteByte(' ')
 		b.WriteString(c.Name)
 		if c.Detail != "" {
@@ -112,7 +113,7 @@ func (a *AgentBlock) Draw(ctx components.DrawContext) components.Surface {
 		w = 40
 	}
 
-	icon, iconSt := toolIcon(a.Status, th, a.Spinner)
+	icon, iconSt := chrome.ToolIcon(a.Status, th, a.Spinner)
 	spans := []components.Span{
 		{Text: icon + " ", Style: iconSt},
 		{Text: a.Name, Style: th.ToolName},
@@ -120,18 +121,11 @@ func (a *AgentBlock) Draw(ctx components.DrawContext) components.Surface {
 	if a.Detail != "" {
 		spans = append(spans, components.Span{Text: " " + a.Detail, Style: th.Muted})
 	}
-	switch a.Status {
-	case status.ToolCancelled:
-		spans = append(spans, components.Span{Text: " (cancelled)", Style: th.Muted})
-	case status.ToolRejected:
-		spans = append(spans, components.Span{Text: " (rejected)", Style: th.Muted})
+	if suf := chrome.StatusSuffix(a.Status); suf != "" {
+		spans = append(spans, components.Span{Text: suf, Style: th.Muted})
 	}
 	if a.hasBody() {
-		arrow := " ▶"
-		if a.Expanded {
-			arrow = " ▼"
-		}
-		spans = append(spans, components.Span{Text: arrow, Style: th.Muted})
+		spans = append(spans, components.Span{Text: chrome.ExpandArrow(a.Expanded), Style: th.Muted})
 	}
 
 	titleLines := components.WrapSpans(spans, w, ctx.Method)
@@ -148,7 +142,7 @@ func (a *AgentBlock) Draw(ctx components.DrawContext) components.Surface {
 		n := len(a.Children)
 		for i, c := range a.Children {
 			prefix := tree.PrefixForSiblings(n, i, st)
-			cIcon, cSt := toolIcon(c.Status, th, a.Spinner)
+			cIcon, cSt := chrome.ToolIcon(c.Status, th, a.Spinner)
 			row := []components.Span{
 				{Text: prefix, Style: th.Muted},
 				{Text: cIcon + " ", Style: cSt},
@@ -187,37 +181,4 @@ func (a *AgentBlock) Draw(ctx components.DrawContext) components.Surface {
 		y++
 	}
 	return s
-}
-
-func toolIcon(st status.ToolStatus, th components.Theme, spin *status.Spinner) (string, xui.Style) {
-	icon := "✓"
-	iconSt := th.Success
-	switch st {
-	case status.ToolRunning, status.ToolQueued:
-		icon = "⋯"
-		iconSt = th.ToolName
-		if spin != nil {
-			icon = spin.Glyph()
-		}
-	case status.ToolError:
-		icon = "✗"
-		iconSt = th.Destructive
-	case status.ToolCancelled, status.ToolRejected:
-		icon = "⊘"
-		iconSt = th.Muted
-	}
-	return icon, iconSt
-}
-
-func childIcon(st status.ToolStatus) string {
-	switch st {
-	case status.ToolRunning, status.ToolQueued:
-		return "⋯"
-	case status.ToolError:
-		return "✗"
-	case status.ToolCancelled, status.ToolRejected:
-		return "⊘"
-	default:
-		return "✓"
-	}
 }

--- a/internal/components/block/assistant_block.go
+++ b/internal/components/block/assistant_block.go
@@ -41,7 +41,7 @@ func (assistantBlock *AssistantBlock) Draw(ctx components.DrawContext) component
 		if len(spans) > 0 {
 			spans = append(spans, components.Span{Text: "\n", Style: th.Muted})
 		}
-		spans = append(spans, components.Span{Text: "cancelled", Style: th.Muted})
+		spans = append(spans, components.Span{Text: "(cancelled)", Style: th.Muted})
 	}
 	return components.PaintRichLines(w, components.WrapSpans(spans, w, ctx.Method), ctx.Method, assistantBlock)
 }

--- a/internal/components/block/assistant_block_test.go
+++ b/internal/components/block/assistant_block_test.go
@@ -90,9 +90,9 @@ func TestAssistantBlockDraw(t *testing.T) {
 			width:         60,
 			wantWidth:     60,
 			wantMinHeight: 2,
-			wantContains:  []string{"partial", "cancelled"},
+			wantContains:  []string{"partial", "(cancelled)"},
 			wantCells: []cellCheck{
-				{x: 0, y: 1, style: th.Muted}, // "cancelled" row
+				{x: 0, y: 1, style: th.Muted}, // "(cancelled)" row
 			},
 		},
 		{

--- a/internal/components/block/bash_block.go
+++ b/internal/components/block/bash_block.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/pulseaiclub/xui"
 
-	"github.com/pulseaiclub/phi/internal/util"
-
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
+	"github.com/pulseaiclub/phi/internal/util"
 )
 
 // BashStatus mirrors bash tool status.
@@ -133,7 +133,7 @@ func (bashBlock *BashBlock) Draw(ctx components.DrawContext) components.Surface 
 
 // titleSpans builds the "$ command [exit code] [arrow]" header spans.
 func (bashBlock *BashBlock) titleSpans(th components.Theme) []components.Span {
-	prefixStyle := th.Success
+	prefixStyle := th.IdentityOrSuccess()
 	switch bashBlock.Status {
 	case BashError:
 		prefixStyle = th.Destructive
@@ -149,7 +149,7 @@ func (bashBlock *BashBlock) titleSpans(th components.Theme) []components.Span {
 	}
 
 	title := []components.Span{
-		{Text: "$ ", Style: prefixStyle},
+		{Text: chrome.BashPrompt, Style: prefixStyle},
 		{Text: bashBlock.Command, Style: cmdStyle},
 	}
 	switch bashBlock.Status {
@@ -172,11 +172,7 @@ func (bashBlock *BashBlock) titleSpans(th components.Theme) []components.Span {
 		)
 	}
 	if bashBlock.hasBody() {
-		arrow := " ▶"
-		if bashBlock.Expanded {
-			arrow = " ▼"
-		}
-		title = append(title, components.Span{Text: arrow, Style: th.Muted})
+		title = append(title, components.Span{Text: chrome.ExpandArrow(bashBlock.Expanded), Style: th.Muted})
 	}
 	return title
 }

--- a/internal/components/block/thinking_block.go
+++ b/internal/components/block/thinking_block.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/components/status"
 )
 
@@ -64,11 +65,11 @@ func (t *ThinkingBlock) Draw(ctx components.DrawContext) components.Surface {
 		w = 40
 	}
 
-	icon := "✓"
+	icon := chrome.Ok
 	iconSt := th.Success
 	labelSt := th.Muted
 	if t.Streaming {
-		icon = "..."
+		icon = chrome.Busy
 		iconSt = th.ToolName
 		if t.Spinner != nil {
 			icon = t.Spinner.Glyph()
@@ -76,7 +77,7 @@ func (t *ThinkingBlock) Draw(ctx components.DrawContext) components.Surface {
 		labelSt = th.ToolName
 	}
 	if t.Interrupted {
-		icon = "⊘"
+		icon = chrome.Stop
 		iconSt = th.Warning
 		labelSt = th.Warning
 	}
@@ -88,11 +89,7 @@ func (t *ThinkingBlock) Draw(ctx components.DrawContext) components.Surface {
 	if t.Interrupted {
 		spans = append(spans, components.Span{Text: " (interrupted)", Style: th.Warning})
 	}
-	arrow := " ▶"
-	if t.Expanded {
-		arrow = " ▼"
-	}
-	spans = append(spans, components.Span{Text: arrow, Style: th.Muted})
+	spans = append(spans, components.Span{Text: chrome.ExpandArrow(t.Expanded), Style: th.Muted})
 
 	titleLines := components.WrapSpans(spans, w, ctx.Method)
 	t.titleH = len(titleLines)
@@ -102,7 +99,11 @@ func (t *ThinkingBlock) Draw(ctx components.DrawContext) components.Surface {
 		body := th.Muted
 		body.Italic = true
 		body.Dim = true
-		bodyLines = components.WrapSpans([]components.Span{{Text: t.Text, Style: body}}, w, ctx.Method)
+		bodyW := w
+		if bodyW > 2 {
+			bodyW -= 2
+		}
+		bodyLines = components.WrapSpans([]components.Span{{Text: t.Text, Style: body}}, bodyW, ctx.Method)
 	}
 
 	h := len(titleLines) + len(bodyLines)
@@ -114,7 +115,7 @@ func (t *ThinkingBlock) Draw(ctx components.DrawContext) components.Surface {
 		y++
 	}
 	for _, line := range bodyLines {
-		components.PaintSpans(&s, 0, y, line, ctx.Method)
+		components.PaintSpans(&s, 2, y, line, ctx.Method)
 		y++
 	}
 	return s

--- a/internal/components/block/tool_block.go
+++ b/internal/components/block/tool_block.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/components/status"
 )
 
@@ -89,26 +90,7 @@ func (toolBlock *ToolBlock) Draw(ctx components.DrawContext) components.Surface 
 		w = 40
 	}
 
-	icon := "✓"
-	iconSt := th.Success
-	switch toolBlock.Status {
-	case status.ToolRunning, status.ToolQueued:
-		icon = "..."
-		iconSt = th.ToolName
-		if toolBlock.Spinner != nil {
-			icon = toolBlock.Spinner.Glyph()
-		}
-	case status.ToolError:
-		icon = "✗"
-		iconSt = th.Destructive
-	case status.ToolCancelled:
-		icon = "⊘"
-		iconSt = th.Muted
-	case status.ToolRejected:
-		icon = "⊘"
-		iconSt = th.Destructive
-	}
-
+	icon, iconSt := chrome.ToolIcon(toolBlock.Status, th, toolBlock.Spinner)
 	spans := []components.Span{
 		{Text: icon + " ", Style: iconSt},
 		{Text: toolBlock.Name, Style: th.ToolName},
@@ -116,18 +98,11 @@ func (toolBlock *ToolBlock) Draw(ctx components.DrawContext) components.Surface 
 	if toolBlock.Detail != "" {
 		spans = append(spans, components.Span{Text: " " + toolBlock.Detail, Style: th.Muted})
 	}
-	switch toolBlock.Status {
-	case status.ToolCancelled:
-		spans = append(spans, components.Span{Text: " (cancelled)", Style: th.Muted})
-	case status.ToolRejected:
-		spans = append(spans, components.Span{Text: " (rejected)", Style: th.Muted})
+	if suf := chrome.StatusSuffix(toolBlock.Status); suf != "" {
+		spans = append(spans, components.Span{Text: suf, Style: th.Muted})
 	}
 	if toolBlock.hasBody() {
-		arrow := " ▶"
-		if toolBlock.Expanded {
-			arrow = " ▼"
-		}
-		spans = append(spans, components.Span{Text: arrow, Style: th.Muted})
+		spans = append(spans, components.Span{Text: chrome.ExpandArrow(toolBlock.Expanded), Style: th.Muted})
 	}
 
 	titleLines := components.WrapSpans(spans, w, ctx.Method)

--- a/internal/components/block/user_block.go
+++ b/internal/components/block/user_block.go
@@ -34,7 +34,7 @@ func (userBlock *UserBlock) Draw(ctx components.DrawContext) components.Surface 
 	}
 	body := th.Foreground
 	body.Italic = true
-	rule := th.Success
+	rule := th.IdentityOrSuccess()
 	innerW := w - 2
 	innerW = max(innerW, 1)
 	lines := components.WrapSpans([]components.Span{{Text: userBlock.Text, Style: body}}, innerW, ctx.Method)

--- a/internal/components/chat/chat_input.go
+++ b/internal/components/chat/chat_input.go
@@ -691,7 +691,7 @@ func (c *ChatInput) paintPendingSkills(s *components.Surface, x, y, width int, m
 	}
 	labelSt := th.Muted
 	labelSt.Dim = true
-	nameSt := th.Success
+	nameSt := th.IdentityOrSuccess()
 	nameSt.Bold = false
 	nameSt.Underline = true
 

--- a/internal/components/chrome/chrome.go
+++ b/internal/components/chrome/chrome.go
@@ -1,0 +1,171 @@
+// Package chrome locks TUI visual grammar: glyphs, hints, and decision-row chrome.
+// Call sites should not invent parallel dialects for the same job.
+package chrome
+
+import (
+	"strings"
+
+	"github.com/pulseaiclub/xui"
+
+	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/status"
+)
+
+// Status / expand glyphs.
+const (
+	Ok       = "✓"
+	Err      = "✗"
+	Stop     = "⊘"
+	Busy     = "⋯"
+	Expand   = " ▶"
+	Collapse = " ▼"
+)
+
+// Decision-row glyphs (permission / continue / confirm).
+const (
+	SelectArrow = "▸"
+	DotOn       = "●"
+	DotOff      = "○"
+)
+
+// Prompt glyphs.
+const (
+	FilterPrompt = ">"
+	SoftPrompt   = "› "
+	BashPrompt   = "$ "
+)
+
+// Sep joins hint fragments. One separator for the whole product.
+const Sep = " · "
+
+// ListHint is the default bottom-border caption for filterable list overlays.
+func ListHint(action string) string {
+	if action == "" {
+		action = "select"
+	}
+	return " ↑↓ move" + Sep + "⏎ " + action + Sep + "esc close "
+}
+
+// ListHintShort is the compact fallback when the full ListHint does not fit.
+func ListHintShort(action string) string {
+	if action == "" {
+		action = "select"
+	}
+	return " ⏎ " + action + Sep + "esc close "
+}
+
+// AskHint builds muted footer copy for decision panels.
+// nav is typically "↑↓ move" or "←→ move"; action/dismiss are verb phrases
+// after the key (e.g. "select", "cancel").
+func AskHint(nav, action, dismiss string) string {
+	parts := make([]string, 0, 3)
+	if nav != "" {
+		parts = append(parts, nav)
+	}
+	if action != "" {
+		parts = append(parts, "Enter "+action)
+	}
+	if dismiss != "" {
+		parts = append(parts, "Esc "+dismiss)
+	}
+	return strings.Join(parts, Sep)
+}
+
+// ConfirmHint is the confirm-panel footer (includes Y/N chords).
+func ConfirmHint() string {
+	return "←→ move" + Sep + "Enter confirm" + Sep + "Y yes" + Sep + "N/Esc cancel"
+}
+
+// FeedbackHint is the deny-with-feedback footer.
+func FeedbackHint() string {
+	return "Enter send" + Sep + "Esc cancel"
+}
+
+// DecisionPrimary is the accent used for selected decision rows.
+func DecisionPrimary(th components.Theme) xui.Style {
+	if th.ToolName.Fg.Kind != 0 {
+		return th.ToolName
+	}
+	return th.Success
+}
+
+// OptionLine paints one ▸● /  ○ decision row.
+func OptionLine(
+	th components.Theme,
+	primary xui.Style,
+	label string,
+	selected bool,
+	innerW int,
+	method xui.WidthMethod,
+) []components.RichLine {
+	arrow, dot := " ", DotOff
+	labelSt, dotSt := th.Foreground, th.Muted
+	if selected {
+		arrow, dot = SelectArrow, DotOn
+		labelSt = xui.Style{Bold: true, Fg: primary.Fg}
+		dotSt = primary
+	}
+	return components.WrapSpans([]components.Span{
+		{Text: arrow, Style: primary},
+		{Text: dot, Style: dotSt},
+		{Text: " " + label, Style: labelSt},
+	}, innerW, method)
+}
+
+// ExpandArrow returns the collapsed/expanded disclosure glyph.
+func ExpandArrow(expanded bool) string {
+	if expanded {
+		return Collapse
+	}
+	return Expand
+}
+
+// ToolIcon returns the status glyph + style for a tool / agent title row.
+func ToolIcon(st status.ToolStatus, th components.Theme, spin *status.Spinner) (string, xui.Style) {
+	icon := Ok
+	iconSt := th.Success
+	switch st {
+	case status.ToolRunning, status.ToolQueued:
+		icon = Busy
+		iconSt = th.ToolName
+		if spin != nil {
+			icon = spin.Glyph()
+		}
+	case status.ToolError:
+		icon = Err
+		iconSt = th.Destructive
+	case status.ToolCancelled:
+		icon = Stop
+		iconSt = th.Muted
+	case status.ToolRejected:
+		icon = Stop
+		iconSt = th.Destructive
+	}
+	return icon, iconSt
+}
+
+// ChildIcon is the compact nested-tree status mark (no spinner).
+func ChildIcon(st status.ToolStatus) string {
+	switch st {
+	case status.ToolRunning, status.ToolQueued:
+		return Busy
+	case status.ToolError:
+		return Err
+	case status.ToolCancelled, status.ToolRejected:
+		return Stop
+	default:
+		return Ok
+	}
+}
+
+// StatusSuffix is the muted parenthetical for cancelled / rejected rows.
+func StatusSuffix(st status.ToolStatus) string {
+	switch st {
+	case status.ToolCancelled:
+		return " (cancelled)"
+	case status.ToolRejected:
+		return " (rejected)"
+	default:
+		return ""
+	}
+}

--- a/internal/components/chrome/chrome_test.go
+++ b/internal/components/chrome/chrome_test.go
@@ -1,0 +1,53 @@
+package chrome_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
+	"github.com/pulseaiclub/phi/internal/components/status"
+)
+
+func TestHintDialect(t *testing.T) {
+	assert.Equal(t, " ↑↓ move · ⏎ select · esc close ", chrome.ListHint("select"))
+	assert.Equal(t, " ↑↓ move · ⏎ resume · esc close ", chrome.ListHint("resume"))
+	assert.Equal(t, " ⏎ select · esc close ", chrome.ListHintShort("select"))
+	assert.Equal(t, "↑↓ move · Enter select · Esc cancel", chrome.AskHint("↑↓ move", "select", "cancel"))
+	assert.Equal(t, "↑↓ move · Enter select · Esc stop", chrome.AskHint("↑↓ move", "select", "stop"))
+	assert.Equal(t, "←→ move · Enter confirm · Y yes · N/Esc cancel", chrome.ConfirmHint())
+	assert.Equal(t, "Enter send · Esc cancel", chrome.FeedbackHint())
+}
+
+func TestToolIconRejectedUsesDestructive(t *testing.T) {
+	th := components.DefaultTheme()
+	icon, st := chrome.ToolIcon(status.ToolRejected, th, nil)
+	assert.Equal(t, chrome.Stop, icon)
+	assert.Equal(t, th.Destructive.Fg, st.Fg)
+
+	icon, st = chrome.ToolIcon(status.ToolCancelled, th, nil)
+	assert.Equal(t, chrome.Stop, icon)
+	assert.Equal(t, th.Muted.Fg, st.Fg)
+}
+
+func TestExpandArrow(t *testing.T) {
+	assert.Equal(t, chrome.Expand, chrome.ExpandArrow(false))
+	assert.Equal(t, chrome.Collapse, chrome.ExpandArrow(true))
+}
+
+func TestOptionLineSelected(t *testing.T) {
+	th := components.DefaultTheme()
+	primary := chrome.DecisionPrimary(th)
+	lines := chrome.OptionLine(th, primary, "Approve", true, 40, 0)
+	require.NotEmpty(t, lines)
+	joined := ""
+	for _, sp := range lines[0] {
+		joined += sp.Text
+	}
+	assert.Contains(t, joined, chrome.SelectArrow)
+	assert.Contains(t, joined, chrome.DotOn)
+	assert.Contains(t, joined, "Approve")
+	assert.NotContains(t, joined, "Alt+")
+}

--- a/internal/components/listpicker/picker.go
+++ b/internal/components/listpicker/picker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/components/layout"
 	"github.com/pulseaiclub/phi/internal/util"
 )
@@ -96,7 +97,7 @@ func normalizeConfig(cfg ShowConfig) ShowConfig {
 		cfg.EmptyFilter = "No matches for %q"
 	}
 	if cfg.Hint == "" {
-		cfg.Hint = " ↑↓ move  ⏎ select  esc close "
+		cfg.Hint = chrome.ListHint("select")
 	}
 	if cfg.LeadingWidth <= 0 {
 		cfg.LeadingWidth = 10
@@ -353,10 +354,11 @@ func (p *Picker) Draw(ctx components.DrawContext) components.Surface {
 func (p *Picker) panelWidth(maxW int) int {
 	boxW := p.Width
 	if boxW <= 0 {
-		boxW = maxW * 4 / 5
-		boxW = min(boxW, 72)
-		if boxW < 48 {
-			boxW = min(maxW, 60)
+		// Session previews need room; prefer ~90% of the terminal up to a soft cap.
+		boxW = maxW * 9 / 10
+		boxW = min(boxW, 112)
+		if boxW < 56 {
+			boxW = min(maxW, 72)
 		}
 	}
 	if boxW > maxW-2 {
@@ -406,7 +408,7 @@ func (p *Picker) syncScroll(visible int) {
 
 func (p *Picker) drawPrompt(panel *components.Surface, ctx components.DrawContext, th components.Theme, boxW int) {
 	const y = 1
-	panel.Print(1, y, ">", th.Foreground, ctx.Method)
+	panel.Print(1, y, chrome.FilterPrompt, th.Foreground, ctx.Method)
 	avail := max(boxW-5, 1)
 	q := p.Query
 	placeholder := false
@@ -512,7 +514,7 @@ func (p *Picker) drawHint(
 ) {
 	hint := p.cfg.Hint
 	if xui.StringWidth(hint, ctx.Method) > boxW-2 {
-		hint = " ⏎ select  esc close "
+		hint = chrome.ListHintShort("select")
 	}
 	y := boxH - 1
 	w := xui.StringWidth(hint, ctx.Method)

--- a/internal/components/palette/command_palette.go
+++ b/internal/components/palette/command_palette.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pulseaiclub/phi/internal/util"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/components/layout"
 )
 
@@ -452,7 +453,7 @@ func (p *CommandPalette) Draw(ctx components.DrawContext) components.Surface {
 
 	// Prompt: "> query"
 	promptY := 1
-	panel.Print(1, promptY, ">", th.Foreground, ctx.Method)
+	panel.Print(1, promptY, chrome.FilterPrompt, th.Foreground, ctx.Method)
 	q := p.Query
 	qx := 3
 	availQ := innerW - 2

--- a/internal/components/sessionlist/items.go
+++ b/internal/components/sessionlist/items.go
@@ -4,6 +4,7 @@ package sessionlist
 import (
 	"time"
 
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/components/listpicker"
 	"github.com/pulseaiclub/phi/internal/session"
 )
@@ -15,7 +16,7 @@ func Config() listpicker.ShowConfig {
 		FilterHint:  "filter id or preview…",
 		Empty:       "No sessions in this directory",
 		EmptyFilter: "No sessions match %q",
-		Hint:        " ↑↓ move  ⏎ resume  esc close ",
+		Hint:        chrome.ListHint("resume"),
 	}
 }
 

--- a/internal/components/splash/screen.go
+++ b/internal/components/splash/screen.go
@@ -112,7 +112,7 @@ func (w *Screen) Draw(ctx components.DrawContext) components.Surface {
 	if th.Foreground.Fg.Kind == xui.ColorRGB {
 		brand = xui.Style{Fg: th.Foreground.Fg, Bold: true}
 	}
-	helpKey := th.Success
+	helpKey := th.IdentityOrSuccess()
 	if helpKey == (xui.Style{}) {
 		helpKey = th.Keybind
 	}

--- a/internal/components/theme.go
+++ b/internal/components/theme.go
@@ -7,10 +7,18 @@ import (
 )
 
 // Theme holds semantic colors for transcript chrome.
+//
+// Roles (do not overload):
+//   - Success / Destructive / Warning — status outcomes
+//   - Identity — speaker / model / shell prompt chrome (not "ok")
+//   - ToolName — tool titles and busy marks
+//   - Border — box edges; Warning doubles as overlay / palette titles
+//   - Selection* / Keybind / Command — palette / list pickers
 type Theme struct {
 	Foreground  xui.Style
 	Muted       xui.Style
 	Success     xui.Style
+	Identity    xui.Style // model label, user rule, bash "$"
 	Accent      xui.Style // links / "Show more"
 	Warning     xui.Style // inline highlights / palette title
 	Destructive xui.Style
@@ -37,6 +45,7 @@ func DarkTheme() Theme {
 		Foreground:  xui.Style{Fg: xui.DefaultColor()},
 		Muted:       xui.Style{Fg: xui.IndexedColor(245), Dim: true},
 		Success:     xui.Style{Fg: xui.RGBColor(0x7d, 0xc3, 0xa0), Bold: true},
+		Identity:    xui.Style{Fg: xui.RGBColor(0x7d, 0xc3, 0xa0), Bold: true},
 		Accent:      xui.Style{Fg: xui.RGBColor(0xc4, 0x8a, 0xd9), Underline: true},
 		Warning:     xui.Style{Fg: xui.RGBColor(0xe5, 0xc0, 0x7b)},
 		Destructive: xui.Style{Fg: xui.RGBColor(0xe0, 0x6c, 0x75)},
@@ -55,6 +64,7 @@ func DarculaTheme() Theme {
 		Foreground:  xui.Style{Fg: xui.RGBColor(0xa9, 0xb7, 0xc6)},
 		Muted:       xui.Style{Fg: xui.RGBColor(0x80, 0x80, 0x80), Dim: true},
 		Success:     xui.Style{Fg: xui.RGBColor(0x6a, 0x87, 0x59), Bold: true},
+		Identity:    xui.Style{Fg: xui.RGBColor(0x6a, 0x87, 0x59), Bold: true},
 		Accent:      xui.Style{Fg: xui.RGBColor(0x58, 0x9d, 0xf6), Underline: true},
 		Warning:     xui.Style{Fg: xui.RGBColor(0xcc, 0x78, 0x32)},
 		Destructive: xui.Style{Fg: xui.RGBColor(0xff, 0x6b, 0x68)},
@@ -73,6 +83,7 @@ func PinkTheme() Theme {
 		Foreground:  xui.Style{Fg: xui.DefaultColor()},
 		Muted:       xui.Style{Fg: xui.RGBColor(0xc8, 0xa0, 0xb4), Dim: true},
 		Success:     xui.Style{Fg: xui.RGBColor(0x9e, 0xd4, 0xb8), Bold: true},
+		Identity:    xui.Style{Fg: xui.RGBColor(0x9e, 0xd4, 0xb8), Bold: true},
 		Accent:      xui.Style{Fg: xui.RGBColor(0xff, 0x9e, 0xc8), Underline: true},
 		Warning:     xui.Style{Fg: xui.RGBColor(0xff, 0xb8, 0x9a)},
 		Destructive: xui.Style{Fg: xui.RGBColor(0xf0, 0x6a, 0x8a)},
@@ -91,6 +102,7 @@ func TerminalTheme() Theme {
 		Foreground:  xui.Style{Fg: xui.DefaultColor()},
 		Muted:       xui.Style{Fg: xui.IndexedColor(8), Dim: true},
 		Success:     xui.Style{Fg: xui.IndexedColor(2), Bold: true},
+		Identity:    xui.Style{Fg: xui.IndexedColor(2), Bold: true},
 		Accent:      xui.Style{Fg: xui.IndexedColor(5), Underline: true},
 		Warning:     xui.Style{Fg: xui.IndexedColor(3)},
 		Destructive: xui.Style{Fg: xui.IndexedColor(1)},
@@ -117,4 +129,12 @@ func ThemeByName(name string) (Theme, bool) {
 	default:
 		return Theme{}, false
 	}
+}
+
+// IdentityOrSuccess returns Identity when set, else Success (legacy themes / zero Theme).
+func (th Theme) IdentityOrSuccess() xui.Style {
+	if th.Identity.Fg.Kind != 0 {
+		return th.Identity
+	}
+	return th.Success
 }

--- a/internal/components/toast/toast.go
+++ b/internal/components/toast/toast.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/components/layout"
 )
 
@@ -142,10 +143,10 @@ func (t *Toast) Draw(ctx components.DrawContext) components.Surface {
 func toastChrome(kind ToastKind, th components.Theme) (border xui.Style, icon string) {
 	switch kind {
 	case ToastError:
-		return th.Destructive, "✕"
+		return th.Destructive, chrome.Err
 	case ToastWarning:
 		return th.Warning, ""
 	default:
-		return th.Success, "✓"
+		return th.Success, chrome.Ok
 	}
 }

--- a/internal/tui/composer/pane.go
+++ b/internal/tui/composer/pane.go
@@ -379,7 +379,7 @@ func (c *ComposerPane) SetTheme(th components.Theme) {
 	c.Chat.BorderStyle = th.Border
 	c.Chat.TextStyle = th.Foreground
 	c.Chat.BottomRightLabel.Style = footer.PathLabelStyle(th)
-	c.Chat.TopRightLabel.Style = th.Success
+	c.Chat.TopRightLabel.Style = th.IdentityOrSuccess()
 	c.palette.Theme = th
 	c.listPicker.Theme = th
 	c.mention.Theme = th
@@ -950,7 +950,7 @@ func newChatInput(theme components.Theme, model, cwd string) chat.ChatInput {
 		CursorStyle:    xui.Style{Reverse: true},
 		TopRightLabel: layout.BorderLabel{
 			Text:  model,
-			Style: theme.Success,
+			Style: theme.IdentityOrSuccess(),
 		},
 		BottomRightLabel: layout.BorderLabel{
 			Text:  pathutil.PathWithBranch(cwd),

--- a/internal/tui/controller/activity.go
+++ b/internal/tui/controller/activity.go
@@ -119,7 +119,7 @@ func activityMessage(a Activity) string {
 	case ActivityCancelled:
 		return "Stopped"
 	case ActivityAwaitingApproval:
-		return "Waiting for approval..."
+		return "Waiting for approval…"
 	default:
 		return ""
 	}

--- a/internal/tui/overlays/confirm.go
+++ b/internal/tui/overlays/confirm.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/tui/controller"
 )
 
@@ -184,14 +185,10 @@ func (o *Overlays) drawExtConfirm(ctx components.DrawContext, width, height int)
 		innerW = width
 	}
 
-	primary := th.Success
-	if st.danger {
-		primary = th.Destructive
-	} else if th.ToolName.Fg.Kind != 0 {
-		primary = th.ToolName
-	}
+	primary := chrome.DecisionPrimary(th)
 	warn := th.Warning
 	if st.danger {
+		primary = th.Destructive
 		warn = th.Destructive
 	}
 
@@ -212,27 +209,11 @@ func (o *Overlays) drawExtConfirm(ctx components.DrawContext, width, height int)
 	}
 	body = append(body, components.RichLine{})
 
-	labels := []string{st.yes, st.no}
-	for i, label := range labels {
-		sel := i == st.selected
-		arrow := " "
-		dot := "○"
-		labelSt := th.Foreground
-		dotSt := th.Muted
-		if sel {
-			arrow = "▸"
-			dot = "●"
-			labelSt = xui.Style{Bold: true, Fg: primary.Fg}
-			dotSt = primary
-		}
-		body = append(body, components.WrapSpans([]components.Span{
-			{Text: arrow, Style: primary},
-			{Text: dot, Style: dotSt},
-			{Text: " " + label, Style: labelSt},
-		}, innerW, ctx.Method)...)
+	for i, label := range []string{st.yes, st.no} {
+		body = append(body, chrome.OptionLine(th, primary, label, i == st.selected, innerW, ctx.Method)...)
 	}
 	body = append(body, components.WrapSpans([]components.Span{
-		{Text: "←→ select · Enter confirm · Esc/N cancel · Y yes", Style: th.Muted},
+		{Text: chrome.ConfirmHint(), Style: th.Muted},
 	}, innerW, ctx.Method)...)
 
 	return paintAskPanel(body, width, height, warn, ctx.Method)

--- a/internal/tui/overlays/overlays.go
+++ b/internal/tui/overlays/overlays.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
+	"github.com/pulseaiclub/phi/internal/components/chrome"
 	"github.com/pulseaiclub/phi/internal/components/layout"
 	"github.com/pulseaiclub/phi/internal/permission"
 	"github.com/pulseaiclub/phi/internal/tui/controller"
@@ -268,21 +269,12 @@ func (o *Overlays) handlePermissionKey(ctx *components.EventContext, e xui.KeyEv
 		return o.handlePermissionFeedbackKey(ctx, e)
 	}
 
-	if e.Mods.Has(xui.ModAlt) && e.Code == xui.KeyRune && e.Rune >= '1' && e.Rune <= '9' {
-		idx := int(e.Rune - '1')
-		if idx < len(askOptionLabels) {
-			o.acceptPermissionOption(askOption(idx))
-			ctx.ConsumeAndRedraw()
-			return true
-		}
-	}
-
 	switch e.Code {
 	case xui.KeyEscape:
 		o.resolvePermission(controller.AskReply{})
 		ctx.ConsumeAndRedraw()
 		return true
-	case xui.KeyUp:
+	case xui.KeyUp, xui.KeyLeft:
 		if st.selected > 0 {
 			st.selected--
 		} else {
@@ -290,7 +282,7 @@ func (o *Overlays) handlePermissionKey(ctx *components.EventContext, e xui.KeyEv
 		}
 		ctx.ConsumeAndRedraw()
 		return true
-	case xui.KeyDown, xui.KeyTab:
+	case xui.KeyDown, xui.KeyRight, xui.KeyTab:
 		st.selected = (st.selected + 1) % len(askOptionLabels)
 		ctx.ConsumeAndRedraw()
 		return true
@@ -304,13 +296,13 @@ func (o *Overlays) handlePermissionKey(ctx *components.EventContext, e xui.KeyEv
 			return true
 		}
 		switch e.Rune {
-		case 'k', 'K':
+		case 'k', 'K', 'h', 'H':
 			if st.selected > 0 {
 				st.selected--
 			}
 			ctx.ConsumeAndRedraw()
 			return true
-		case 'j', 'J':
+		case 'j', 'J', 'l', 'L':
 			st.selected = (st.selected + 1) % len(askOptionLabels)
 			ctx.ConsumeAndRedraw()
 			return true
@@ -398,19 +390,12 @@ func (o *Overlays) handleContinueKey(ctx *components.EventContext, e xui.KeyEven
 		return false
 	}
 
-	if e.Mods.Has(xui.ModAlt) && e.Code == xui.KeyRune && e.Rune >= '1' && e.Rune <= '2' {
-		idx := int(e.Rune - '1')
-		o.acceptContinueOption(idx)
-		ctx.ConsumeAndRedraw()
-		return true
-	}
-
 	switch e.Code {
 	case xui.KeyEscape:
 		o.resolveContinue(controller.ContinueReply{})
 		ctx.ConsumeAndRedraw()
 		return true
-	case xui.KeyUp:
+	case xui.KeyUp, xui.KeyLeft:
 		if st.selected > 0 {
 			st.selected--
 		} else {
@@ -418,7 +403,7 @@ func (o *Overlays) handleContinueKey(ctx *components.EventContext, e xui.KeyEven
 		}
 		ctx.ConsumeAndRedraw()
 		return true
-	case xui.KeyDown, xui.KeyTab:
+	case xui.KeyDown, xui.KeyRight, xui.KeyTab:
 		st.selected = (st.selected + 1) % len(continueOptionLabels)
 		ctx.ConsumeAndRedraw()
 		return true
@@ -432,13 +417,13 @@ func (o *Overlays) handleContinueKey(ctx *components.EventContext, e xui.KeyEven
 			return true
 		}
 		switch e.Rune {
-		case 'k', 'K':
+		case 'k', 'K', 'h', 'H':
 			if st.selected > 0 {
 				st.selected--
 			}
 			ctx.ConsumeAndRedraw()
 			return true
-		case 'j', 'J':
+		case 'j', 'J', 'l', 'L':
 			st.selected = (st.selected + 1) % len(continueOptionLabels)
 			ctx.ConsumeAndRedraw()
 			return true
@@ -474,10 +459,7 @@ func (o *Overlays) drawPermissionAsk(ctx components.DrawContext, width, height i
 		innerW = width
 	}
 
-	primary := th.Success
-	if th.ToolName.Fg.Kind != 0 {
-		primary = th.ToolName
-	}
+	primary := chrome.DecisionPrimary(th)
 
 	var body []components.RichLine
 	add := func(spans ...components.Span) {
@@ -517,11 +499,7 @@ func (o *Overlays) drawContinueAsk(ctx components.DrawContext, width, height int
 		innerW = width
 	}
 
-	warn := th.Warning
-	primary := th.Success
-	if th.ToolName.Fg.Kind != 0 {
-		primary = th.ToolName
-	}
+	primary := chrome.DecisionPrimary(th)
 
 	var body []components.RichLine
 	body = append(body, components.WrapSpans([]components.Span{
@@ -533,30 +511,13 @@ func (o *Overlays) drawContinueAsk(ctx components.DrawContext, width, height int
 	body = append(body, components.RichLine{})
 
 	for i, label := range continueOptionLabels {
-		sel := i == st.selected
-		arrow := " "
-		dot := "○"
-		labelSt := th.Foreground
-		dotSt := th.Muted
-		if sel {
-			arrow = "▸"
-			dot = "●"
-			labelSt = xui.Style{Bold: true, Fg: primary.Fg}
-			dotSt = primary
-		}
-		shortcut := fmt.Sprintf(" [Alt+%d]", i+1)
-		body = append(body, components.WrapSpans([]components.Span{
-			{Text: arrow, Style: primary},
-			{Text: dot, Style: dotSt},
-			{Text: " " + label, Style: labelSt},
-			{Text: shortcut, Style: th.Muted},
-		}, innerW, ctx.Method)...)
+		body = append(body, chrome.OptionLine(th, primary, label, i == st.selected, innerW, ctx.Method)...)
 	}
 	body = append(body, components.WrapSpans([]components.Span{
-		{Text: "↑↓ navigate • Enter select • Esc stop", Style: th.Muted},
+		{Text: chrome.AskHint("↑↓ move", "select", "stop"), Style: th.Muted},
 	}, innerW, ctx.Method)...)
 
-	return paintAskPanel(body, width, height, warn, ctx.Method)
+	return paintAskPanel(body, width, height, th.Warning, ctx.Method)
 }
 
 type askOption int
@@ -685,6 +646,7 @@ func (st *permAskState) detailLines(th components.Theme, innerW int, method xui.
 	if st.detail == "" {
 		return nil
 	}
+	id := th.IdentityOrSuccess()
 	lines := strings.Split(st.detail, "\n")
 	out := make([]components.RichLine, 0, len(lines))
 	for i, line := range lines {
@@ -692,7 +654,7 @@ func (st *permAskState) detailLines(th components.Theme, innerW int, method xui.
 		switch {
 		case st.req.Action == permission.ActionBash && i == 0:
 			spans = []components.Span{
-				{Text: "$ ", Style: xui.Style{Bold: true, Fg: th.Success.Fg}},
+				{Text: chrome.BashPrompt, Style: xui.Style{Bold: true, Fg: id.Fg}},
 				{Text: line, Style: th.Foreground},
 			}
 		case st.req.Action == permission.ActionBash:
@@ -713,23 +675,10 @@ func (st *permAskState) optionLines(
 ) []components.RichLine {
 	out := make([]components.RichLine, 0, len(askOptionLabels)+1)
 	for i, label := range askOptionLabels {
-		sel := i == st.selected
-		arrow, dot := " ", "○"
-		labelSt, dotSt := th.Foreground, th.Muted
-		if sel {
-			arrow, dot = "▸", "●"
-			labelSt = xui.Style{Bold: true, Fg: primary.Fg}
-			dotSt = primary
-		}
-		out = append(out, components.WrapSpans([]components.Span{
-			{Text: arrow, Style: primary},
-			{Text: dot, Style: dotSt},
-			{Text: " " + label, Style: labelSt},
-			{Text: fmt.Sprintf(" [Alt+%d]", i+1), Style: th.Muted},
-		}, innerW, method)...)
+		out = append(out, chrome.OptionLine(th, primary, label, i == st.selected, innerW, method)...)
 	}
 	out = append(out, components.WrapSpans([]components.Span{
-		{Text: "↑↓ navigate • Enter select • Esc cancel", Style: th.Muted},
+		{Text: chrome.AskHint("↑↓ move", "select", "cancel"), Style: th.Muted},
 	}, innerW, method)...)
 	return out
 }
@@ -747,16 +696,16 @@ func (st *permAskState) feedbackLines(
 	shown := string(runes[:st.feedbackCur]) + "▎" + string(runes[st.feedbackCur:])
 	var out []components.RichLine
 	out = append(out, components.WrapSpans([]components.Span{
-		{Text: "✗ ", Style: th.Destructive},
+		{Text: chrome.Err + " ", Style: th.Destructive},
 		{Text: "Denied", Style: xui.Style{Bold: true, Fg: th.Destructive.Fg}},
 		{Text: " — tell Phi what to do instead", Style: th.Muted},
 	}, innerW, method)...)
 	out = append(out, components.WrapSpans([]components.Span{
-		{Text: "› ", Style: xui.Style{Bold: true, Fg: primary.Fg}},
+		{Text: chrome.SoftPrompt, Style: xui.Style{Bold: true, Fg: primary.Fg}},
 		{Text: shown, Style: th.Foreground},
 	}, innerW, method)...)
 	out = append(out, components.WrapSpans([]components.Span{
-		{Text: "Enter send  •  Esc cancel", Style: th.Muted},
+		{Text: chrome.FeedbackHint(), Style: th.Muted},
 	}, innerW, method)...)
 	return out
 }


### PR DESCRIPTION
Centralize the TUI visual grammar in internal/components/chrome: status/expand glyphs, prompt chars, list/ask/confirm/feedback hints, decision-row option rendering, and ToolIcon/ChildIcon/StatusSuffix. Migrate agent/tool/thinking/bash/toast/palette/listpicker/overlay call sites off their inline copies.

- add Theme.Identity (speaker/model/bash-prompt chrome) distinct from Success status, with IdentityOrSuccess() fallback for legacy themes
- permission/continue/confirm rows share chrome.OptionLine; drop Alt+N accelerators, add <- ->/h/l nav alongside up down/j/k
- align assistant "(cancelled)" suffix, thinking-body 2-col indent, session picker wider panel (~90% / 112 cols), "..." -> "…" ellipsis