### PR TITLE
feat(llm,block): present provider API errors cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   (`Tool::new_async`) — the SDK drives them to completion on a
   single-threaded tokio runtime, so network / IO calls work without blocking
   tricks; sync `Tool::new` handlers are unchanged.
+- LLM provider errors now read as one compact line — e.g. `anthropic API error
+  (400): prompt is too long` — using the provider's own message instead of a
+  raw JSON body, which can no longer flood the terminal or session history.
+- TUI: assistant blocks that end in error state render their body in red under
+  an `Error:` label, so failures read like tool errors.
 
 ### Deprecated
 

--- a/internal/components/block/assistant_block.go
+++ b/internal/components/block/assistant_block.go
@@ -37,6 +37,13 @@ func (assistantBlock *AssistantBlock) Draw(ctx components.DrawContext) component
 		w = 40
 	}
 	spans := text.RenderMarkdown(assistantBlock.Text, th)
+	if assistantBlock.State == session.StateError && assistantBlock.Text != "" {
+		// Error turns read like tool failures: red body under an "Error:" label.
+		spans = append([]components.Span{{Text: "Error: ", Style: th.Destructive}}, spans...)
+		for i := range spans {
+			spans[i].Style = th.Destructive
+		}
+	}
 	if assistantBlock.State == session.StateCancelled && assistantBlock.Text != "" {
 		if len(spans) > 0 {
 			spans = append(spans, components.Span{Text: "\n", Style: th.Muted})

--- a/internal/components/block/assistant_block_test.go
+++ b/internal/components/block/assistant_block_test.go
@@ -84,6 +84,25 @@ func TestAssistantBlockDraw(t *testing.T) {
 			},
 		},
 		{
+			name:         "error renders red prefixed body",
+			text:         "boom",
+			state:        session.StateError,
+			width:        60,
+			wantWidth:    60,
+			wantContains: []string{"Error: boom"},
+			wantCells: []cellCheck{
+				{x: 0, y: 0, style: th.Destructive}, // "Error:" label
+				{x: 7, y: 0, style: th.Destructive}, // error body
+			},
+		},
+		{
+			name:           "error with empty text renders no label",
+			state:          session.StateError,
+			width:          60,
+			wantWidth:      60,
+			wantNotContain: []string{"Error:"},
+		},
+		{
 			name:          "cancelled appends muted label",
 			text:          "partial",
 			state:         session.StateCancelled,

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"iter"
 	"net/http"
@@ -248,7 +247,7 @@ func Stream(
 
 		if httpResp.StatusCode != http.StatusOK {
 			respBody, _ := io.ReadAll(httpResp.Body)
-			yield(llm.StreamEvent{}, fmt.Errorf("anthropic API error: (%d) %s", httpResp.StatusCode, string(respBody)))
+			yield(llm.StreamEvent{}, llm.FormatAPIError("anthropic", httpResp.StatusCode, respBody))
 			return
 		}
 
@@ -470,7 +469,7 @@ func Compact(ctx context.Context, httpClient *http.Client, cfg llm.ModelConfig, 
 		return "", err
 	}
 	if httpResp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("anthropic API error: (%d) %s", httpResp.StatusCode, string(respBody))
+		return "", llm.FormatAPIError("anthropic", httpResp.StatusCode, respBody)
 	}
 
 	var resp struct {

--- a/internal/llm/apierror.go
+++ b/internal/llm/apierror.go
@@ -1,0 +1,69 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// maxAPIErrorBodyChars caps the raw-body fallback in FormatAPIError so a
+// non-JSON error page can never flood the terminal or the session history.
+const maxAPIErrorBodyChars = 2000
+
+// FormatAPIError builds a compact, human-readable error for a non-2xx
+// provider response: "<provider> API error (<status>): <message>". Provider
+// JSON error envelopes are unwrapped to their message so raw JSON never
+// reaches the UI; the trimmed raw body (capped) is the fallback for bodies
+// with no recognizable envelope.
+func FormatAPIError(provider string, status int, body []byte) error {
+	msg := apiErrorMessage(body)
+	if msg == "" {
+		msg = strings.TrimSpace(string(body))
+		if r := []rune(msg); len(r) > maxAPIErrorBodyChars {
+			msg = string(r[:maxAPIErrorBodyChars]) + "…"
+		}
+	}
+	if msg == "" {
+		msg = "empty error response"
+	}
+	return fmt.Errorf("%s API error (%d): %s", provider, status, msg)
+}
+
+// apiErrorMessage extracts the human-readable message from a provider error
+// JSON body. OpenAI-compatible, Anthropic, and Gemini APIs all nest the
+// reason under "error" as either an object with a "message" field or a plain
+// string; some proxies use a flat top-level {"message": …}. It returns ""
+// when the body has no recognizable message.
+func apiErrorMessage(body []byte) string {
+	var env struct {
+		Error   json.RawMessage `json:"error"`
+		Message string          `json:"message"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return ""
+	}
+	if len(env.Error) > 0 && !bytes.Equal(bytes.TrimSpace(env.Error), []byte("null")) {
+		if msg := errorObjectMessage(env.Error); msg != "" {
+			return msg
+		}
+	}
+	return env.Message
+}
+
+// errorObjectMessage reads a nested "error" value that is either an object
+// with a "message" field ({"error":{"message": …}}) or a bare string
+// ({"error":"…"}).
+func errorObjectMessage(raw json.RawMessage) string {
+	var obj struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil && obj.Message != "" {
+		return obj.Message
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return strings.TrimSpace(s)
+	}
+	return ""
+}

--- a/internal/llm/apierror_test.go
+++ b/internal/llm/apierror_test.go
@@ -1,0 +1,105 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatAPIError(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		status   int
+		body     string
+		want     string
+	}{
+		{
+			name:     "openai envelope",
+			provider: "LLM",
+			status:   401,
+			body:     `{"error":{"message":"Incorrect API key provided","type":"invalid_request_error","param":null,"code":"invalid_api_key"}}`,
+			want:     "LLM API error (401): Incorrect API key provided",
+		},
+		{
+			name:     "anthropic envelope",
+			provider: "anthropic",
+			status:   400,
+			body:     `{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 210000 > 200000 tokens"}}`,
+			want:     "anthropic API error (400): prompt is too long: 210000 > 200000 tokens",
+		},
+		{
+			name:     "gemini envelope",
+			provider: "gemini",
+			status:   400,
+			body:     `{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}`,
+			want:     "gemini API error (400): API key not valid. Please pass a valid API key.",
+		},
+		{
+			name:     "error is a bare string",
+			provider: "gemini",
+			status:   404,
+			body:     `{"error":"model not found"}`,
+			want:     "gemini API error (404): model not found",
+		},
+		{
+			name:     "flat message field",
+			provider: "LLM",
+			status:   413,
+			body:     `{"message":"request body too large"}`,
+			want:     "LLM API error (413): request body too large",
+		},
+		{
+			name:     "non-json body falls back to raw text",
+			provider: "LLM",
+			status:   502,
+			body:     "gateway unavailable\nplease retry",
+			want:     "LLM API error (502): gateway unavailable\nplease retry",
+		},
+		{
+			name:     "json without envelope falls back to raw body",
+			provider: "LLM",
+			status:   404,
+			body:     `{"detail":"not found"}`,
+			want:     "LLM API error (404): {\"detail\":\"not found\"}",
+		},
+		{
+			name:     "empty error object falls back to raw body",
+			provider: "LLM",
+			status:   400,
+			body:     `{"error":{}}`,
+			want:     "LLM API error (400): {\"error\":{}}",
+		},
+		{
+			name:     "empty body",
+			provider: "LLM",
+			status:   502,
+			body:     "",
+			want:     "LLM API error (502): empty error response",
+		},
+		{
+			name:     "whitespace-only body",
+			provider: "LLM",
+			status:   502,
+			body:     "  \n ",
+			want:     "LLM API error (502): empty error response",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := FormatAPIError(tt.provider, tt.status, []byte(tt.body))
+			require.Error(t, err)
+			assert.Equal(t, tt.want, err.Error())
+		})
+	}
+}
+
+func TestFormatAPIErrorCapsRawFallback(t *testing.T) {
+	big := strings.Repeat("x", maxAPIErrorBodyChars+500)
+	err := FormatAPIError("LLM", 502, []byte(big))
+
+	msg := err.Error()
+	assert.Equal(t, "LLM API error (502): "+strings.Repeat("x", maxAPIErrorBodyChars)+"…", msg)
+}

--- a/internal/llm/gemini/client.go
+++ b/internal/llm/gemini/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"iter"
 	"net/http"
@@ -258,7 +257,7 @@ func Stream(
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
 			raw, _ := io.ReadAll(httpResp.Body)
-			yield(llm.StreamEvent{}, fmt.Errorf("gemini API error: (%d) %s", httpResp.StatusCode, string(raw)))
+			yield(llm.StreamEvent{}, llm.FormatAPIError("gemini", httpResp.StatusCode, raw))
 			return
 		}
 		processStream(httpResp.Body, yield)
@@ -418,7 +417,7 @@ func Compact(
 		return "", err
 	}
 	if httpResp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("gemini API error: (%d) %s", httpResp.StatusCode, string(raw))
+		return "", llm.FormatAPIError("gemini", httpResp.StatusCode, raw)
 	}
 	var resp chunk
 	if err := json.Unmarshal(raw, &resp); err != nil {

--- a/internal/llm/gemini/client_test.go
+++ b/internal/llm/gemini/client_test.go
@@ -219,7 +219,7 @@ func TestCompactUsesNonStreamingEndpoint(t *testing.T) {
 }
 
 func TestCompactFormatsAPIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(
 			w,
@@ -239,7 +239,7 @@ func TestCompactFormatsAPIError(t *testing.T) {
 }
 
 func TestStreamFormatsAPIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		fmt.Fprint(
 			w,

--- a/internal/llm/gemini/client_test.go
+++ b/internal/llm/gemini/client_test.go
@@ -217,3 +217,50 @@ func TestCompactUsesNonStreamingEndpoint(t *testing.T) {
 	assert.Equal(t, "summary", out)
 	assert.Equal(t, "/models/gemini-2.5-flash:generateContent", gotPath)
 }
+
+func TestCompactFormatsAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(
+			w,
+			`{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}`,
+		)
+	}))
+	defer srv.Close()
+
+	_, err := Compact(
+		t.Context(),
+		srv.Client(),
+		llm.ModelConfig{Name: "gemini-2.5-flash", BaseURL: srv.URL, APIKey: "bad"},
+		"summarize",
+	)
+	require.Error(t, err)
+	assert.Equal(t, "gemini API error (400): API key not valid. Please pass a valid API key.", err.Error())
+}
+
+func TestStreamFormatsAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(
+			w,
+			`{"error":{"code":401,"message":"API key not valid. Please pass a valid API key.","status":"UNAUTHENTICATED"}}`,
+		)
+	}))
+	defer srv.Close()
+
+	req := BuildRequest("", []llm.Message{{Role: llm.RoleUser, Content: "hi"}}, nil)
+	var gotErr error
+	for _, err := range Stream(
+		t.Context(),
+		srv.Client(),
+		llm.ModelConfig{Name: "gemini-2.5-flash", BaseURL: srv.URL, APIKey: "bad"},
+		&req,
+	) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	require.Error(t, gotErr)
+	assert.Equal(t, "gemini API error (401): API key not valid. Please pass a valid API key.", gotErr.Error())
+}

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"iter"
 	"net/http"
@@ -165,7 +164,7 @@ func Compact(ctx context.Context, httpClient *http.Client, cfg llm.ModelConfig, 
 		return "", err
 	}
 	if httpResp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("LLM API error: (%d) %s", httpResp.StatusCode, string(respBody))
+		return "", llm.FormatAPIError("LLM", httpResp.StatusCode, respBody)
 	}
 
 	var resp llm.Response
@@ -216,7 +215,7 @@ func StreamChatCompletion(
 
 		if httpResp.StatusCode != http.StatusOK {
 			respBody, _ := io.ReadAll(httpResp.Body)
-			yield(llm.StreamEvent{}, fmt.Errorf("LLM API error: (%d) %s", httpResp.StatusCode, string(respBody)))
+			yield(llm.StreamEvent{}, llm.FormatAPIError("LLM", httpResp.StatusCode, respBody))
 			return
 		}
 


### PR DESCRIPTION
llm.FormatAPIError unwraps OpenAI/Anthropic/Gemini error envelopes into a compact "<provider> API error (<status>): <message>" and caps the raw-body fallback, so raw JSON no longer reaches the terminal or session history; the OpenAI, Anthropic, and Gemini clients use it for stream and compact errors.

Assistant blocks in error state render a destructive "Error:" label and red body, so failures read like tool errors.