### PR TITLE
feat: keep composer open for slash commands that need args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Slash commands can declare `NeedsArgs` (Go) / `needs_args` (Rust). Picker accept or bare submit of `/name` leaves `/name ` in the composer so the user can type arguments instead of auto-running and toasting usage. Built-in `/resume` uses this.
+
 ### Changed
 
 - Go author SDK nested module now publishes under `github.com/pulseaiclub/phi/ext/go` (imports `…/ext/go/phi`, `…/ext/go/pxb`; tags `ext/go/vX.Y.Z`), matching its repo location `ext/go/` so proxies can resolve it.

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -119,6 +119,15 @@ func main() {
 			return nil
 		},
 	})
+	// NeedsArgs: picker accept / bare "/plan" leaves "/plan " in the composer.
+	m.RegisterCommand("plan", ext.Command{
+		Description: "Enter/exit plan mode — /plan on|off|status",
+		NeedsArgs:   true,
+		Handler: func(args string, ctx *ext.Context) error {
+			_ = args
+			return nil
+		},
+	})
 	m.OnUserInput(func(ev ext.UserInputEvent) *ext.UserInputResult {
 		// return &ext.UserInputResult{Handled: true} to swallow
 		// return &ext.UserInputResult{Text: "rewritten"} to transform
@@ -190,6 +199,15 @@ fn main() -> Result<(), phi::Error> {
             // ctx.send_user_message("…"); // enqueue a turn anytime
             Ok(())
         }),
+    );
+    // needs_args: picker accept / bare "/plan" leaves "/plan " in the composer.
+    m.register_command(
+        "plan",
+        phi::Command::new("Enter/exit plan mode — /plan on|off|status", |args, _ctx| {
+            let _ = args;
+            Ok(())
+        })
+        .needs_args(),
     );
     m.on_user_input(|_ev| {
         // Some(phi::UserInputResult { handled: true, ..Default::default() }) swallows

--- a/ext/go/api.go
+++ b/ext/go/api.go
@@ -114,7 +114,7 @@ func (a *API) CommandEntries() []CommandEntry {
 	cmds := a.Commands()
 	out := make([]CommandEntry, 0, len(cmds))
 	for name, c := range cmds {
-		out = append(out, CommandEntry{Name: name, Description: c.Description})
+		out = append(out, CommandEntry{Name: name, Description: c.Description, NeedsArgs: c.NeedsArgs})
 	}
 	return out
 }

--- a/ext/go/phi/sdk.go
+++ b/ext/go/phi/sdk.go
@@ -331,7 +331,7 @@ func (extension *ExtensionAPI) Run() error {
 	}
 	for _, c := range cmds {
 		body := pxb.EncodeRegisterCommand(pxb.RegisterCommand{
-			Name: c.name, Description: c.def.Description,
+			Name: c.name, Description: c.def.Description, NeedsArgs: c.def.NeedsArgs,
 		})
 		if err := extension.wr.Write(pxb.TypeRegisterCommand, 0, 0, body); err != nil {
 			return err

--- a/ext/go/pxb/compat_test.go
+++ b/ext/go/pxb/compat_test.go
@@ -85,6 +85,26 @@ func TestSubscribeRoundTrip(t *testing.T) {
 	assert.Equal(t, in.Intercept, out.Intercept)
 }
 
+func TestRegisterCommandNeedsArgsRoundTrip(t *testing.T) {
+	in := pxb.RegisterCommand{Name: "plan", Description: "toggle plan", NeedsArgs: true}
+	out, err := pxb.DecodeRegisterCommand(pxb.EncodeRegisterCommand(in))
+	require.NoError(t, err)
+	assert.Equal(t, in.Name, out.Name)
+	assert.Equal(t, in.Description, out.Description)
+	assert.True(t, out.NeedsArgs)
+
+	// false omits the wire field (backward compatible with old hosts).
+	raw := pxb.EncodeRegisterCommand(pxb.RegisterCommand{Name: "x", Description: "d"})
+	var fw pxb.FieldWriter
+	fw.PutString(1, "x")
+	fw.PutString(2, "d")
+	assert.Equal(t, fw.Bytes(), raw)
+
+	old, err := pxb.DecodeRegisterCommand(fw.Bytes())
+	require.NoError(t, err)
+	assert.False(t, old.NeedsArgs)
+}
+
 func TestRegisterToolTimeoutSecRoundTrip(t *testing.T) {
 	in := pxb.RegisterTool{
 		Name: "fetch", Description: "HTTP GET", SchemaJSON: []byte(`{"type":"object"}`), TimeoutSec: 120,

--- a/ext/go/pxb/msg.go
+++ b/ext/go/pxb/msg.go
@@ -26,8 +26,9 @@ const (
 	fAckSessionID  uint16 = 4
 	fAckExtDir     uint16 = 5
 
-	fRegCmdName uint16 = 1
-	fRegCmdDesc uint16 = 2
+	fRegCmdName      uint16 = 1
+	fRegCmdDesc      uint16 = 2
+	fRegCmdNeedsArgs uint16 = 3 // slash picker fills composer instead of auto-submit
 
 	fRegToolName       uint16 = 1
 	fRegToolDesc       uint16 = 2
@@ -208,12 +209,19 @@ func DecodeHelloAck(b []byte) (HelloAck, error) {
 type RegisterCommand struct {
 	Name        string
 	Description string
+	// NeedsArgs means the host should leave "/name " in the composer when
+	// the user accepts the slash picker or submits the bare command, so they
+	// can type arguments. false omits the wire field (backward compatible).
+	NeedsArgs bool
 }
 
 func EncodeRegisterCommand(r RegisterCommand) []byte {
 	var fw FieldWriter
 	fw.PutString(fRegCmdName, r.Name)
 	fw.PutString(fRegCmdDesc, r.Description)
+	if r.NeedsArgs {
+		fw.PutBool(fRegCmdNeedsArgs, true)
+	}
 	return fw.Bytes()
 }
 
@@ -228,6 +236,10 @@ func DecodeRegisterCommand(b []byte) (RegisterCommand, error) {
 		case fRegCmdDesc:
 			s, err := takeString(kind, fr)
 			r.Description = s
+			return err
+		case fRegCmdNeedsArgs:
+			v, err := takeU64(kind, fr)
+			r.NeedsArgs = v != 0
 			return err
 		default:
 			return fr.Skip(kind)

--- a/ext/go/types.go
+++ b/ext/go/types.go
@@ -165,13 +165,17 @@ type ToolInfo struct {
 // Command registers a slash command.
 type Command struct {
 	Description string
-	Handler     func(args string, ctx *Context) error
+	// NeedsArgs leaves "/name " in the composer on picker accept / bare submit
+	// so the user can type arguments instead of running with an empty arg string.
+	NeedsArgs bool
+	Handler   func(args string, ctx *Context) error
 }
 
 // CommandEntry is a registered slash command name.
 type CommandEntry struct {
 	Name        string
 	Description string
+	NeedsArgs   bool
 }
 
 // ExecResult is returned from API.Exec.

--- a/ext/rust/README.md
+++ b/ext/rust/README.md
@@ -44,6 +44,11 @@ fn main() -> Result<(), phi::Error> {
         // ctx.send_user_message("…");   // enqueue a turn anytime
         Ok(())
     }));
+    // .needs_args() → picker/bare "/plan" fills "/plan " for the user to finish
+    m.register_command(
+        "plan",
+        phi::Command::new("plan mode — /plan on|off|status", |_args, _ctx| Ok(())).needs_args(),
+    );
     m.on_user_input(|_ev| None);   // return Some(UserInputResult { handled: true, .. }) to swallow
     m.on_tool_call(|_ev| None);    // return Some(ToolCallResult { block: true, reason: "…", .. }) to deny
     m.on_tool_result(|_ev| None);  // return Some(ToolResultResult { stop: true, .. }) to end the loop

--- a/ext/rust/src/phi/mod.rs
+++ b/ext/rust/src/phi/mod.rs
@@ -104,6 +104,8 @@ pub struct ToolResult {
 #[allow(clippy::type_complexity)] // handler signature mirrors the Go SDK contract
 pub struct Command {
     pub description: String,
+    /// Leave `/name ` in the composer on picker accept / bare submit.
+    pub needs_args: bool,
     pub handler: Box<dyn FnMut(&str, &mut Context<'_>) -> Result<(), String>>,
 }
 
@@ -114,8 +116,16 @@ impl Command {
     ) -> Self {
         Self {
             description: description.into(),
+            needs_args: false,
             handler: Box::new(handler),
         }
+    }
+
+    /// Mark this command as requiring arguments so the host fills the
+    /// composer instead of auto-submitting an empty invocation.
+    pub fn needs_args(mut self) -> Self {
+        self.needs_args = true;
+        self
     }
 }
 
@@ -430,6 +440,7 @@ fn register(wr: &mut Wr, ext: &Extension) -> Result<(), Error> {
         let body = pxb::encode_register_command(&pxb::RegisterCommand {
             name: name.clone(),
             description: cmd.description.clone(),
+            needs_args: cmd.needs_args,
         });
         pxb::write_frame(wr, pxb::TYPE_REGISTER_COMMAND, 0, 0, &body)?;
     }

--- a/ext/rust/src/pxb/msg.rs
+++ b/ext/rust/src/pxb/msg.rs
@@ -22,6 +22,7 @@ const F_ACK_EXT_DIR: u16 = 5;
 
 const F_REG_CMD_NAME: u16 = 1;
 const F_REG_CMD_DESC: u16 = 2;
+const F_REG_CMD_NEEDS_ARGS: u16 = 3;
 
 const F_REG_TOOL_NAME: u16 = 1;
 const F_REG_TOOL_DESC: u16 = 2;
@@ -199,12 +200,18 @@ pub fn decode_hello_ack(b: &[u8]) -> Result<HelloAck, Error> {
 pub struct RegisterCommand {
     pub name: String,
     pub description: String,
+    /// Host leaves `/name ` in the composer on picker accept / bare submit.
+    /// `false` omits the wire field (backward compatible).
+    pub needs_args: bool,
 }
 
 pub fn encode_register_command(r: &RegisterCommand) -> Vec<u8> {
     let mut fw = FieldWriter::new();
     fw.put_string(F_REG_CMD_NAME, &r.name);
     fw.put_string(F_REG_CMD_DESC, &r.description);
+    if r.needs_args {
+        fw.put_bool(F_REG_CMD_NEEDS_ARGS, true);
+    }
     fw.into_vec()
 }
 
@@ -214,6 +221,7 @@ pub fn decode_register_command(b: &[u8]) -> Result<RegisterCommand, Error> {
         match tag {
             F_REG_CMD_NAME => r.name = take_string(kind, fr)?,
             F_REG_CMD_DESC => r.description = take_string(kind, fr)?,
+            F_REG_CMD_NEEDS_ARGS => r.needs_args = take_u64(kind, fr)? != 0,
             _ => fr.skip(kind)?,
         }
         Ok(())
@@ -773,6 +781,7 @@ mod tests {
                 encode_register_command(&RegisterCommand {
                     name: "hi".into(),
                     description: "Say hi".into(),
+                    needs_args: true,
                 }),
                 |b| Ok(encode_register_command(&decode_register_command(b)?)),
             ),

--- a/internal/extension/loader_test.go
+++ b/internal/extension/loader_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ext "github.com/pulseaiclub/phi/ext/go"
+	"github.com/pulseaiclub/phi/ext/go/pxb"
 	"github.com/pulseaiclub/phi/internal/extension"
 )
 
@@ -242,4 +244,58 @@ func main() {
 	detail, err := proc.CallToolDetail(t.Context(), "ping", json.RawMessage(`{}`))
 	require.NoError(t, err)
 	assert.Equal(t, "ping-detail", detail)
+}
+
+func TestRegisterCommandNeedsArgsPropagates(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "plan")
+	src := `package main
+
+import (
+	"github.com/pulseaiclub/phi/ext/go"
+	"github.com/pulseaiclub/phi/ext/go/phi"
+)
+
+func main() {
+	m := phi.New("plan", "0.0.1")
+	m.RegisterCommand("plan", ext.Command{
+		Description: "Enter/exit plan mode — /plan on|off|status",
+		NeedsArgs:   true,
+		Handler: func(args string, ctx *ext.Context) error {
+			return nil
+		},
+	})
+	m.RegisterCommand("hello", ext.Command{
+		Description: "Say hi",
+		Handler: func(args string, ctx *ext.Context) error {
+			return nil
+		},
+	})
+	_ = m.Run()
+}
+`
+	require.NoError(t, extension.Materialize(t.Context(), extDir, "plan", "0.0.1", src))
+	m, err := extension.ReadManifest(extDir)
+	require.NoError(t, err)
+	proc, err := extension.StartProc(t.Context(), m, extDir, t.TempDir(), root, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = proc.Close() })
+	cmds := proc.Commands()
+	require.Len(t, cmds, 2)
+	byName := map[string]pxb.RegisterCommand{}
+	for _, c := range cmds {
+		byName[c.Name] = c
+	}
+	assert.True(t, byName["plan"].NeedsArgs)
+	assert.False(t, byName["hello"].NeedsArgs)
+
+	api := ext.NewAPI()
+	proc.BuildAPI(api)
+	entries := api.CommandEntries()
+	entryBy := map[string]ext.CommandEntry{}
+	for _, e := range entries {
+		entryBy[e.Name] = e
+	}
+	assert.True(t, entryBy["plan"].NeedsArgs)
+	assert.False(t, entryBy["hello"].NeedsArgs)
 }

--- a/internal/extension/proc.go
+++ b/internal/extension/proc.go
@@ -527,6 +527,16 @@ func (p *Proc) Tools() []pxb.RegisterTool {
 	return out
 }
 
+// Commands returns slash commands registered during handshake (copy).
+func (p *Proc) Commands() []pxb.RegisterCommand {
+	if p == nil {
+		return nil
+	}
+	out := make([]pxb.RegisterCommand, len(p.cmds))
+	copy(out, p.cmds)
+	return out
+}
+
 // BuildAPI installs shim handlers onto api from this process's registrations.
 func (p *Proc) BuildAPI(api *ext.API) {
 	if p == nil || api == nil {
@@ -561,8 +571,10 @@ func (p *Proc) BuildAPI(api *ext.API) {
 	for _, c := range p.cmds {
 		name := c.Name
 		desc := c.Description
+		needsArgs := c.NeedsArgs
 		api.RegisterCommand(name, ext.Command{
 			Description: desc,
+			NeedsArgs:   needsArgs,
 			Handler: func(args string, _ *ext.Context) error {
 				resp, err := p.CallCommand(context.Background(), name, args)
 				if err != nil {

--- a/internal/tui/commands/builtins.go
+++ b/internal/tui/commands/builtins.go
@@ -3,11 +3,9 @@ package commands
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/palette"
-	"github.com/pulseaiclub/phi/internal/components/toast"
 	"github.com/pulseaiclub/phi/internal/extension"
 	"github.com/pulseaiclub/phi/internal/llm/skills"
 )
@@ -36,10 +34,10 @@ func registerBuiltinCommands(r *CommandRegistry) {
 		Name:        "resume",
 		Description: "Resume a session in this directory — /resume <id>",
 		Slash:       true,
+		NeedsArgs:   true,
 		Insert:      "/resume ",
 		Run: func(ctx CommandContext) error {
 			if len(ctx.Args) < 1 {
-				ctx.toast("Usage: /resume <session-id>", toast.ToastWarning, 3*time.Second)
 				return nil
 			}
 			if ctx.ResumeSession != nil {

--- a/internal/tui/commands/commands_test.go
+++ b/internal/tui/commands/commands_test.go
@@ -166,8 +166,10 @@ func TestCommandRegistry_DispatchSlash(t *testing.T) {
 	assert.True(t, r.DispatchSlash("/resume abc", ctx))
 	assert.Equal(t, "abc", resumeID)
 
-	assert.True(t, r.DispatchSlash("/resume", ctx))
-	assert.Contains(t, drainToast(t, bus), "Usage:")
+	insert, ok := r.IncompleteSlash("/resume")
+	assert.True(t, ok)
+	assert.Equal(t, "/resume ", insert)
+	assert.Empty(t, drainToast(t, bus))
 
 	assert.True(t, r.DispatchSlash("/clear", ctx))
 	assert.Equal(t, 1, cleared)
@@ -238,6 +240,25 @@ func TestCommandRegistry_ExtCommandsDoNotReplaceBuiltins(t *testing.T) {
 	r.clearExtCommands()
 	assert.Empty(t, r.LookupInsert("review"))
 	assert.Equal(t, "/clear", r.LookupInsert("clear"))
+}
+
+func TestCommandRegistry_NeedsArgs(t *testing.T) {
+	r := NewCommandRegistry()
+	r.Register(Command{
+		Name:      "plan",
+		Slash:     true,
+		NeedsArgs: true,
+		Run:       func(CommandContext) error { return nil },
+	})
+	assert.Equal(t, "/plan ", r.LookupInsert("plan"))
+	insert, ok := r.IncompleteSlash("/plan")
+	assert.True(t, ok)
+	assert.Equal(t, "/plan ", insert)
+	_, ok = r.IncompleteSlash("/plan on")
+	assert.False(t, ok)
+
+	assert.True(t, r.registerExt(Command{Name: "review", Slash: true, NeedsArgs: true}))
+	assert.Equal(t, "/review ", r.LookupInsert("review"))
 }
 
 // drainToast returns the message of the last queued ToastMsg and empties the bus.

--- a/internal/tui/commands/ext_cmds.go
+++ b/internal/tui/commands/ext_cmds.go
@@ -59,7 +59,7 @@ func (h *ExtCommands) Sync() {
 			if desc == "" {
 				desc = "extension command"
 			}
-			if !h.Registry.registerExt(h.slashCommand(name, desc)) {
+			if !h.Registry.registerExt(h.slashCommand(name, desc, entry.NeedsArgs)) {
 				debuglog.Logf("extension: command %q skipped (name already registered)", name)
 			}
 		}
@@ -71,12 +71,12 @@ func (h *ExtCommands) Sync() {
 	h.Composer.SetPaletteCommands(h.Registry.BuildPalette(ctx))
 }
 
-func (h *ExtCommands) slashCommand(name, desc string) Command {
+func (h *ExtCommands) slashCommand(name, desc string, needsArgs bool) Command {
 	return Command{
 		Name:        name,
 		Description: desc,
 		Slash:       true,
-		Insert:      "/" + name,
+		NeedsArgs:   needsArgs,
 		Run: func(ctx CommandContext) error {
 			if h.running.Load() {
 				ctx.toast("An extension command is already running", toast.ToastWarning, 3*time.Second)

--- a/internal/tui/commands/registry.go
+++ b/internal/tui/commands/registry.go
@@ -47,8 +47,12 @@ type Command struct {
 	Description string
 	Slash       bool
 	// Insert is written into the composer on slash-picker accept.
-	// Empty defaults to "/"+Name.
+	// Empty defaults to "/"+Name (or "/"+Name+" " when NeedsArgs).
+	// A trailing space means "fill composer, do not auto-submit".
 	Insert string
+	// NeedsArgs means bare "/name" (picker accept or submit) should leave
+	// Insert in the composer so the user can type arguments.
+	NeedsArgs bool
 
 	// Run handles slash dispatch (and may be unused for palette-only trees).
 	Run func(ctx CommandContext) error
@@ -71,6 +75,23 @@ func NewCommandRegistry() *CommandRegistry {
 	return &CommandRegistry{by: make(map[string]int)}
 }
 
+func finalizeSlashInsert(cmd *Command) {
+	if !cmd.Slash {
+		return
+	}
+	if cmd.Insert == "" {
+		cmd.Insert = "/" + cmd.Name
+		if cmd.NeedsArgs {
+			cmd.Insert += " "
+		}
+	} else if cmd.NeedsArgs && !strings.HasSuffix(cmd.Insert, " ") {
+		cmd.Insert += " "
+	}
+	if strings.HasSuffix(cmd.Insert, " ") {
+		cmd.NeedsArgs = true
+	}
+}
+
 // Register adds cmd. Duplicate names (case-insensitive) replace the prior entry.
 func (r *CommandRegistry) Register(cmd Command) {
 	name := strings.ToLower(strings.TrimSpace(cmd.Name))
@@ -78,9 +99,7 @@ func (r *CommandRegistry) Register(cmd Command) {
 		return
 	}
 	cmd.Name = strings.TrimSpace(cmd.Name)
-	if cmd.Slash && cmd.Insert == "" {
-		cmd.Insert = "/" + cmd.Name
-	}
+	finalizeSlashInsert(&cmd)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -104,9 +123,7 @@ func (r *CommandRegistry) registerExt(cmd Command) bool {
 	}
 	cmd.Name = strings.TrimSpace(cmd.Name)
 	cmd.fromExt = true
-	if cmd.Slash && cmd.Insert == "" {
-		cmd.Insert = "/" + cmd.Name
-	}
+	finalizeSlashInsert(&cmd)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -185,6 +202,24 @@ func (r *CommandRegistry) LookupInsert(name string) string {
 		return ""
 	}
 	return cmd.Insert
+}
+
+// IncompleteSlash reports whether text is a known NeedsArgs slash with no
+// arguments. insert is the composer value to leave for the user to finish.
+func (r *CommandRegistry) IncompleteSlash(text string) (insert string, ok bool) {
+	fields := strings.Fields(text)
+	if len(fields) != 1 {
+		return "", false
+	}
+	name := strings.TrimPrefix(fields[0], "/")
+	if name == "" || name == fields[0] {
+		return "", false
+	}
+	cmd, found := r.lookup(name)
+	if !found || !cmd.Slash || !cmd.NeedsArgs {
+		return "", false
+	}
+	return cmd.Insert, true
 }
 
 // BuildPalette returns Ctrl+K root commands in registration order.

--- a/internal/tui/composer/deps.go
+++ b/internal/tui/composer/deps.go
@@ -13,6 +13,7 @@ import (
 type Input interface {
 	HideCompleters()
 	ClearInput()
+	SetInput(text string)
 	PendingSkills() []string
 	PendingImages() []imgutil.Attachment
 	ClearPendingSkills()

--- a/internal/tui/composer/pane.go
+++ b/internal/tui/composer/pane.go
@@ -230,6 +230,15 @@ func (c *ComposerPane) ClearInput() {
 	c.Chat.Cursor = 0
 }
 
+// SetInput replaces the composer text and places the cursor at the end.
+func (c *ComposerPane) SetInput(text string) {
+	if c == nil {
+		return
+	}
+	c.Chat.Value = text
+	c.Chat.Cursor = len(text)
+}
+
 // PendingSkills returns attached skill names awaiting submit.
 func (c *ComposerPane) PendingSkills() []string {
 	if c == nil {

--- a/internal/tui/submit/submitter.go
+++ b/internal/tui/submit/submitter.go
@@ -88,6 +88,12 @@ func (s *Submitter) Submit(text string) {
 		}
 	}
 	if strings.HasPrefix(text, "/") {
+		if insert, ok := s.incompleteSlash(text); ok {
+			s.composer.HideCompleters()
+			s.composer.SetInput(insert)
+			s.composer.SyncBashBorder("")
+			return
+		}
 		if s.dispatchSlash(text) {
 			s.composer.HideCompleters()
 			s.composer.ClearInput()
@@ -228,4 +234,11 @@ func (s *Submitter) dispatchSlash(text string) bool {
 		return false
 	}
 	return s.commands.DispatchSlash(text, s.commandContext())
+}
+
+func (s *Submitter) incompleteSlash(text string) (string, bool) {
+	if s == nil || s.commands == nil {
+		return "", false
+	}
+	return s.commands.IncompleteSlash(text)
 }

--- a/internal/tui/submit/submitter_test.go
+++ b/internal/tui/submit/submitter_test.go
@@ -18,10 +18,12 @@ import (
 type stubComposer struct {
 	skills []string
 	images []imgutil.Attachment
+	input  string
 }
 
 func (stubComposer) HideCompleters()                       {}
-func (stubComposer) ClearInput()                           {}
+func (s *stubComposer) ClearInput()                        { s.input = "" }
+func (s *stubComposer) SetInput(text string)               { s.input = text }
 func (s stubComposer) PendingSkills() []string             { return s.skills }
 func (s stubComposer) PendingImages() []imgutil.Attachment { return s.images }
 func (stubComposer) ClearPendingSkills()                   {}
@@ -34,10 +36,13 @@ func newTestSubmitter(
 	t *testing.T,
 	tp *transcript.TranscriptPane,
 	activity *controller.ActivityHandler,
-	composer stubComposer,
+	composer *stubComposer,
 	cmds *commands.CommandRegistry,
 ) *Submitter {
 	t.Helper()
+	if composer == nil {
+		composer = &stubComposer{}
+	}
 	return NewSubmitter(
 		nil,
 		cmds,
@@ -55,7 +60,7 @@ func TestSubmitter_IsBusy(t *testing.T) {
 	th := components.DefaultTheme()
 	spin := status.NewSpinner(th.ToolName)
 	tp := transcript.NewTranscriptPane(th, spin, "Phi test")
-	sub := newTestSubmitter(t, tp, nil, stubComposer{}, nil)
+	sub := newTestSubmitter(t, tp, nil, nil, nil)
 	assert.False(t, sub.IsBusy())
 }
 
@@ -63,7 +68,7 @@ func TestSubmitter_StreamActive_activity(t *testing.T) {
 	th := components.DefaultTheme()
 	spin := status.NewSpinner(th.ToolName)
 	activity := controller.NewActivityHandler(spin)
-	sub := newTestSubmitter(t, transcript.NewTranscriptPane(th, spin, "Phi test"), activity, stubComposer{}, nil)
+	sub := newTestSubmitter(t, transcript.NewTranscriptPane(th, spin, "Phi test"), activity, nil, nil)
 	activity.Apply(controller.ActivityWaiting)
 	assert.True(t, sub.StreamActive())
 }
@@ -72,7 +77,7 @@ func TestSubmitter_Submit_unknownSlashFallsThroughToAgent(t *testing.T) {
 	th := components.DefaultTheme()
 	spin := status.NewSpinner(th.ToolName)
 	tp := transcript.NewTranscriptPane(th, spin, "Phi test")
-	sub := newTestSubmitter(t, tp, nil, stubComposer{}, commands.NewBuiltinRegistry())
+	sub := newTestSubmitter(t, tp, nil, nil, commands.NewBuiltinRegistry())
 	sub.Submit("/not-a-real-command")
 	require.Len(t, tp.Snapshot().Messages, 1)
 	assert.Equal(t, "/not-a-real-command", tp.Snapshot().Messages[0].Text)
@@ -83,10 +88,21 @@ func TestSubmitter_Submit_bareBangFallsThroughToAgent(t *testing.T) {
 	th := components.DefaultTheme()
 	spin := status.NewSpinner(th.ToolName)
 	tp := transcript.NewTranscriptPane(th, spin, "Phi test")
-	sub := newTestSubmitter(t, tp, nil, stubComposer{}, nil)
+	sub := newTestSubmitter(t, tp, nil, nil, nil)
 	sub.Submit("!")
 	require.Len(t, tp.Snapshot().Messages, 1)
 	assert.Equal(t, "!", tp.Snapshot().Messages[0].Text)
+}
+
+func TestSubmitter_Submit_needsArgsRefillsComposer(t *testing.T) {
+	th := components.DefaultTheme()
+	spin := status.NewSpinner(th.ToolName)
+	tp := transcript.NewTranscriptPane(th, spin, "Phi test")
+	comp := &stubComposer{}
+	sub := newTestSubmitter(t, tp, nil, comp, commands.NewBuiltinRegistry())
+	sub.Submit("/resume")
+	assert.Equal(t, "/resume ", comp.input)
+	assert.Empty(t, tp.Snapshot().Messages)
 }
 
 func TestSubmitter_Submit_withImagesOnly(t *testing.T) {
@@ -96,7 +112,7 @@ func TestSubmitter_Submit_withImagesOnly(t *testing.T) {
 	images := []imgutil.Attachment{
 		{Label: "a.png", Result: imgutil.Result{Data: []byte("abc"), MimeType: "image/png"}},
 	}
-	sub := newTestSubmitter(t, tp, nil, stubComposer{images: images}, nil)
+	sub := newTestSubmitter(t, tp, nil, &stubComposer{images: images}, nil)
 	sub.Submit("")
 	require.Len(t, tp.Snapshot().Messages, 1)
 	msg := tp.Snapshot().Messages[0]


### PR DESCRIPTION
RegisterCommand now carries NeedsArgs (Go) / needs_args (Rust), defaulting to false, so a bare /name picked from the palette or submitted refills the composer with "/name " for the user to type arguments instead of auto-running empty and toasting usage. The wire field is omitted when false, keeping old hosts compatible. /resume opts in.