### PR TITLE
feat(extension): allow tools to set a per-tool RPC timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Extension tools can set `TimeoutSec` (Go SDK) / `timeout_sec` (Rust SDK) so the host waits longer than the default 30s RPC budget for slow tools (e.g. HTTP fetch). Clamped to 1–3600s.
 - Rust SDK: typed `phi::Schema` builder for tool parameters (replaces raw `Vec<u8>`), staying zero-dep instead of Codex-style `schemars`.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 A minimal terminal coding agent harness in Go — a sibling to Pi.
 
+**Docs:** [pulseaiclub.github.io](https://pulseaiclub.github.io/)
+
 - **Sub-agents** — spawn isolated jobs and watch the full run unfold in the TUI / job logs, without stuffing every turn into the parent context
 - **Hashline edits** — edit by whole-file `@file path#TAG` plus line `LINE#HASH` anchors (same idea as [oh-my-pi](https://github.com/can1357/oh-my-pi)): the model points at anchors instead of rewriting whole files; stale tags/hashes are rejected so over-edits and silent corruption stop here
 - **Permission gate** — Gate / Ask before destructive tools fire; safety is not optional when an agent can touch your tree
@@ -25,6 +27,7 @@ A minimal terminal coding agent harness in Go — a sibling to Pi.
 
 ![phi TUI](assets/image.png)
 
+- [Docs](https://pulseaiclub.github.io/docs/getting-started/)
 - [Quick start](#quick-start)
 - [Footprint](#footprint)
 - [Configuration](#configuration)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,8 @@
 
 一个用 Go 编写的最小化终端编码代理框架（harness）——Pi 的姊妹项目。
 
+**文档：** [pulseaiclub.github.io](https://pulseaiclub.github.io/)
+
 - **子代理（Sub-agents）** — 拉起隔离任务，在 TUI / job 日志里完整看到执行过程，而不是把每一步都塞进父会话上下文
 - **Hashline 编辑** — 用整文件 `@file path#TAG` 加上行级 `LINE#HASH` 锚点改文件（思路对齐 [oh-my-pi](https://github.com/can1357/oh-my-pi)）：模型瞄锚点改，而不是整文件重写；TAG/哈希对不上就拒绝，避免过度编辑和静默写坏
 - **权限门控** — 危险工具先过 Gate / Ask；代理能碰你的代码树时，安全不是可选项
@@ -27,6 +29,7 @@
 你可以通过 [Skills（技能）](#skills技能)、[Hooks（钩子）](#hooks钩子)
 和 [MCP](#mcp) 扩展它——不必做成插件框架。
 
+- [文档](https://pulseaiclub.github.io/docs/getting-started/)
 - [快速开始](#快速开始)
 - [资源占用](#资源占用)
 - [配置](#配置)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes land on the latest release of [phi](https://github.com/pulseaiclub/phi).
+Please upgrade before reporting issues that are already fixed on `main`.
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue with exploit detail.
+
+Prefer one of:
+
+1. [GitHub private security advisories](https://github.com/pulseaiclub/phi/security/advisories/new)
+2. A minimal private report to the PulseAI Club maintainers via GitHub
+
+Include: phi version / commit, OS, steps to reproduce, and impact.
+
+We aim to acknowledge reports quickly and coordinate disclosure after a fix
+is available.
+
+## Scope
+
+In scope examples:
+
+- Permission gate bypasses that allow unexpected destructive tool use
+- Path traversal or workspace escape around `workspace_only_writes`
+- Supply-chain issues in release artifacts or install scripts
+
+Out of scope examples:
+
+- Issues that require a malicious model provider already trusted by the user
+- Vulnerabilities only present in third-party MCP servers or extensions you installed
+- Social engineering of API keys stored in the user’s own config
+
+Product overview of local-first design: https://pulseaiclub.github.io/security/

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -73,6 +73,22 @@ go get github.com/pulseaiclub/phi/ext@v0.19.0
 
 (`scripts/bump.sh` tags both `vX.Y.Z` and `ext/vX.Y.Z`.)
 
+Slow tools (HTTP fetch, long builds, …) should set `TimeoutSec` — the host’s
+default RPC wait is **30s**. Values are clamped to 1–3600.
+
+```go
+m.RegisterTool(ext.Tool{
+	Name:        "fetch",
+	Description: "HTTP GET",
+	TimeoutSec:  120, // host waits up to 2m for this tool
+	Parameters:  map[string]any{"type": "object", /* … */},
+	Execute: func(ctx context.Context, args json.RawMessage) (ext.ToolResult, error) {
+		// …
+		return ext.ToolResult{}, nil
+	},
+})
+```
+
 ```go
 package main
 
@@ -183,6 +199,17 @@ fn main() -> Result<(), phi::Error> {
     m.subscribe(pxb::Event::SessionStart, |_ev| {});
     m.run()
 }
+```
+
+Slow tools should chain `.timeout_sec(n)` (host default RPC wait is 30s; clamped to 1–3600):
+
+```rust,no_run
+m.register_tool(
+    phi::Tool::new("fetch", "HTTP GET", phi::Schema::object(), |_args| {
+        Ok(phi::ToolResult { content: "…".into(), ..Default::default() })
+    })
+    .timeout_sec(120),
+);
 ```
 
 UI surface today: **toast** (`ctx.notify`), **footer status** (`ctx.set_status`),

--- a/ext/go/phi/sdk.go
+++ b/ext/go/phi/sdk.go
@@ -317,9 +317,13 @@ func (extension *ExtensionAPI) Run() error {
 
 	for _, t := range tools {
 		schema, _ := json.Marshal(t.def.Parameters)
-		body := pxb.EncodeRegisterTool(pxb.RegisterTool{
+		reg := pxb.RegisterTool{
 			Name: t.def.Name, Description: t.def.Description, SchemaJSON: schema,
-		})
+		}
+		if t.def.TimeoutSec > 0 {
+			reg.TimeoutSec = uint32(t.def.TimeoutSec) //nolint:gosec // G115: author-supplied seconds; host clamps
+		}
+		body := pxb.EncodeRegisterTool(reg)
 		if err := extension.wr.Write(pxb.TypeRegisterTool, 0, 0, body); err != nil {
 			return err
 		}

--- a/ext/go/pxb/compat_test.go
+++ b/ext/go/pxb/compat_test.go
@@ -85,6 +85,28 @@ func TestSubscribeRoundTrip(t *testing.T) {
 	assert.Equal(t, in.Intercept, out.Intercept)
 }
 
+func TestRegisterToolTimeoutSecRoundTrip(t *testing.T) {
+	in := pxb.RegisterTool{
+		Name: "fetch", Description: "HTTP GET", SchemaJSON: []byte(`{"type":"object"}`), TimeoutSec: 120,
+	}
+	out, err := pxb.DecodeRegisterTool(pxb.EncodeRegisterTool(in))
+	require.NoError(t, err)
+	assert.Equal(t, in.Name, out.Name)
+	assert.Equal(t, in.TimeoutSec, out.TimeoutSec)
+	assert.JSONEq(t, string(in.SchemaJSON), string(out.SchemaJSON))
+
+	// Zero timeout omits the wire field (backward compatible with old hosts).
+	raw := pxb.EncodeRegisterTool(pxb.RegisterTool{Name: "x", Description: "d"})
+	var fw pxb.FieldWriter
+	fw.PutString(1, "x")
+	fw.PutString(2, "d")
+	assert.Equal(t, fw.Bytes(), raw)
+
+	old, err := pxb.DecodeRegisterTool(fw.Bytes())
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), old.TimeoutSec)
+}
+
 func TestUnknownEventCodeMapsEmpty(t *testing.T) {
 	assert.Empty(t, pxb.EventName(999))
 	assert.Equal(t, uint16(0), pxb.EventCode("nope"))

--- a/ext/go/pxb/msg.go
+++ b/ext/go/pxb/msg.go
@@ -29,9 +29,10 @@ const (
 	fRegCmdName uint16 = 1
 	fRegCmdDesc uint16 = 2
 
-	fRegToolName   uint16 = 1
-	fRegToolDesc   uint16 = 2
-	fRegToolSchema uint16 = 3
+	fRegToolName       uint16 = 1
+	fRegToolDesc       uint16 = 2
+	fRegToolSchema     uint16 = 3
+	fRegToolTimeoutSec uint16 = 4 // host RPC wait for ToolInvoke; 0 = host default
 
 	fSubEvents    uint16 = 1
 	fSubIntercept uint16 = 2
@@ -237,6 +238,9 @@ type RegisterTool struct {
 	Name        string
 	Description string
 	SchemaJSON  []byte
+	// TimeoutSec is how long the host waits for this tool's ToolResult.
+	// 0 omits the field (host default, currently 30s). Host clamps to a max.
+	TimeoutSec uint32
 }
 
 func EncodeRegisterTool(r RegisterTool) []byte {
@@ -244,6 +248,9 @@ func EncodeRegisterTool(r RegisterTool) []byte {
 	fw.PutString(fRegToolName, r.Name)
 	fw.PutString(fRegToolDesc, r.Description)
 	fw.PutBytes(fRegToolSchema, r.SchemaJSON)
+	if r.TimeoutSec > 0 {
+		fw.PutU32(fRegToolTimeoutSec, r.TimeoutSec)
+	}
 	return fw.Bytes()
 }
 
@@ -262,6 +269,10 @@ func DecodeRegisterTool(b []byte) (RegisterTool, error) {
 		case fRegToolSchema:
 			p, err := takeBytes(kind, fr)
 			r.SchemaJSON = append([]byte(nil), p...)
+			return err
+		case fRegToolTimeoutSec:
+			v, err := takeU64(kind, fr)
+			r.TimeoutSec = uint32(v) //nolint:gosec // G115: timeout seconds are u32 by protocol
 			return err
 		default:
 			return fr.Skip(kind)

--- a/ext/go/types.go
+++ b/ext/go/types.go
@@ -146,6 +146,9 @@ type Tool struct {
 	Description string
 	// Parameters is a JSON Schema object (type/object/properties/required).
 	Parameters map[string]any
+	// TimeoutSec is how long the host waits for Execute to finish (RPC).
+	// 0 uses the host default (30s). Values are clamped to 1–3600 by the host.
+	TimeoutSec int
 	Execute    func(ctx context.Context, args json.RawMessage) (ToolResult, error)
 }
 

--- a/ext/rust/src/phi/mod.rs
+++ b/ext/rust/src/phi/mod.rs
@@ -54,6 +54,8 @@ pub struct Tool {
     pub name: String,
     pub description: String,
     pub schema: Schema,
+    /// Host RPC wait for `execute`, in seconds. `0` = host default (30s).
+    pub timeout_sec: u32,
     pub execute: Box<dyn FnMut(&[u8]) -> Result<ToolResult, String>>,
 }
 
@@ -68,8 +70,15 @@ impl Tool {
             name: name.into(),
             description: description.into(),
             schema: schema.into(),
+            timeout_sec: 0,
             execute: Box::new(execute),
         }
+    }
+
+    /// Sets how long the host waits for this tool's result (1–3600; host clamps).
+    pub fn timeout_sec(mut self, secs: u32) -> Self {
+        self.timeout_sec = secs;
+        self
     }
 }
 
@@ -403,6 +412,7 @@ fn register(wr: &mut Wr, ext: &Extension) -> Result<(), Error> {
             name: tool.name.clone(),
             description: tool.description.clone(),
             schema_json: tool.schema.to_json_bytes(),
+            timeout_sec: tool.timeout_sec,
         });
         pxb::write_frame(wr, pxb::TYPE_REGISTER_TOOL, 0, 0, &body)?;
     }

--- a/ext/rust/src/pxb/msg.rs
+++ b/ext/rust/src/pxb/msg.rs
@@ -26,6 +26,7 @@ const F_REG_CMD_DESC: u16 = 2;
 const F_REG_TOOL_NAME: u16 = 1;
 const F_REG_TOOL_DESC: u16 = 2;
 const F_REG_TOOL_SCHEMA: u16 = 3;
+const F_REG_TOOL_TIMEOUT_SEC: u16 = 4;
 
 const F_SUB_EVENTS: u16 = 1;
 const F_SUB_INTERCEPT: u16 = 2;
@@ -223,6 +224,9 @@ pub struct RegisterTool {
     pub name: String,
     pub description: String,
     pub schema_json: Vec<u8>,
+    /// Host RPC wait for this tool's result, in seconds. `0` omits the field
+    /// (host default). Host clamps to a maximum.
+    pub timeout_sec: u32,
 }
 
 pub fn encode_register_tool(r: &RegisterTool) -> Vec<u8> {
@@ -230,6 +234,9 @@ pub fn encode_register_tool(r: &RegisterTool) -> Vec<u8> {
     fw.put_string(F_REG_TOOL_NAME, &r.name);
     fw.put_string(F_REG_TOOL_DESC, &r.description);
     fw.put_bytes(F_REG_TOOL_SCHEMA, &r.schema_json);
+    if r.timeout_sec > 0 {
+        fw.put_u32(F_REG_TOOL_TIMEOUT_SEC, r.timeout_sec);
+    }
     fw.into_vec()
 }
 
@@ -240,6 +247,7 @@ pub fn decode_register_tool(b: &[u8]) -> Result<RegisterTool, Error> {
             F_REG_TOOL_NAME => r.name = take_string(kind, fr)?,
             F_REG_TOOL_DESC => r.description = take_string(kind, fr)?,
             F_REG_TOOL_SCHEMA => r.schema_json = take_bytes(kind, fr)?.to_vec(),
+            F_REG_TOOL_TIMEOUT_SEC => r.timeout_sec = take_u64(kind, fr)? as u32,
             _ => fr.skip(kind)?,
         }
         Ok(())
@@ -739,6 +747,7 @@ mod tests {
                     name: "t".into(),
                     description: "d".into(),
                     schema_json: br#"{"type":"object"}"#.to_vec(),
+                    timeout_sec: 120,
                 }),
                 |b| Ok(encode_register_tool(&decode_register_tool(b)?)),
             ),

--- a/internal/extension/loader_test.go
+++ b/internal/extension/loader_test.go
@@ -121,6 +121,7 @@ func main() {
 	m.RegisterTool(ext.Tool{
 		Name:        "greet",
 		Description: "Greet someone",
+		TimeoutSec:  120,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -151,4 +152,41 @@ func main() {
 	res, err := tools[0].Run(t.Context(), json.RawMessage(`{"name":"phi"}`))
 	require.NoError(t, err)
 	assert.Equal(t, "Hello, phi!", res.Content)
+}
+
+func TestRegisterToolTimeoutSecPropagates(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "slow")
+	src := `package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pulseaiclub/phi/ext"
+	"github.com/pulseaiclub/phi/ext/phi"
+)
+
+func main() {
+	m := phi.New("slow", "0.0.1")
+	m.RegisterTool(ext.Tool{
+		Name:        "slow",
+		Description: "Takes a while",
+		TimeoutSec:  180,
+		Parameters:  map[string]any{"type": "object"},
+		Execute: func(ctx context.Context, args json.RawMessage) (ext.ToolResult, error) {
+			return ext.ToolResult{Content: "ok"}, nil
+		},
+	})
+	_ = m.Run()
+}
+`
+	require.NoError(t, extension.Materialize(t.Context(), extDir, "slow", "0.0.1", src))
+	m, err := extension.ReadManifest(extDir)
+	require.NoError(t, err)
+	proc, err := extension.StartProc(t.Context(), m, extDir, t.TempDir(), root, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = proc.Close() })
+	require.Len(t, proc.Tools(), 1)
+	assert.Equal(t, uint32(180), proc.Tools()[0].TimeoutSec)
 }

--- a/internal/extension/proc.go
+++ b/internal/extension/proc.go
@@ -22,6 +22,7 @@ import (
 const (
 	handshakeTimeout = 5 * time.Second
 	rpcTimeout       = 30 * time.Second
+	rpcTimeoutMax    = 3600 * time.Second // matches bash tool upper bound
 	shutdownWait     = 2 * time.Second
 )
 
@@ -286,6 +287,19 @@ func (p *Proc) failPending(err error) {
 }
 
 func (p *Proc) rpc(ctx context.Context, typ uint16, body []byte, want uint16) (pxb.Frame, error) {
+	return p.rpcWait(ctx, typ, body, want, 0)
+}
+
+// rpcWait is rpc with an optional per-call wait override (0 = host default).
+// When override > 0, the wait is clamp(override) capped by any ctx deadline.
+// When override == 0, legacy behavior: ctx deadline replaces the default if set.
+func (p *Proc) rpcWait(
+	ctx context.Context,
+	typ uint16,
+	body []byte,
+	want uint16,
+	override time.Duration,
+) (pxb.Frame, error) {
 	if p == nil || p.closed.Load() {
 		return pxb.Frame{}, errors.New("extension: process closed")
 	}
@@ -302,13 +316,7 @@ func (p *Proc) rpc(ctx context.Context, typ uint16, body []byte, want uint16) (p
 		return pxb.Frame{}, err
 	}
 
-	deadline := rpcTimeout
-	if d, ok := ctx.Deadline(); ok {
-		deadline = time.Until(d)
-		if deadline <= 0 {
-			deadline = time.Millisecond
-		}
-	}
+	deadline := rpcWaitDuration(ctx, override)
 	timer := time.NewTimer(deadline)
 	defer timer.Stop()
 	select {
@@ -338,10 +346,38 @@ func (p *Proc) rpc(ctx context.Context, typ uint16, body []byte, want uint16) (p
 	}
 }
 
+func rpcWaitDuration(ctx context.Context, override time.Duration) time.Duration {
+	wait := rpcTimeout
+	if override > 0 {
+		wait = min(override, rpcTimeoutMax)
+	}
+	if d, ok := ctx.Deadline(); ok {
+		rem := time.Until(d)
+		if override > 0 {
+			wait = min(wait, rem)
+		} else {
+			wait = rem
+		}
+	}
+	if wait <= 0 {
+		return time.Millisecond
+	}
+	return wait
+}
+
+func (p *Proc) toolRPCTimeout(name string) time.Duration {
+	for _, t := range p.tools {
+		if t.Name == name && t.TimeoutSec > 0 {
+			return time.Duration(t.TimeoutSec) * time.Second
+		}
+	}
+	return 0
+}
+
 // CallTool invokes a registered tool.
 func (p *Proc) CallTool(ctx context.Context, name string, args json.RawMessage) (ext.ToolResult, error) {
 	body := pxb.EncodeToolInvoke(pxb.ToolInvoke{Name: name, Args: args})
-	f, err := p.rpc(ctx, pxb.TypeToolInvoke, body, pxb.TypeToolResult)
+	f, err := p.rpcWait(ctx, pxb.TypeToolInvoke, body, pxb.TypeToolResult, p.toolRPCTimeout(name))
 	if err != nil {
 		return ext.ToolResult{}, err
 	}
@@ -464,6 +500,16 @@ func (p *Proc) Close() error {
 	}
 	p.failPending(errors.New("extension: closed"))
 	return nil
+}
+
+// Tools returns tools registered during handshake (copy).
+func (p *Proc) Tools() []pxb.RegisterTool {
+	if p == nil {
+		return nil
+	}
+	out := make([]pxb.RegisterTool, len(p.tools))
+	copy(out, p.tools)
+	return out
 }
 
 // BuildAPI installs shim handlers onto api from this process's registrations.

--- a/internal/extension/rpc_timeout_test.go
+++ b/internal/extension/rpc_timeout_test.go
@@ -1,0 +1,52 @@
+package extension
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulseaiclub/phi/ext/pxb"
+)
+
+func TestRPCWaitDurationDefault(t *testing.T) {
+	d := rpcWaitDuration(t.Context(), 0)
+	assert.Equal(t, rpcTimeout, d)
+}
+
+func TestRPCWaitDurationOverride(t *testing.T) {
+	d := rpcWaitDuration(t.Context(), 120*time.Second)
+	assert.Equal(t, 120*time.Second, d)
+}
+
+func TestRPCWaitDurationClampsMax(t *testing.T) {
+	d := rpcWaitDuration(t.Context(), 10_000*time.Second)
+	assert.Equal(t, rpcTimeoutMax, d)
+}
+
+func TestRPCWaitDurationOverrideCappedByCtx(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 40*time.Second)
+	defer cancel()
+	d := rpcWaitDuration(ctx, 120*time.Second)
+	assert.Less(t, d, 45*time.Second)
+	assert.Greater(t, d, 30*time.Second)
+}
+
+func TestRPCWaitDurationLegacyCtxReplacesDefault(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+	d := rpcWaitDuration(ctx, 0)
+	assert.Greater(t, d, 80*time.Second)
+	assert.LessOrEqual(t, d, 90*time.Second)
+}
+
+func TestToolRPCTimeoutLookup(t *testing.T) {
+	p := &Proc{tools: []pxb.RegisterTool{
+		{Name: "fetch", TimeoutSec: 180},
+		{Name: "ping"},
+	}}
+	assert.Equal(t, 180*time.Second, p.toolRPCTimeout("fetch"))
+	assert.Equal(t, time.Duration(0), p.toolRPCTimeout("ping"))
+	assert.Equal(t, time.Duration(0), p.toolRPCTimeout("missing"))
+}


### PR DESCRIPTION
Slow extension tools (HTTP fetch, long builds) previously hit the host's fixed 30s RPC budget. Add an optional timeout to tool registration:

- pxb: new RegisterTool wire field `timeout_sec` (field 4); 0 omits it, so old hosts/extensions stay compatible
- Go SDK: `ext.Tool.TimeoutSec`; Rust SDK: `Tool::timeout_sec(n)`
- host: Proc.CallTool waits up to the tool's override, clamped to 1-3600s and capped by any ctx deadline; default stays 30s