### PR TITLE
perf(session): stop context walk at compaction boundary

### DIFF
--- a/doc/project-layout.md
+++ b/doc/project-layout.md
@@ -36,3 +36,4 @@
 | [`extensions.md`](extensions.md) | Extensions: discover, API, events, migration from hooks |
 | [`mcp.md`](mcp.md) | MCP: zero schema pollution, meta-tools, config, CLI |
 | [`tui.md`](tui.md) | TUI: package layout, aggregation, interaction flows |
+| [`session-context-building.md`](session-context-building.md) | Sessions: tree model, compaction, context building |

--- a/doc/session-context-building.md
+++ b/doc/session-context-building.md
@@ -1,0 +1,146 @@
+# Building LLM context from the session tree
+
+`internal/session/manager.go` keeps every session message in a tree. Entries
+are never deleted: compaction summarizes old history into a new node instead of
+removing it, so the tree only grows. `buildSessionContext` walks one branch of
+that tree on every context-cache miss to produce the messages sent to the LLM.
+This document explains what the context must contain, why the original
+implementation did work proportional to the *whole* branch, and how the
+optimized version bounds the work by the *output*.
+
+## Data model
+
+Entries form a tree linked by parent ID. A conversation branch is the chain
+from its leaf back to the first message (the session header sits at
+`entries[0]` but is not part of the message chain).
+
+```
+root message ── m1 ── … ── F ── … ── C ── … ── leaf
+```
+
+- `C` is the newest **compaction entry**: an LLM-written summary of the
+  history below it, stored as a normal tree node whose parent is the last
+  message at compaction time.
+- `F` (`C.Compaction.FirstKeptEntryID`) marks the retention boundary: the
+  compaction summarized everything below `F`; from `F` upward messages stay
+  verbatim. When a compaction happens, the session is cut somewhere in the
+  recent window and `F` names the first kept entry.
+- History below `F` is dead for context purposes. It stays in the tree for
+  replay and diagnostics, but it can never appear in LLM context again.
+
+The context produced for a branch is, oldest first:
+
+1. the newest compaction entry (its summary reads as history the model no
+   longer sees verbatim), then
+2. every message from `F` up to the leaf.
+
+Older compaction entries are never re-emitted; only the newest one leads.
+Without any compaction the context is simply the whole branch.
+
+## Original implementation
+
+The original `buildSessionContext` did, for every call:
+
+1. walk the branch from the leaf to the root through `byID`, collecting every
+   ancestor — **including all summarized history below `F`**;
+2. reverse that path;
+3. scan it for the newest compaction entry;
+4. scan from the compaction back down to the root for `FirstKeptEntryID`;
+5. emit the retained tail.
+
+It also preallocated the path with `make([]MessageEntry, 0, len(entries))`,
+sized to the *entire* session, not the branch being walked.
+
+Worst case (no compaction) is output-bound at O(branch depth) and fine.
+But once a compaction exists the context is usually a small tail while the
+branch keeps every historical round, so steps 1–4 re-traverse dead history
+on every call. Sessions that are compacted repeatedly accumulate unbounded
+dead history, making each context build more expensive than the last even
+though the output stays small.
+
+## Optimized implementation
+
+Key observation: the walk can stop at the retention boundary. Once the walk
+(from the leaf upward) reaches the newest compaction `C` and reads its
+`FirstKeptEntryID`, nothing below that ID can reach the output, so there is no
+reason to keep walking toward the root.
+
+The rewrite is a single bounded walk, newest first:
+
+```text
+up = []
+current = leaf
+loop:
+  up.push(current)
+  if no compaction seen yet and current is a compaction entry:
+      C = current; keepFrom = C.FirstKeptEntryID
+      if keepFrom is empty: break          # summary is authoritative
+  if keepFrom is set and current.ID == keepFrom:
+      break                                # retention boundary reached
+  current = byID[current.parent]           # stop at chain root / missing parent
+```
+
+Emission then prepends the compaction entry and appends the kept messages from
+oldest to newest (skipping non-message entries, matching the original filter).
+`up` grows from a small capacity to what is actually walked.
+
+- No compaction: the walk still drains the branch — required, the output *is*
+  the branch.
+- With compaction: only the compaction plus the retained tail (`F` upward) is
+  walked, so the cost is O(context size), independent of total history.
+
+## Behavioural equivalence
+
+The rewrite is intentionally behaviour-preserving. Edge cases match the
+original:
+
+- **Only the newest compaction leads.** The original picked the last
+  compaction in the root-first path; the new code detects the first one
+  encountered walking up — the same node.
+- **Empty `FirstKeptEntryID`**: nothing below the summary stays verbatim; the
+  walk stops at the compaction immediately (original kept `firstKeptIdx =
+  compactionIdx`).
+- **Dangling `FirstKeptEntryID`** (not on the branch): the original fell back
+  to keeping only messages above the compaction; the new code walks to the
+  chain root, finds no match, and applies the same fallback.
+- **Older compaction nodes inside the retained tail** are filtered out of the
+  output, as before.
+
+The only intentional behavioural difference is defensive: an empty entry list
+with an unknown leaf used to panic on `entries[len(entries)-1]`; it now
+returns `nil`.
+
+## Verification
+
+- Existing session tests (load/replay/manager) pass unchanged.
+- New regression subtests in `TestBuildSessionContext` pin the compaction
+  semantics: multi-round compaction (round 1's compaction and its history must
+  not leak into the context), empty `FirstKeptEntryID`, and dangling
+  `FirstKeptEntryID`.
+- `TestBuildSessionContextMatchesReference` keeps the original implementation
+  in the test file as an oracle and compares both against 2000 deterministic
+  random branches (messages plus 0–3 compaction entries with empty, dangling,
+  or real keep-from IDs). This is the strongest guarantee that the rewrite
+  produces identical output.
+
+## Benchmarks
+
+Representative numbers, Apple M4, `-benchtime=300ms -benchmem`
+(reproduce with `go test -run '^$' -bench BenchmarkBuildSessionContext
+-benchmem ./internal/session/`):
+
+| Scenario | Optimized | Reference (old) |
+| --- | --- | --- |
+| compactedHistory (~5000 summarized + 50 kept) | 1.6 µs, 2.5 KB, 3 alloc | 151 µs, 84 KB, 6 alloc |
+| forkedShortBranch (10000 other + 30 current) | 0.8 µs, 1 KB, 2 alloc | 11 µs, 165 KB, 7 alloc |
+| noCompaction (2000 messages) | 65 µs, 9 alloc | 70 µs, 14 alloc |
+
+Two caveats keep the numbers honest:
+
+- The 97× gap on `compactedHistory` is the scenario where the old code did the
+  most dead work; short uncompacted sessions show only constant-factor
+  differences.
+- In absolute terms the whole call is tens of microseconds against LLM round
+  trips of seconds. The practical value is not latency but complexity: work no
+  longer grows with total session history, so very long, repeatedly compacted
+  sessions stay cheap and predictable.

--- a/internal/session/bench_test.go
+++ b/internal/session/bench_test.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// benchSink prevents the compiler from eliminating benchmarked calls.
+var benchSink []MessageEntry
+
+func BenchmarkBuildSessionContext(b *testing.B) {
+	type scenario struct {
+		name    string
+		entries []MessageEntry
+		leafID  string
+	}
+	var scenarios []scenario
+	add := func(name string, entries []MessageEntry, leafID string) {
+		scenarios = append(scenarios, scenario{name: name, entries: entries, leafID: leafID})
+	}
+	{
+		entries, leaf := linearMessages(2000)
+		add("noCompaction", entries, leaf)
+	}
+	{
+		entries, leaf := compactedHistory()
+		add("compactedHistory", entries, leaf)
+	}
+	{
+		entries, leaf := forkedShortBranch()
+		add("forkedShortBranch", entries, leaf)
+	}
+
+	for _, sc := range scenarios {
+		byID := idMap(sc.entries)
+		// Sanity check that the scenario exercises both implementations
+		// identically before timing anything.
+		require.Equal(b, contextIDs(referenceBuildSessionContext(sc.entries, sc.leafID, byID)),
+			contextIDs(buildSessionContext(sc.entries, sc.leafID, byID)))
+
+		b.Run(sc.name+"/optimized", func(b *testing.B) {
+			for range b.N {
+				benchSink = buildSessionContext(sc.entries, sc.leafID, byID)
+			}
+		})
+		b.Run(sc.name+"/reference", func(b *testing.B) {
+			for range b.N {
+				benchSink = referenceBuildSessionContext(sc.entries, sc.leafID, byID)
+			}
+		})
+	}
+}
+
+// linearMessages returns a root-first chain of n messages and the leaf ID.
+func linearMessages(n int) ([]MessageEntry, string) {
+	entries := make([]MessageEntry, 0, n)
+	var parent *string
+	for i := range n {
+		id := fmt.Sprintf("m%d", i)
+		entry := testMessageEntry(id, parent)
+		entries = append(entries, entry)
+		parent = &id
+	}
+	return entries, entries[len(entries)-1].GetID()
+}
+
+// compactedHistory returns a branch with five fully summarized rounds of
+// history below the short retained tail of the newest compaction round.
+func compactedHistory() ([]MessageEntry, string) {
+	var (
+		entries []MessageEntry
+		parent  *string
+		count   int
+	)
+	add := func(entry MessageEntry) {
+		entries = append(entries, entry)
+		id := entry.GetID()
+		parent = &id
+	}
+	for range 5 {
+		for range 1000 {
+			add(testMessageEntry(fmt.Sprintf("old%d", count), parent))
+			count++
+		}
+		add(testCompactionEntry(fmt.Sprintf("round%d", count), parent, fmt.Sprintf("old%d", count-1000)))
+	}
+	for i := range 20 {
+		add(testMessageEntry(fmt.Sprintf("kept%d", i), parent))
+	}
+	add(testCompactionEntry("cnew", parent, "kept0"))
+	for i := range 30 {
+		add(testMessageEntry(fmt.Sprintf("post%d", i), parent))
+	}
+	return entries, entries[len(entries)-1].GetID()
+}
+
+// forkedShortBranch returns many entries on other branches plus a short
+// current branch, mirroring a session that forked after heavy use.
+func forkedShortBranch() ([]MessageEntry, string) {
+	entries, _ := linearMessages(10000)
+	var parent *string
+	for i := range 30 {
+		id := fmt.Sprintf("b%d", i)
+		entry := testMessageEntry(id, parent)
+		entries = append(entries, entry)
+		parent = &id
+	}
+	return entries, entries[len(entries)-1].GetID()
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"sync"
 	"time"
 
@@ -347,9 +346,11 @@ func generateSessionID() string {
 	return hex.EncodeToString(bytes)
 }
 
-// buildSessionContext walks from the leaf back to the root and returns the
-// messages that form the LLM context: a compaction entry (if any) followed by
-// the messages kept after it.
+// buildSessionContext returns the entries that form the LLM context for the
+// branch ending at leafId, oldest first: a compaction entry (if any) followed
+// by the messages retained after it. Everything summarized by the newest
+// compaction never reaches the output, so the walk stops at the retained
+// tail instead of draining the whole branch.
 func buildSessionContext(
 	entries []MessageEntry,
 	leafId string,
@@ -360,20 +361,40 @@ func buildSessionContext(
 			byId[entry.GetID()] = entry
 		}
 	}
-
 	if leafId == "" {
 		return nil
 	}
 
 	leaf, ok := byId[leafId]
 	if !ok {
+		if len(entries) == 0 {
+			return nil
+		}
 		leaf = entries[len(entries)-1]
 	}
 
-	path := make([]MessageEntry, 0, len(entries))
-	current := leaf
-	for current != nil {
-		path = append(path, current)
+	// Walk the branch upward (newest first). Once the newest compaction entry
+	// is crossed, nothing older than the entry it names in FirstKeptEntryID is
+	// kept, so the walk stops there instead of draining summarized history.
+	up := make([]MessageEntry, 0, 16)
+	compactionIdx := -1 // newest-first index of the newest compaction entry
+	keepFrom := ""      // its FirstKeptEntryID ("" = nothing kept below it)
+	keptReached := false
+	for current := leaf; ; {
+		up = append(up, current)
+		if compactionIdx < 0 && current.GetType() == EntryCompaction {
+			compactionIdx = len(up) - 1
+			if ce, ok := current.(CompactionEntry); ok {
+				keepFrom = ce.Compaction.FirstKeptEntryID
+			}
+			if keepFrom == "" {
+				break // summary is authoritative; nothing below stays verbatim
+			}
+		}
+		if keepFrom != "" && current.GetID() == keepFrom {
+			keptReached = true
+			break
+		}
 		parentID := current.GetParent()
 		if parentID == nil {
 			break
@@ -384,45 +405,20 @@ func buildSessionContext(
 		}
 		current = next
 	}
-	slices.Reverse(path)
 
-	var (
-		messages      []MessageEntry
-		compactionIdx = -1
-	)
-	for i, m := range path {
-		if m.GetType() == EntryCompaction {
-			compactionIdx = i
-		}
-	}
-
-	appendMessage := func(entry MessageEntry) {
-		if entry.GetType() == EntryMessage {
-			messages = append(messages, entry)
-		}
-	}
-
+	messages := make([]MessageEntry, 0, len(up))
 	if compactionIdx >= 0 {
-		compaction := path[compactionIdx]
-		messages = append(messages, compaction)
-
-		firstKeptIdx := compactionIdx
-		if ce, ok := compaction.(CompactionEntry); ok && ce.Compaction.FirstKeptEntryID != "" {
-			for i := compactionIdx; i >= 0; i-- {
-				if path[i].GetID() == ce.Compaction.FirstKeptEntryID {
-					firstKeptIdx = i
-					break
-				}
-			}
+		messages = append(messages, up[compactionIdx]) // summary first
+	}
+	start := len(up) - 1
+	if compactionIdx >= 0 && !keptReached {
+		start = compactionIdx - 1 // dangling FirstKeptEntryID: keep nothing below
+	}
+	for i := start; i >= 0; i-- {
+		if i == compactionIdx || up[i].GetType() != EntryMessage {
+			continue
 		}
-
-		for i := firstKeptIdx; i < len(path); i++ {
-			appendMessage(path[i])
-		}
-	} else {
-		for _, entry := range path {
-			appendMessage(entry)
-		}
+		messages = append(messages, up[i])
 	}
 	return messages
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,7 +1,9 @@
 package session
 
 import (
+	"fmt"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/pulseaiclub/phi/internal/llm"
@@ -222,6 +224,221 @@ func TestBuildSessionContext(t *testing.T) {
 		assert.Equal(t, "msg2", ctx[1].GetID())
 		assert.Equal(t, "msg3", ctx[2].GetID())
 	})
+
+	t.Run("second compaction drops history summarized by earlier rounds", func(t *testing.T) {
+		m1 := testMessageEntry("m1", nil)
+		m2 := testMessageEntry("m2", &m1.ID)
+		c1 := testCompactionEntry("c1", &m2.ID, "m2")
+		m3 := testMessageEntry("m3", &c1.ID)
+		m4 := testMessageEntry("m4", &m3.ID)
+		c2 := testCompactionEntry("c2", &m4.ID, "m3")
+		m5 := testMessageEntry("m5", &c2.ID)
+		entries := []MessageEntry{m1, m2, c1, m3, m4, c2, m5}
+
+		ctx := buildSessionContext(entries, m5.ID, idMap(entries))
+
+		// Round 2 summarized everything below m3, including round 1's
+		// compaction and its old history.
+		assert.Equal(t, []string{"c2", "m3", "m4", "m5"}, contextIDs(ctx))
+	})
+
+	t.Run("compaction without FirstKeptEntryID keeps only newer messages", func(t *testing.T) {
+		m1 := testMessageEntry("m1", nil)
+		m2 := testMessageEntry("m2", &m1.ID)
+		c1 := testCompactionEntry("c1", &m2.ID, "")
+		m3 := testMessageEntry("m3", &c1.ID)
+		entries := []MessageEntry{m1, m2, c1, m3}
+
+		ctx := buildSessionContext(entries, m3.ID, idMap(entries))
+
+		assert.Equal(t, []string{"c1", "m3"}, contextIDs(ctx))
+	})
+
+	t.Run("dangling FirstKeptEntryID keeps only newer messages", func(t *testing.T) {
+		m1 := testMessageEntry("m1", nil)
+		m2 := testMessageEntry("m2", &m1.ID)
+		c1 := testCompactionEntry("c1", &m2.ID, "ghost")
+		m3 := testMessageEntry("m3", &c1.ID)
+		entries := []MessageEntry{m1, m2, c1, m3}
+
+		ctx := buildSessionContext(entries, m3.ID, idMap(entries))
+
+		assert.Equal(t, []string{"c1", "m3"}, contextIDs(ctx))
+	})
+}
+
+func testMessageEntry(id string, parent *string) SessionMessageEntry {
+	return SessionMessageEntry{
+		SessionBaseEntry: SessionBaseEntry{
+			Type: EntryMessage, ID: id, ParentID: parent,
+		},
+	}
+}
+
+func testCompactionEntry(id string, parent *string, keepFrom string) CompactionEntry {
+	return CompactionEntry{
+		SessionBaseEntry: SessionBaseEntry{
+			Type: EntryCompaction, ID: id, ParentID: parent,
+		},
+		Compaction: Compaction{FirstKeptEntryID: keepFrom},
+	}
+}
+
+func idMap(entries []MessageEntry) map[string]MessageEntry {
+	byID := make(map[string]MessageEntry, len(entries))
+	for _, entry := range entries {
+		byID[entry.GetID()] = entry
+	}
+	return byID
+}
+
+func contextIDs(entries []MessageEntry) []string {
+	ids := make([]string, len(entries))
+	for i, entry := range entries {
+		ids[i] = entry.GetID()
+	}
+	return ids
+}
+
+// referenceBuildSessionContext is the pre-optimization implementation of
+// buildSessionContext, kept as an oracle for differential testing.
+func referenceBuildSessionContext(
+	entries []MessageEntry,
+	leafId string,
+	byId map[string]MessageEntry,
+) []MessageEntry {
+	if len(byId) == 0 {
+		for _, entry := range entries {
+			byId[entry.GetID()] = entry
+		}
+	}
+
+	if leafId == "" {
+		return nil
+	}
+
+	leaf, ok := byId[leafId]
+	if !ok {
+		leaf = entries[len(entries)-1]
+	}
+
+	path := make([]MessageEntry, 0, len(entries))
+	current := leaf
+	for current != nil {
+		path = append(path, current)
+		parentID := current.GetParent()
+		if parentID == nil {
+			break
+		}
+		next, ok := byId[*parentID]
+		if !ok {
+			break
+		}
+		current = next
+	}
+	slices.Reverse(path)
+
+	var (
+		messages      []MessageEntry
+		compactionIdx = -1
+	)
+	for i, m := range path {
+		if m.GetType() == EntryCompaction {
+			compactionIdx = i
+		}
+	}
+
+	appendMessage := func(entry MessageEntry) {
+		if entry.GetType() == EntryMessage {
+			messages = append(messages, entry)
+		}
+	}
+
+	if compactionIdx >= 0 {
+		compaction := path[compactionIdx]
+		messages = append(messages, compaction)
+
+		firstKeptIdx := compactionIdx
+		if ce, ok := compaction.(CompactionEntry); ok && ce.Compaction.FirstKeptEntryID != "" {
+			for i := compactionIdx; i >= 0; i-- {
+				if path[i].GetID() == ce.Compaction.FirstKeptEntryID {
+					firstKeptIdx = i
+					break
+				}
+			}
+		}
+
+		for i := firstKeptIdx; i < len(path); i++ {
+			appendMessage(path[i])
+		}
+	} else {
+		for _, entry := range path {
+			appendMessage(entry)
+		}
+	}
+	return messages
+}
+
+func TestBuildSessionContextMatchesReference(t *testing.T) {
+	// Deterministic MINSTD PRNG keeps the corpus reproducible without math/rand.
+	seed := int64(1)
+	next := func(n int) int {
+		seed = seed * 48271 % 2147483647
+		return int(seed % int64(n))
+	}
+
+	for range 2000 {
+		entries := randomContextEntries(next)
+		leafID := entries[len(entries)-1].GetID()
+
+		got := buildSessionContext(entries, leafID, idMap(entries))
+		want := referenceBuildSessionContext(entries, leafID, idMap(entries))
+
+		assert.Equal(t, contextIDs(want), contextIDs(got))
+	}
+}
+
+// randomContextEntries builds a random linear branch (messages plus zero to
+// three compaction entries) for differential testing; entry order is root
+// first, leaf last.
+func randomContextEntries(next func(n int) int) []MessageEntry {
+	var (
+		entries []MessageEntry
+		parent  *string
+		msgID   int
+		compID  int
+	)
+	appendNode := func(entry MessageEntry) {
+		entries = append(entries, entry)
+		id := entry.GetID()
+		parent = &id
+	}
+	addMessage := func() {
+		msgID++
+		appendNode(testMessageEntry(fmt.Sprintf("m%d", msgID), parent))
+	}
+	addCompaction := func() {
+		compID++
+		var keepFrom string
+		switch next(3) {
+		case 1:
+			keepFrom = "missing" // dangling ID
+		case 2:
+			if len(entries) > 0 {
+				keepFrom = entries[next(len(entries))].GetID()
+			}
+		}
+		appendNode(testCompactionEntry(fmt.Sprintf("c%d", compID), parent, keepFrom))
+	}
+
+	addMessage()
+	for range next(5) {
+		if next(2) == 0 {
+			addCompaction()
+		}
+		addMessage()
+	}
+	return entries
 }
 
 func TestReplaySnapshotEmpty(t *testing.T) {


### PR DESCRIPTION
Apple M4, `-benchtime=300ms -benchmem`
(reproduce with `go test -run '^$' -bench BenchmarkBuildSessionContext
-benchmem ./internal/session/`):

| Scenario | Optimized | Reference (old) |
| --- | --- | --- |
| compactedHistory (~5000 summarized + 50 kept) | 1.6 µs, 2.5 KB, 3 alloc | 151 µs, 84 KB, 6 alloc |
| forkedShortBranch (10000 other + 30 current) | 0.8 µs, 1 KB, 2 alloc | 11 µs, 165 KB, 7 alloc |
| noCompaction (2000 messages) | 65 µs, 9 alloc | 70 µs, 14 alloc |