### PR TITLE
fix: correct PowerShell installer interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Fix PowerShell installer parsing of checksum mismatch errors.
+
 ### Security
 
 <!-- Released section -->

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -121,7 +121,7 @@ try {
 
     $got = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash
     if ($got -ne $want.ToUpperInvariant()) {
-        throw "checksum mismatch for $asset: got $got, want $want"
+        throw "checksum mismatch for ${asset}: got $got, want $want"
     }
 
     # ---- extract + install ----


### PR DESCRIPTION
## Summary

- Fix the PowerShell installer checksum error message so the script parses correctly.
- Add an Unreleased changelog entry.

## Root cause

PowerShell interprets `$asset:` inside a double-quoted string as an invalid variable reference. Delimiting the variable as `${asset}` allows the checksum mismatch message to parse and execute correctly.

## Validation

- PowerShell parser: `parse_errors=0`
- Full install test using the `v0.22.0` Windows amd64 release in a temporary directory
- SHA-256 verification, extraction, installation, and `phi mcp --help` all succeeded
- `internal/tools/bashtool` tests pass when Git Bash is first on `PATH`

`go test ./...` was also run. One unrelated existing test currently fails in `internal/tools/findtool`: `TestFind_PathPatternUsesFullPath` returns `No files found` on this Windows environment. All other packages pass.