### PR TITLE
refactor(llm): deduplicate provider HTTP setup, share helpers, return streams directly

### DIFF
--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -46,7 +46,7 @@ func BuildRequest(
 	messages []llm.Message,
 	tools []llm.ToolDefinition,
 ) AnthropicRequest {
-	cc := resolveCacheControl()
+	cc := &cacheControl{Type: "ephemeral", TTL: "1h"}
 
 	req := AnthropicRequest{
 		Model:     cfg.Name,
@@ -167,14 +167,10 @@ func BuildRequest(
 	}
 
 	for i, t := range tools {
-		params, _ := json.Marshal(t.Params)
-		if len(params) == 0 || bytes.Equal(bytes.TrimSpace(params), []byte("null")) {
-			params = json.RawMessage("{}")
-		}
 		tool := anthropicTool{
 			Name:        t.Name,
 			Description: t.Description,
-			InputSchema: params,
+			InputSchema: llm.MarshalToolParams(t.Params, "{}"),
 		}
 		if i == len(tools)-1 {
 			tool.CacheControl = cc
@@ -208,6 +204,25 @@ func toolUseInput(arguments string) json.RawMessage {
 	return encoded
 }
 
+func newMessagesHTTPRequest(ctx context.Context, cfg llm.ModelConfig, body []byte, stream bool) (*http.Request, error) {
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		normalizeBaseURL(cfg.BaseURL)+messagesPath,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Api-Key", cfg.APIKey)
+	httpReq.Header.Set("Anthropic-Version", apiVersion)
+	if stream {
+		httpReq.Header.Set("Accept", util.ContentEventStream)
+	}
+	return httpReq, nil
+}
+
 // Stream POSTs a streaming request to the Messages API and yields normalized
 // events (same StreamEvent contract as the OpenAI-compatible path).
 func Stream(
@@ -223,20 +238,11 @@ func Stream(
 			return
 		}
 
-		httpReq, err := http.NewRequestWithContext(
-			ctx,
-			http.MethodPost,
-			normalizeBaseURL(cfg.BaseURL)+messagesPath,
-			bytes.NewReader(body),
-		)
+		httpReq, err := newMessagesHTTPRequest(ctx, cfg, body, true)
 		if err != nil {
 			yield(llm.StreamEvent{}, err)
 			return
 		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("X-Api-Key", cfg.APIKey)
-		httpReq.Header.Set("Anthropic-Version", apiVersion)
-		httpReq.Header.Set("Accept", util.ContentEventStream)
 
 		httpResp, err := util.DoWithRetry(httpClient, httpReq)
 		if err != nil {
@@ -417,18 +423,7 @@ func processStream(body io.Reader, yield func(llm.StreamEvent, error) bool) {
 	}
 
 	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
-	out := llm.Response{
-		Choices: []llm.Choice{{
-			Message: llm.Message{
-				Role:             llm.RoleAssistant,
-				Content:          content.String(),
-				ReasoningContent: reasoning.String(),
-				ToolCalls:        toolCalls,
-			},
-		}},
-		Usage: usage,
-	}
-	yield(llm.StreamEvent{Type: llm.StreamEventTypeDone, Partial: out}, nil)
+	yield(llm.AssistantDone(content.String(), reasoning.String(), toolCalls, usage), nil)
 }
 
 // Compact sends a single non-streaming request and returns the assistant
@@ -445,18 +440,10 @@ func Compact(ctx context.Context, httpClient *http.Client, cfg llm.ModelConfig, 
 		return "", err
 	}
 
-	httpReq, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		normalizeBaseURL(cfg.BaseURL)+messagesPath,
-		bytes.NewReader(body),
-	)
+	httpReq, err := newMessagesHTTPRequest(ctx, cfg, body, false)
 	if err != nil {
 		return "", err
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("X-Api-Key", cfg.APIKey)
-	httpReq.Header.Set("Anthropic-Version", apiVersion)
 
 	httpResp, err := util.DoWithRetry(httpClient, httpReq)
 	if err != nil {

--- a/internal/llm/anthropic/request.go
+++ b/internal/llm/anthropic/request.go
@@ -53,10 +53,3 @@ type anthropicContentBlock struct {
 	Source       *anthropicImageSource `json:"source,omitempty"`
 	CacheControl *cacheControl         `json:"cache_control,omitempty"`
 }
-
-func resolveCacheControl() *cacheControl {
-	return &cacheControl{
-		Type: "ephemeral",
-		TTL:  "1h",
-	}
-}

--- a/internal/llm/client/client.go
+++ b/internal/llm/client/client.go
@@ -13,9 +13,9 @@ import (
 	"github.com/pulseaiclub/phi/internal/util"
 )
 
-// Client talks to the configured LLM endpoint: the OpenAI-compatible
-// /chat/completions API by default, or the Anthropic Messages API when the
-// config targets anthropic (see isAnthropicProvider).
+// Client talks to the configured LLM endpoint: OpenAI-compatible by default,
+// or Anthropic / Gemini when the config matches (see isAnthropicProvider /
+// isGeminiProvider).
 type Client struct {
 	httpClient *http.Client
 	cfg        llm.ModelConfig
@@ -39,50 +39,32 @@ func NewClient(cfg llm.ModelConfig, tools []llm.ToolDefinition, systemPrompt str
 
 // Stream runs a streaming chat completion over messages (+ optional system prompt / tools).
 func (c *Client) Stream(ctx context.Context, messages []llm.Message) iter.Seq2[llm.StreamEvent, error] {
-	return func(yield func(llm.StreamEvent, error) bool) {
-		if c.anthropic {
-			req := anthropic.BuildRequest(c.cfg, c.system, messages, c.tools)
-			for ev, err := range anthropic.Stream(ctx, c.httpClient, c.cfg, &req) {
-				if !yield(ev, err) {
-					return
-				}
-			}
-			return
-		}
-
-		if c.gemini {
-			req := gemini.BuildRequest(c.system, messages, c.tools)
-			for ev, err := range gemini.Stream(ctx, c.httpClient, c.cfg, &req) {
-				if !yield(ev, err) {
-					return
-				}
-			}
-			return
-		}
-
+	switch {
+	case c.anthropic:
+		req := anthropic.BuildRequest(c.cfg, c.system, messages, c.tools)
+		return anthropic.Stream(ctx, c.httpClient, c.cfg, &req)
+	case c.gemini:
+		req := gemini.BuildRequest(c.system, messages, c.tools)
+		return gemini.Stream(ctx, c.httpClient, c.cfg, &req)
+	default:
 		req := openai.BuildRequest(c.cfg, c.system, messages, c.tools)
-		for ev, err := range openai.StreamChatCompletion(ctx, c.httpClient, c.cfg.BaseURL, c.cfg.APIKey, req) {
-			if !yield(ev, err) {
-				return
-			}
-		}
+		return openai.StreamChatCompletion(ctx, c.httpClient, c.cfg.BaseURL, c.cfg.APIKey, req)
 	}
 }
 
 // Compact sends a single non-streaming chat request and returns the
 // assistant text. It satisfies llm.Compactor for session compaction.
 func (c *Client) Compact(ctx context.Context, prompt string) (string, error) {
-	if c.anthropic {
+	switch {
+	case c.anthropic:
 		return anthropic.Compact(ctx, c.httpClient, c.cfg, prompt)
-	}
-	if c.gemini {
+	case c.gemini:
 		return gemini.Compact(ctx, c.httpClient, c.cfg, prompt)
+	default:
+		return openai.Compact(ctx, c.httpClient, c.cfg, prompt)
 	}
-	return openai.Compact(ctx, c.httpClient, c.cfg, prompt)
 }
 
-// isAnthropicProvider reports whether the config targets the Anthropic
-// Messages API: either an anthropic base URL or a claude model name.
 func isAnthropicProvider(cfg llm.ModelConfig) bool {
 	base := strings.ToLower(cfg.BaseURL)
 	if strings.Contains(base, "anthropic") {
@@ -91,7 +73,6 @@ func isAnthropicProvider(cfg llm.ModelConfig) bool {
 	return strings.HasPrefix(strings.ToLower(cfg.Name), "claude")
 }
 
-// isGeminiProvider reports a Gemini model or Google AI Studio base URL.
 func isGeminiProvider(cfg llm.ModelConfig) bool {
 	base := strings.ToLower(cfg.BaseURL)
 	name := strings.ToLower(cfg.Name)

--- a/internal/llm/client/doc.go
+++ b/internal/llm/client/doc.go
@@ -1,4 +1,3 @@
-// Package client is the LLM facade. It talks to either the OpenAI-compatible
-// /chat/completions API (openai package) or the Anthropic Messages API
-// (anthropic package), chosen by config.
+// Package client is the LLM facade: OpenAI-compatible, Anthropic, or Gemini,
+// chosen by model config.
 package client

--- a/internal/llm/gemini/client.go
+++ b/internal/llm/gemini/client.go
@@ -163,11 +163,11 @@ func lastFunctionResponseContent(contents []content) *content {
 func toToolMessage(tools []llm.ToolDefinition) []functionDeclaration {
 	decls := make([]functionDeclaration, 0, len(tools))
 	for _, t := range tools {
-		params, _ := json.Marshal(t.Params)
-		if len(params) == 0 || bytes.Equal(bytes.TrimSpace(params), []byte("null")) {
-			params = json.RawMessage(`{"type":"object"}`)
-		}
-		decls = append(decls, functionDeclaration{Name: t.Name, Description: t.Description, Parameters: params})
+		decls = append(decls, functionDeclaration{
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  llm.MarshalToolParams(t.Params, `{"type":"object"}`),
+		})
 	}
 	return decls
 }
@@ -215,8 +215,11 @@ func getURL(model, baseURL, apiKey string, stream bool) string {
 	return u.String()
 }
 
-func getStreamURL(model, baseURL, apiKey string) string {
-	return getURL(model, baseURL, apiKey, true)
+func setGeminiAuth(req *http.Request, baseURL, apiKey string) {
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" && strings.Contains(strings.ToLower(baseURL), "aiplatform.googleapis.com") {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 }
 
 func Stream(
@@ -237,17 +240,14 @@ func Stream(
 		httpReq, err := http.NewRequestWithContext(
 			ctx,
 			http.MethodPost,
-			getStreamURL(config.Name, config.BaseURL, config.APIKey), bytes.NewReader(body),
+			getURL(config.Name, config.BaseURL, config.APIKey, true),
+			bytes.NewReader(body),
 		)
 		if err != nil {
 			yield(llm.StreamEvent{}, err)
 			return
 		}
-
-		httpReq.Header.Set("Content-Type", "application/json")
-		if strings.Contains(strings.ToLower(config.BaseURL), "aiplatform.googleapis.com") && config.APIKey != "" {
-			httpReq.Header.Set("Authorization", "Bearer "+config.APIKey)
-		}
+		setGeminiAuth(httpReq, config.BaseURL, config.APIKey)
 
 		httpResp, err := util.DoWithRetry(client, httpReq)
 		if err != nil {
@@ -351,20 +351,7 @@ func processStream(body io.Reader, yield func(llm.StreamEvent, error) bool) {
 			}
 		}
 	}
-	yield(llm.StreamEvent{
-		Type: llm.StreamEventTypeDone,
-		Partial: llm.Response{
-			Choices: []llm.Choice{{
-				Message: llm.Message{
-					Role:             llm.RoleAssistant,
-					Content:          text.String(),
-					ReasoningContent: reasoning.String(),
-					ToolCalls:        toolCalls,
-				},
-			}},
-			Usage: usage,
-		},
-	}, nil)
+	yield(llm.AssistantDone(text.String(), reasoning.String(), toolCalls, usage), nil)
 }
 
 func toLLMToolCall(p part, index int) llm.ToolCall {
@@ -391,22 +378,18 @@ func Compact(
 	req.DisableThinking(cfg.Name)
 	body, err := json.Marshal(req)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	request, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
-		// Non-streaming endpoint: the whole body is a single JSON response.
 		getURL(cfg.Name, cfg.BaseURL, cfg.APIKey, false),
 		bytes.NewReader(body),
 	)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
-	request.Header.Set("Content-Type", "application/json")
-	if strings.Contains(strings.ToLower(cfg.BaseURL), "aiplatform.googleapis.com") && cfg.APIKey != "" {
-		request.Header.Set("Authorization", "Bearer "+cfg.APIKey)
-	}
+	setGeminiAuth(request, cfg.BaseURL, cfg.APIKey)
 	httpResp, err := util.DoWithRetry(client, request)
 	if err != nil {
 		return "", err

--- a/internal/llm/gemini/client_test.go
+++ b/internal/llm/gemini/client_test.go
@@ -39,7 +39,7 @@ func TestGetStreamURL(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			url := getStreamURL(tc.model, tc.baseURL, tc.apiKey)
+			url := getURL(tc.model, tc.baseURL, tc.apiKey, true)
 			assert.Equal(t, tc.expect, url)
 		})
 	}

--- a/internal/llm/helpers.go
+++ b/internal/llm/helpers.go
@@ -1,0 +1,38 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// MarshalToolParams encodes tool parameters for provider wire formats.
+// empty is used when Params is nil/null (Anthropic wants "{}", Gemini wants
+// `{"type":"object"}`).
+func MarshalToolParams(params *FunctionParameters, empty string) json.RawMessage {
+	if empty == "" {
+		empty = "{}"
+	}
+	raw, err := json.Marshal(params)
+	if err != nil || len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return json.RawMessage(empty)
+	}
+	return raw
+}
+
+// AssistantDone builds the terminal stream event for an assistant turn.
+func AssistantDone(content, reasoning string, tools []ToolCall, usage Usage) StreamEvent {
+	return StreamEvent{
+		Type: StreamEventTypeDone,
+		Partial: Response{
+			Choices: []Choice{{
+				Message: Message{
+					Role:             RoleAssistant,
+					Content:          content,
+					ReasoningContent: reasoning,
+					ToolCalls:        tools,
+				},
+			}},
+			Usage: usage,
+		},
+	}
+}

--- a/internal/llm/helpers_test.go
+++ b/internal/llm/helpers_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMarshalToolParams(t *testing.T) {
 	assert.Equal(t, `{}`, string(MarshalToolParams(nil, "{}")))
-	assert.Equal(t, `{"type":"object"}`, string(MarshalToolParams(nil, `{"type":"object"}`)))
+	assert.JSONEq(t, `{"type":"object"}`, string(MarshalToolParams(nil, `{"type":"object"}`)))
 	raw := MarshalToolParams(&FunctionParameters{Type: "object", Properties: Object{}}, "{}")
 	assert.Contains(t, string(raw), `"type":"object"`)
 }

--- a/internal/llm/helpers_test.go
+++ b/internal/llm/helpers_test.go
@@ -1,0 +1,23 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalToolParams(t *testing.T) {
+	assert.Equal(t, `{}`, string(MarshalToolParams(nil, "{}")))
+	assert.Equal(t, `{"type":"object"}`, string(MarshalToolParams(nil, `{"type":"object"}`)))
+	raw := MarshalToolParams(&FunctionParameters{Type: "object", Properties: Object{}}, "{}")
+	assert.Contains(t, string(raw), `"type":"object"`)
+}
+
+func TestAssistantDone(t *testing.T) {
+	ev := AssistantDone("hi", "think", []ToolCall{{ID: "1", Function: Function{Name: "read"}}}, Usage{TotalTokens: 3})
+	assert.Equal(t, StreamEventTypeDone, ev.Type)
+	assert.Equal(t, "hi", ev.Partial.Choices[0].Message.Content)
+	assert.Equal(t, "think", ev.Partial.Choices[0].Message.ReasoningContent)
+	assert.Equal(t, 3, ev.Partial.Usage.TotalTokens)
+	assert.Len(t, ev.Partial.Choices[0].Message.ToolCalls, 1)
+}

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -39,27 +39,23 @@ type apiRequest struct {
 	Tools         []apiTool      `json:"tools,omitempty"`
 	Stream        bool           `json:"stream,omitempty"`
 	StreamOptions *streamOptions `json:"stream_options,omitempty"`
-	ExtraBody     *ExtraBody     `json:"extra_body,omitempty"`
+	ExtraBody     *extraBody     `json:"extra_body,omitempty"`
 }
 
-// ExtraBody holds provider-specific request fields (e.g. DeepSeek thinking).
-type ExtraBody struct {
-	Thinking *ThinkingConfig `json:"thinking,omitempty"`
+type extraBody struct {
+	Thinking *thinkingConfig `json:"thinking,omitempty"`
 }
 
-// ThinkingConfig enables reasoning mode.
-type ThinkingConfig struct {
+type thinkingConfig struct {
 	Type string `json:"type"`
 }
 
-// StreamChunk is a raw SSE chunk from the provider.
-type StreamChunk struct {
-	Choices []StreamChoice `json:"choices"`
+type streamChunk struct {
+	Choices []streamChoice `json:"choices"`
 	Usage   *llm.Usage     `json:"usage,omitempty"`
 }
 
-// StreamChoice is one streaming choice.
-type StreamChoice struct {
+type streamChoice struct {
 	Delta   llm.StreamDelta `json:"delta"`
 	Message *llm.Message    `json:"message,omitempty"`
 }
@@ -111,9 +107,9 @@ func BuildRequest(cfg llm.ModelConfig, system string, messages []llm.Message, to
 		apiTools[i] = apiTool{Type: "function", Function: t}
 	}
 
-	var extra *ExtraBody
+	var extra *extraBody
 	if isThinkingModeModel(cfg.Name) {
-		extra = &ExtraBody{Thinking: &ThinkingConfig{Type: "enabled"}}
+		extra = &extraBody{Thinking: &thinkingConfig{Type: "enabled"}}
 	}
 
 	return &apiRequest{
@@ -130,6 +126,26 @@ func isThinkingModeModel(model string) bool {
 	return strings.HasPrefix(strings.ToLower(model), "deepseek")
 }
 
+func chatCompletionsURL(baseURL string) string {
+	if strings.HasSuffix(baseURL, chatCompletionsPath) {
+		return baseURL
+	}
+	return baseURL + chatCompletionsPath
+}
+
+func newChatRequest(ctx context.Context, url, apiKey string, body []byte, stream bool) (*http.Request, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	if stream {
+		httpReq.Header.Set("Accept", util.ContentEventStream)
+	}
+	return httpReq, nil
+}
+
 // Compact sends a single non-streaming chat request and returns the assistant
 // text. Satisfies llm.Compactor for session compaction.
 func Compact(ctx context.Context, httpClient *http.Client, cfg llm.ModelConfig, prompt string) (string, error) {
@@ -141,17 +157,10 @@ func Compact(ctx context.Context, httpClient *http.Client, cfg llm.ModelConfig, 
 		return "", err
 	}
 
-	url := cfg.BaseURL
-	if !strings.HasSuffix(url, chatCompletionsPath) {
-		url += chatCompletionsPath
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	httpReq, err := newChatRequest(ctx, chatCompletionsURL(cfg.BaseURL), cfg.APIKey, body, false)
 	if err != nil {
 		return "", err
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+cfg.APIKey)
 
 	httpResp, err := util.DoWithRetry(httpClient, httpReq)
 	if err != nil {
@@ -192,19 +201,11 @@ func StreamChatCompletion(
 			return
 		}
 
-		url := baseURL
-		if !strings.HasSuffix(url, chatCompletionsPath) {
-			url += chatCompletionsPath
-		}
-
-		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		httpReq, err := newChatRequest(ctx, chatCompletionsURL(baseURL), apiKey, body, true)
 		if err != nil {
 			yield(llm.StreamEvent{}, err)
 			return
 		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-		httpReq.Header.Set("Accept", util.ContentEventStream)
 
 		httpResp, err := util.DoWithRetry(httpClient, httpReq)
 		if err != nil {
@@ -239,7 +240,7 @@ func StreamChatCompletion(
 				decodeData = bytes.ReplaceAll(decodeData, []byte("\t"), []byte(" "))
 			}
 
-			var chunk StreamChunk
+			var chunk streamChunk
 			if err := json.Unmarshal(decodeData, &chunk); err != nil {
 				continue
 			}


### PR DESCRIPTION
- Extract HTTP request builders (newMessagesHTTPRequest, newChatRequest, setGeminiAuth) to eliminate duplicated setup across providers
- Share tool-schema marshal via llm.MarshalToolParams and Done-event construction via llm.AssistantDone
- Return provider streams directly from client facade instead of re-yielding
- Make Gemini Compact propagate marshal/request errors instead of swallowing
- Rename internal types to unexported (extraBody, streamChunk, etc.)
- Switch client Stream/Compact from if-else to switch on provider