### PR TITLE
refactor(agent): single-source model state, move max rounds to options

### DIFF
--- a/cmd/runloop.go
+++ b/cmd/runloop.go
@@ -75,6 +75,9 @@ func runHeadless(opts runOptions) error {
 		agent.WithExtensions(extRunner),
 		agent.WithTools(opts.builtinTools),
 	}
+	if opts.maxRounds > 0 {
+		engineOpts = append(engineOpts, agent.WithMaxRounds(opts.maxRounds))
+	}
 	if pool, err := mcp.LoadPool(bs.Proj.MCPConfigFile()); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: mcp:", err)
 	} else if pool != nil {
@@ -113,12 +116,6 @@ func runHeadless(opts runOptions) error {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "phi run:", err)
 		return exitCode(ExitUsage)
-	}
-	if opts.maxRounds > 0 {
-		if err := engine.SetMaxRounds(opts.maxRounds); err != nil {
-			fmt.Fprintln(os.Stderr, "phi run:", err)
-			return exitCode(ExitUsage)
-		}
 	}
 
 	fmt.Fprintf(os.Stderr, "session: %s\n", engine.SessionID())

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -39,20 +39,18 @@ type ContinueFunc func(ctx context.Context, maxRounds int) (bool, error)
 // and yields session.Event for the TUI reducer. Context compaction is owned
 // here so Session stays a thin message store.
 type Engine struct {
-	client        *llmclient.Client
-	executor      *Executor
-	maxRounds     int
-	skillPath     string
-	contextWindow int
-	modelCfg      llm.ModelConfig
-	gate          permission.Gate
-	ask           permission.AskFunc
-	continueAsk   ContinueFunc
-	jobs          *job.Manager
-	extensions    *extension.Runner // nil = disabled; all methods are nil-safe no-ops
-	baseTools     []tools.Tool      // nil = DefaultTools; preserved across rebind
-	omitExtTools  bool              // sub-agents: emit events but skip RegisterTool merge
-	mcp           *mcp.Pool
+	client       *llmclient.Client
+	executor     *Executor
+	maxRounds    int
+	modelCfg     llm.ModelConfig
+	gate         permission.Gate
+	ask          permission.AskFunc
+	continueAsk  ContinueFunc
+	jobs         *job.Manager
+	extensions   *extension.Runner // nil = disabled; all methods are nil-safe no-ops
+	baseTools    []tools.Tool      // nil = DefaultTools; preserved across rebind
+	omitExtTools bool              // sub-agents: emit events but skip RegisterTool merge
+	mcp          *mcp.Pool
 
 	session *Session
 }
@@ -67,18 +65,16 @@ func NewEngine(model llm.ModelConfig, sess *Session, opts ...EngineOption) (*Eng
 		opt(&cfg)
 	}
 	engine := &Engine{
-		maxRounds:     defaultMaxToolRounds,
-		skillPath:     model.SkillPath,
-		contextWindow: model.ContextWindow,
-		modelCfg:      model,
-		session:       sess,
-		gate:          cfg.gate,
-		ask:           cfg.ask,
-		continueAsk:   cfg.continueAsk,
-		jobs:          cfg.jobs,
-		extensions:    cfg.extensions,
-		omitExtTools:  cfg.omitExtTools,
-		mcp:           cfg.mcp,
+		maxRounds:    defaultMaxToolRounds,
+		modelCfg:     model,
+		session:      sess,
+		gate:         cfg.gate,
+		ask:          cfg.ask,
+		continueAsk:  cfg.continueAsk,
+		jobs:         cfg.jobs,
+		extensions:   cfg.extensions,
+		omitExtTools: cfg.omitExtTools,
+		mcp:          cfg.mcp,
 	}
 	if cfg.maxRounds > 0 {
 		engine.maxRounds = cfg.maxRounds
@@ -136,12 +132,9 @@ func (engine *Engine) buildCoreTools(base []tools.Tool) []tools.Tool {
 
 // SetModel replaces the LLM client and model-related settings without
 // discarding the session tree. Agent tools remain registered when Jobs is set.
-func (engine *Engine) SetModel(cfg llm.ModelConfig) error {
+func (engine *Engine) SetModel(cfg llm.ModelConfig) {
 	engine.modelCfg = cfg
-	engine.skillPath = cfg.SkillPath
-	engine.contextWindow = cfg.ContextWindow
 	engine.rebindTools()
-	return nil
 }
 
 // SetJobs attaches or detaches the job manager and rebuilds the tool list.
@@ -174,7 +167,7 @@ func (engine *Engine) systemPrompt() string {
 	if engine.jobs != nil {
 		maxConcurrent = engine.jobs.MaxConcurrent()
 	}
-	return prompt.Build(engine.skillPath, engine.jobs != nil, maxConcurrent, mcpServers)
+	return prompt.Build(engine.modelCfg.SkillPath, engine.jobs != nil, maxConcurrent, mcpServers)
 }
 
 func (engine *Engine) bindExecutor(registry tools.Registry) {
@@ -189,27 +182,6 @@ func (engine *Engine) HasTool(name string) bool {
 	}
 	_, ok := engine.executor.registry[name]
 	return ok
-}
-
-// Jobs returns the process-level job manager, if any.
-func (engine *Engine) Jobs() *job.Manager {
-	if engine == nil {
-		return nil
-	}
-	return engine.jobs
-}
-
-// SetMaxRounds bounds the number of tool rounds per Loop call.
-// Non-positive values are rejected.
-func (engine *Engine) SetMaxRounds(n int) error {
-	if engine == nil {
-		return nil
-	}
-	if n <= 0 {
-		return fmt.Errorf("agent: max rounds must be positive (got %d)", n)
-	}
-	engine.maxRounds = n
-	return nil
 }
 
 // SetPermission updates the gate and ask handler used by the tool executor.
@@ -244,14 +216,6 @@ func (engine *Engine) SetExtensions(r *extension.Runner) {
 	engine.rebindTools()
 }
 
-// Extensions returns the current extension runner, if any.
-func (engine *Engine) Extensions() *extension.Runner {
-	if engine == nil {
-		return nil
-	}
-	return engine.extensions
-}
-
 // SessionID returns the durable session id.
 func (engine *Engine) SessionID() string {
 	if engine == nil || engine.session == nil {
@@ -274,18 +238,6 @@ func (engine *Engine) SessionCwd() string {
 		return ""
 	}
 	return engine.session.Cwd()
-}
-
-// ReplaceSession swaps the session store (used by /resume).
-func (engine *Engine) ReplaceSession(sess *Session) error {
-	if sess == nil {
-		return errors.New("agent: session is required")
-	}
-	engine.session = sess
-	if engine.executor != nil {
-		engine.executor.SetMeta(sess.ID(), sess.Cwd())
-	}
-	return nil
 }
 
 // Session returns the underlying session wrapper (for UI transcript replay).
@@ -318,7 +270,7 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 		if handled {
 			return
 		}
-		if instr := pendingSkillsInstruction(engine.skillPath, opts.PendingSkills); instr != "" {
+		if instr := pendingSkillsInstruction(engine.modelCfg.SkillPath, opts.PendingSkills); instr != "" {
 			if content == "" {
 				content = instr
 			} else {
@@ -428,25 +380,13 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 	}
 }
 
-// RunUntil is the reserved interface for task 007 (eval / until-goal): it
-// will run Loop repeatedly against a verifier until a goal predicate passes,
-// the budget is exhausted, or ctx is cancelled. Intentionally unimplemented
-// here — the verifier contract does not exist until the eval suite lands.
-//
-// Suggested shape (final signature TBD in 007):
-//
-//	func (engine *Engine) RunUntil(
-//		ctx context.Context,
-//		goal func(snapshot) bool,
-//		maxAttempts int,
-//	) (bool, error)
 func (engine *Engine) maybeCompact(
 	ctx context.Context,
 	yield func(session.Event, error) bool,
 	usage int,
 ) error {
 	settings := compaction.DefaultSettings()
-	if engine.client == nil || !compaction.ShouldCompact(usage, engine.contextWindow, settings) {
+	if engine.client == nil || !compaction.ShouldCompact(usage, engine.modelCfg.ContextWindow, settings) {
 		return nil
 	}
 	prep, err := compaction.PrepareCompact(engine.session.PathEntries(), settings)

--- a/internal/agent/engine_jobs_test.go
+++ b/internal/agent/engine_jobs_test.go
@@ -30,11 +30,9 @@ func TestNewEngineRegistersJobs(t *testing.T) {
 		agent.WithJobs(mgr),
 	)
 	require.NoError(t, err)
-	assert.Same(t, mgr, eng.Jobs())
 	assert.True(t, eng.HasTool("agent_spawn"))
 
-	require.NoError(t, eng.SetModel(llm.ModelConfig{Name: "fake2", BaseURL: "http://127.0.0.1:9", APIKey: "x"}))
-	assert.Same(t, mgr, eng.Jobs())
+	eng.SetModel(llm.ModelConfig{Name: "fake2", BaseURL: "http://127.0.0.1:9", APIKey: "x"})
 	assert.True(t, eng.HasTool("agent_spawn"))
 }
 
@@ -58,11 +56,9 @@ func TestSetJobsTogglesAgentTools(t *testing.T) {
 	assert.False(t, eng.HasTool("agent_spawn"))
 
 	eng.SetJobs(mgr)
-	assert.Same(t, mgr, eng.Jobs())
 	assert.True(t, eng.HasTool("agent_spawn"))
 
 	eng.SetJobs(nil)
-	assert.Nil(t, eng.Jobs())
 	assert.False(t, eng.HasTool("agent_spawn"))
 	assert.True(t, eng.HasTool("bash")) // default tools still present
 }

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -86,7 +86,7 @@ func countingTool(runs *atomic.Int32) tools.Tool {
 	}
 }
 
-func newRoundTestEngine(t *testing.T, serverURL string, runs *atomic.Int32) *Engine {
+func newRoundTestEngine(t *testing.T, serverURL string, runs *atomic.Int32, maxRounds int) *Engine {
 	t.Helper()
 	sess, err := NewSession(WithCwd(t.TempDir()))
 	require.NoError(t, err)
@@ -95,6 +95,7 @@ func newRoundTestEngine(t *testing.T, serverURL string, runs *atomic.Int32) *Eng
 		sess,
 		WithGate(permission.AllowAll{}),
 		WithTools([]tools.Tool{countingTool(runs)}),
+		WithMaxRounds(maxRounds),
 	)
 	require.NoError(t, err)
 	return engine
@@ -105,8 +106,7 @@ func TestLoopMaxRoundsAllowsFinalAnswerAfterLastToolRound(t *testing.T) {
 	defer server.Close()
 
 	var runs atomic.Int32
-	engine := newRoundTestEngine(t, server.URL, &runs)
-	require.NoError(t, engine.SetMaxRounds(2))
+	engine := newRoundTestEngine(t, server.URL, &runs, 2)
 
 	var lastErr error
 	var finalText string
@@ -130,8 +130,7 @@ func TestLoopMaxRoundsDoesNotExecuteExtraToolRound(t *testing.T) {
 	defer server.Close()
 
 	var runs atomic.Int32
-	engine := newRoundTestEngine(t, server.URL, &runs)
-	require.NoError(t, engine.SetMaxRounds(2))
+	engine := newRoundTestEngine(t, server.URL, &runs, 2)
 
 	var lastErr error
 	for ev, err := range engine.Loop(t.Context(), "go", LoopOpts{}) {
@@ -168,13 +167,13 @@ func TestLoopContinueAskGrantsAnotherBudget(t *testing.T) {
 		llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
 		sess,
 		WithGate(permission.AllowAll{}),
+		WithMaxRounds(1),
 		WithContinueAsk(func(context.Context, int) (bool, error) {
 			// Approve once so the loop can start a second budget window, then stop.
 			return asks.Add(1) == 1, nil
 		}),
 	)
 	require.NoError(t, err)
-	require.NoError(t, engine.SetMaxRounds(1))
 
 	var lastErr error
 	for ev, err := range engine.Loop(t.Context(), "go", LoopOpts{}) {
@@ -199,12 +198,12 @@ func TestLoopContinueAskDeclineReturnsErrMaxRounds(t *testing.T) {
 		llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
 		sess,
 		WithGate(permission.AllowAll{}),
+		WithMaxRounds(1),
 		WithContinueAsk(func(context.Context, int) (bool, error) {
 			return false, nil
 		}),
 	)
 	require.NoError(t, err)
-	require.NoError(t, engine.SetMaxRounds(1))
 
 	var lastErr error
 	for ev, err := range engine.Loop(t.Context(), "go", LoopOpts{}) {
@@ -215,18 +214,4 @@ func TestLoopContinueAskDeclineReturnsErrMaxRounds(t *testing.T) {
 		}
 	}
 	require.ErrorIs(t, lastErr, ErrMaxRounds)
-}
-
-func TestSetMaxRoundsRejectsNonPositive(t *testing.T) {
-	sess, err := NewSession(WithCwd(t.TempDir()))
-	require.NoError(t, err)
-	engine, err := NewEngine(
-		llm.ModelConfig{Name: "fake", BaseURL: "http://unused", APIKey: "x"},
-		sess,
-		WithGate(permission.AllowAll{}),
-	)
-	require.NoError(t, err)
-	require.Error(t, engine.SetMaxRounds(0))
-	require.Error(t, engine.SetMaxRounds(-1))
-	require.NoError(t, engine.SetMaxRounds(1))
 }

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -73,18 +73,18 @@ func TestEngineSetModelKeepsSession(t *testing.T) {
 	require.NoError(t, eng.session.Append(llm.Message{Role: llm.RoleAssistant, Content: "ok"}))
 	n := eng.session.Len()
 
-	require.NoError(t, eng.SetModel(llm.ModelConfig{
+	eng.SetModel(llm.ModelConfig{
 		Name:          "model-b",
 		APIKey:        "k",
 		BaseURL:       "http://example",
 		ContextWindow: 8192,
 		SkillPath:     dir,
-	}))
+	})
 	assert.Equal(t, id, eng.SessionID())
 	assert.Equal(t, file, eng.SessionFile())
 	assert.Equal(t, n, eng.session.Len())
-	assert.Equal(t, 8192, eng.contextWindow)
-	assert.Equal(t, dir, eng.skillPath)
+	assert.Equal(t, 8192, eng.modelCfg.ContextWindow)
+	assert.Equal(t, dir, eng.modelCfg.SkillPath)
 }
 
 func splitFirstJSONL(b []byte) []byte {

--- a/internal/tui/controller/controller.go
+++ b/internal/tui/controller/controller.go
@@ -484,9 +484,7 @@ func (c *EngineController) SetModel(name string) error {
 	if _, _, err := c.ReloadExtensions(); err != nil {
 		debuglog.Logf("extension: reload on SetModel: %v", err)
 	}
-	if err := c.engine.SetModel(cfg); err != nil {
-		return err
-	}
+	c.engine.SetModel(cfg)
 	c.modelCfg = cfg
 	return nil
 }


### PR DESCRIPTION
- read skillPath/contextWindow from modelCfg; SetModel no longer errors
- configure tool-round budget via WithMaxRounds, drop SetMaxRounds
- remove unused Jobs/Extensions getters, ReplaceSession, RunUntil stub