### PR TITLE
fix(tui): reset extension footer status on runner swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fix PowerShell installer parsing of checksum mismatch errors.
+- Extension footer status (e.g. plan-mode hints) is reset when extensions are reloaded or the model is switched, so stale text no longer outlives the extension subprocess.
 
 ### Security
 

--- a/internal/tui/controller/controller.go
+++ b/internal/tui/controller/controller.go
@@ -276,6 +276,10 @@ func (c *EngineController) swapExtensionRunner(r *extension.Runner) {
 		prev.Close()
 	}
 	c.bindExtensionHost(r)
+	// The previous runner's UI state died with its subprocesses: reset the
+	// extension footer status slot so stale text (e.g. plan-mode hints) does
+	// not outlive an extension reload / model switch.
+	c.publish(ExtSessionEffectsMsg{Status: "", StatusSet: true})
 }
 
 // ListExtensions returns the current on-disk discovery (does not swap the runner).

--- a/internal/tui/controller/controller_ext_test.go
+++ b/internal/tui/controller/controller_ext_test.go
@@ -30,14 +30,18 @@ func TestSwapExtensionRunner_ClosesPrevious(t *testing.T) {
 	first, _, err := extension.Load(t.TempDir(), "")
 	require.NoError(t, err)
 	require.NotNil(t, first)
+	ctrl.bus.Drain() // drop startup messages
 	ctrl.swapExtensionRunner(first)
 	assert.Same(t, first, ctrl.Extensions())
+	assertStatusReset(t, ctrl.bus)
 
 	second, _, err := extension.Load(t.TempDir(), "")
 	require.NoError(t, err)
 	require.NotNil(t, second)
+	ctrl.bus.Drain()
 	ctrl.swapExtensionRunner(second)
 	assert.Same(t, second, ctrl.Extensions())
+	assertStatusReset(t, ctrl.bus)
 	// Previous runner must be closed; a second Close is a safe no-op.
 	first.Close()
 
@@ -45,4 +49,16 @@ func TestSwapExtensionRunner_ClosesPrevious(t *testing.T) {
 	assert.Nil(t, ctrl.Extensions())
 	// Idempotent.
 	ctrl.Close()
+}
+
+// assertStatusReset requires a footer extension-status reset message: swapping
+// the runner kills the previous subprocesses, whose UI state must not linger.
+func assertStatusReset(t *testing.T, bus *Bus) {
+	t.Helper()
+	for _, m := range bus.Drain() {
+		if eff, ok := m.(ExtSessionEffectsMsg); ok && eff.StatusSet && eff.Status == "" {
+			return
+		}
+	}
+	t.Fatal("expected an extension status reset (ExtSessionEffectsMsg{StatusSet:true, Status:\"\"})")
 }


### PR DESCRIPTION
The previous runner's subprocesses die on reload or model switch, but their UI state outlived them. Publish an empty ExtSessionEffectsMsg status when swapping the runner so stale plan-mode hints do not linger.