### PR TITLE
fix(agent): compact and retry on mid-loop context overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Agent: mid-loop context-window overflow (`prompt is too long` and similar
+  provider errors) now force-compacts once and retries the stream instead of
+  failing the turn cold. A second overflow still fails closed. (`agent`, `llm`)
+
 ### Security
 
 <!-- Released section -->

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -260,8 +260,11 @@ type LoopOpts struct {
 // Loop appends the user prompt and runs inference + tool rounds until the
 // model stops calling tools or the context is cancelled.
 //
-// Compaction: persist the turn first, then check usage after
-// the agent turn ends (final assistant with no tool_calls) — never mid-tool-loop.
+// Compaction runs in two places:
+//  1. After a finished turn (final assistant with no tool_calls), when usage
+//     crosses the context-window threshold.
+//  2. Mid-loop on a context-overflow API error: force-compact once, rebuild
+//     context, and retry the stream. A second overflow fails closed.
 func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) iter.Seq2[session.Event, error] {
 	return func(yield func(session.Event, error) bool) {
 		// The extension runner is nil-safe (nil = disabled), so calls are
@@ -294,6 +297,7 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 		}
 
 		toolRounds := 0
+		overflowRecovered := false
 		for {
 			if ctx.Err() != nil {
 				return
@@ -303,8 +307,20 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 
 			msgs := engine.session.BuildContext()
 
-			msg, completeEvent, ok := engine.streamTurn(ctx, yield, msgs)
-			if !ok {
+			msg, completeEvent, err := engine.streamTurn(ctx, yield, msgs)
+			if err != nil {
+				if !overflowRecovered && llm.IsContextOverflow(err) {
+					did, cerr := engine.runCompact(ctx, yield, 0, true)
+					if cerr == nil && did {
+						overflowRecovered = true
+						continue
+					}
+				}
+				yield(nil, err)
+				return
+			}
+			if completeEvent == nil {
+				// Cancelled or consumer stopped — no error to surface.
 				return
 			}
 
@@ -316,9 +332,9 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 					yield(nil, fmt.Errorf("agent: %w (%d)", ErrMaxRounds, engine.maxRounds))
 					return
 				}
-				ok, err := engine.continueAsk(ctx, engine.maxRounds)
-				if err != nil {
-					yield(nil, err)
+				ok, askErr := engine.continueAsk(ctx, engine.maxRounds)
+				if askErr != nil {
+					yield(nil, askErr)
 					return
 				}
 				if !ok {
@@ -354,7 +370,7 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 					continue
 				}
 				// Turn finished — compact using this assistant's usage.
-				if err := engine.maybeCompact(ctx, yield, msg.Usage.TotalTokens); err != nil {
+				if _, err := engine.runCompact(ctx, yield, msg.Usage.TotalTokens, false); err != nil {
 					yield(nil, err)
 				}
 				return
@@ -380,32 +396,45 @@ func (engine *Engine) Loop(ctx context.Context, prompt string, opts LoopOpts) it
 	}
 }
 
-func (engine *Engine) maybeCompact(
+// runCompact prepares and persists a compaction entry.
+// When force is false, it no-ops unless usage crosses the window threshold.
+// When force is true (overflow recovery), it skips the threshold check but
+// still no-ops when there is nothing useful to summarize (avoids burning the
+// single overflow retry on a no-op compact).
+// did is true only when a compaction entry was appended.
+func (engine *Engine) runCompact(
 	ctx context.Context,
 	yield func(session.Event, error) bool,
 	usage int,
-) error {
+	force bool,
+) (did bool, err error) {
 	settings := compaction.DefaultSettings()
-	if engine.client == nil || !compaction.ShouldCompact(usage, engine.modelCfg.ContextWindow, settings) {
-		return nil
+	if engine.client == nil {
+		return false, nil
+	}
+	if !force && !compaction.ShouldCompact(usage, engine.modelCfg.ContextWindow, settings) {
+		return false, nil
 	}
 	prep, err := compaction.PrepareCompact(engine.session.PathEntries(), settings)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if prep.FirstKeptEntryId == "" {
-		return nil
+		return false, nil
+	}
+	if force && len(prep.MessagesToSummarize) == 0 && len(prep.TurnPrefixMessages) == 0 {
+		return false, nil
 	}
 
 	id := fmt.Sprintf("compaction-%d", time.Now().UnixNano())
 	if !yield(session.CompactionStarted{}, nil) {
-		return context.Canceled
+		return false, context.Canceled
 	}
 
 	result, err := compaction.Compact(ctx, *prep, engine.client)
 	if err != nil {
 		_ = yield(session.CompactionComplete{ID: id, Failed: true}, nil)
-		return err
+		return false, err
 	}
 	if err := engine.session.AppendCompaction(session.Compaction{
 		Summary:          result.Summary,
@@ -414,20 +443,25 @@ func (engine *Engine) maybeCompact(
 		Details:          result.Details,
 	}); err != nil {
 		_ = yield(session.CompactionComplete{ID: id, Failed: true}, nil)
-		return err
+		return false, err
 	}
 	if !yield(session.CompactionComplete{ID: id}, nil) {
-		return context.Canceled
+		return false, context.Canceled
 	}
 	engine.extensions.EmitSessionCompact("auto")
-	return nil
+	return true, nil
 }
 
+// streamTurn runs one assistant stream. On success it returns the final
+// message and a StateComplete event (not yet yielded — caller checks tool
+// budget first). On API/stream failure it returns err without yielding it
+// so Loop can attempt overflow recovery. A nil event with nil err means
+// cancel or the consumer stopped receiving.
 func (engine *Engine) streamTurn(
 	ctx context.Context,
 	yield func(session.Event, error) bool,
 	messages []llm.Message,
-) (llm.Message, session.Event, bool) {
+) (llm.Message, session.Event, error) {
 	id := fmt.Sprintf("assistant-%d", time.Now().UnixNano())
 	var thinking, text string
 	var final llm.Message
@@ -438,8 +472,7 @@ func (engine *Engine) streamTurn(
 			if thinking != "" || text != "" {
 				_ = yield(emitMessage(id, session.StateError, session.StopNone, thinking, text, nil, llm.Usage{}), nil)
 			}
-			yield(nil, err)
-			return llm.Message{}, nil, false
+			return llm.Message{}, nil, err
 		}
 
 		switch event.Type {
@@ -448,8 +481,7 @@ func (engine *Engine) streamTurn(
 			if errText == "" {
 				errText = "stream error"
 			}
-			yield(nil, fmt.Errorf("%s", errText))
-			return llm.Message{}, nil, false
+			return llm.Message{}, nil, fmt.Errorf("%s", errText)
 
 		case llm.StreamEventTypeDelta:
 			if event.Delta.ReasoningContent != "" {
@@ -462,13 +494,12 @@ func (engine *Engine) streamTurn(
 				emitMessage(id, session.StateStreaming, session.StopNone, thinking, text, nil, llm.Usage{}),
 				nil,
 			) {
-				return llm.Message{}, nil, false
+				return llm.Message{}, nil, nil
 			}
 
 		case llm.StreamEventTypeDone:
 			if len(event.Partial.Choices) == 0 {
-				yield(nil, errors.New("agent: stream finished with no assistant choice"))
-				return llm.Message{}, nil, false
+				return llm.Message{}, nil, errors.New("agent: stream finished with no assistant choice")
 			}
 			final = event.Partial.Choices[0].Message
 			final.Usage = event.Partial.Usage
@@ -486,10 +517,9 @@ func (engine *Engine) streamTurn(
 	if !gotDone {
 		if ctx.Err() != nil {
 			_ = yield(emitMessage(id, session.StateCancelled, session.StopNone, thinking, text, nil, llm.Usage{}), nil)
-			return llm.Message{}, nil, false
+			return llm.Message{}, nil, nil
 		}
-		yield(nil, errors.New("agent: stream closed without assistant output"))
-		return llm.Message{}, nil, false
+		return llm.Message{}, nil, errors.New("agent: stream closed without assistant output")
 	}
 
 	blocks := engine.toolCallsToBlocks(final.ToolCalls)
@@ -498,7 +528,7 @@ func (engine *Engine) streamTurn(
 		reason = session.StopToolUse
 	}
 	complete := emitMessage(id, session.StateComplete, reason, thinking, text, blocks, final.Usage)
-	return final, complete, true
+	return final, complete, nil
 }
 
 func (engine *Engine) toolCallsToBlocks(calls []llm.ToolCall) []session.ContentBlock {

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -215,3 +215,167 @@ func TestLoopContinueAskDeclineReturnsErrMaxRounds(t *testing.T) {
 	}
 	require.ErrorIs(t, lastErr, ErrMaxRounds)
 }
+
+// overflowThenOKServer fails the first streaming chat with a context overflow,
+// serves a non-stream compact summary, then streams a final text reply.
+func overflowThenOKServer(streamHits *atomic.Int32) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if stream, _ := body["stream"].(bool); stream {
+			n := streamHits.Add(1)
+			if n == 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"message":"prompt is too long: 210000 > 200000 tokens"}}`))
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = fmt.Fprint(w, sseTextChunk("recovered"))
+			_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+			return
+		}
+		// Compaction Compact() is non-streaming chat.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []any{map[string]any{
+				"message": map[string]any{"role": "assistant", "content": "prior work summarized"},
+			}},
+		})
+	}))
+}
+
+func TestLoopOverflowCompactsAndRetries(t *testing.T) {
+	var streamHits atomic.Int32
+	server := overflowThenOKServer(&streamHits)
+	defer server.Close()
+
+	sess, err := NewSession(WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	// Seed enough prior usage that force-compact has a summarizable prefix
+	// (default keepRecentTokens is 20k).
+	require.NoError(t, sess.Append(
+		llm.Message{Role: llm.RoleUser, Content: "old1", Usage: llm.Usage{TotalTokens: 12000}},
+		llm.Message{Role: llm.RoleAssistant, Content: "old2", Usage: llm.Usage{TotalTokens: 12000}},
+		llm.Message{Role: llm.RoleUser, Content: "old3", Usage: llm.Usage{TotalTokens: 5000}},
+		llm.Message{Role: llm.RoleAssistant, Content: "old4", Usage: llm.Usage{TotalTokens: 5000}},
+	))
+
+	engine, err := NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x", ContextWindow: 200_000},
+		sess,
+		WithGate(permission.AllowAll{}),
+		WithTools([]tools.Tool{}),
+	)
+	require.NoError(t, err)
+
+	var lastErr error
+	var finalText string
+	var sawCompact bool
+	for ev, err := range engine.Loop(t.Context(), "continue", LoopOpts{}) {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		switch e := ev.(type) {
+		case session.CompactionStarted:
+			sawCompact = true
+		case session.AssistantMessageUpdate:
+			if e.Message.State == session.StateComplete {
+				finalText = e.Message.FlatText()
+			}
+		}
+	}
+	require.NoError(t, lastErr)
+	require.True(t, sawCompact, "expected overflow path to emit CompactionStarted")
+	require.Equal(t, int32(2), streamHits.Load(), "overflow then one retry stream")
+	require.Equal(t, "recovered", finalText)
+}
+
+func TestLoopOverflowFailsClosedAfterOneRetry(t *testing.T) {
+	var streamHits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if stream, _ := body["stream"].(bool); stream {
+			streamHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"prompt is too long: 210000 > 200000 tokens"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []any{map[string]any{
+				"message": map[string]any{"role": "assistant", "content": "summary"},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	sess, err := NewSession(WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	require.NoError(t, sess.Append(
+		llm.Message{Role: llm.RoleUser, Content: "old1", Usage: llm.Usage{TotalTokens: 12000}},
+		llm.Message{Role: llm.RoleAssistant, Content: "old2", Usage: llm.Usage{TotalTokens: 12000}},
+		llm.Message{Role: llm.RoleUser, Content: "old3", Usage: llm.Usage{TotalTokens: 5000}},
+		llm.Message{Role: llm.RoleAssistant, Content: "old4", Usage: llm.Usage{TotalTokens: 5000}},
+	))
+
+	engine, err := NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x", ContextWindow: 200_000},
+		sess,
+		WithGate(permission.AllowAll{}),
+		WithTools([]tools.Tool{}),
+	)
+	require.NoError(t, err)
+
+	var lastErr error
+	for ev, err := range engine.Loop(t.Context(), "continue", LoopOpts{}) {
+		_ = ev
+		if err != nil {
+			lastErr = err
+			break
+		}
+	}
+	require.Error(t, lastErr)
+	require.True(t, llm.IsContextOverflow(lastErr))
+	require.Equal(t, int32(2), streamHits.Load(), "one recovery attempt then fail")
+}
+
+func TestLoopNonOverflowErrorDoesNotCompact(t *testing.T) {
+	var streamHits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		streamHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"Incorrect API key provided"}}`))
+	}))
+	defer server.Close()
+
+	sess, err := NewSession(WithCwd(t.TempDir()))
+	require.NoError(t, err)
+	engine, err := NewEngine(
+		llm.ModelConfig{Name: "fake", BaseURL: server.URL, APIKey: "x"},
+		sess,
+		WithGate(permission.AllowAll{}),
+		WithTools([]tools.Tool{}),
+	)
+	require.NoError(t, err)
+
+	var lastErr error
+	var sawCompact bool
+	for ev, err := range engine.Loop(t.Context(), "go", LoopOpts{}) {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		if _, ok := ev.(session.CompactionStarted); ok {
+			sawCompact = true
+		}
+	}
+	require.Error(t, lastErr)
+	require.False(t, llm.IsContextOverflow(lastErr))
+	require.False(t, sawCompact)
+	require.Equal(t, int32(1), streamHits.Load())
+}

--- a/internal/llm/overflow.go
+++ b/internal/llm/overflow.go
@@ -1,0 +1,64 @@
+package llm
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Provider error text that means the prompt exceeded the model context window.
+var overflowPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)prompt is too long`),
+	regexp.MustCompile(`(?i)request_too_large`),
+	regexp.MustCompile(`(?i)input is too long for requested model`),
+	regexp.MustCompile(`(?i)exceeds the context window`),
+	regexp.MustCompile(`(?i)exceeds (?:the )?(?:model'?s )?maximum context length`),
+	regexp.MustCompile(`(?i)input token count.*exceeds the maximum`),
+	regexp.MustCompile(`(?i)maximum prompt length is \d+`),
+	regexp.MustCompile(`(?i)reduce the length of the messages`),
+	regexp.MustCompile(`(?i)maximum context length is \d+ tokens`),
+	regexp.MustCompile(`(?i)exceeds (?:the )?maximum allowed input length`),
+	regexp.MustCompile(`(?i)input \(\d+ tokens\) is longer than the model'?s context length`),
+	regexp.MustCompile(`(?i)exceeds the limit of \d+`),
+	regexp.MustCompile(`(?i)exceeds the available context size`),
+	regexp.MustCompile(`(?i)greater than the context length`),
+	regexp.MustCompile(`(?i)context window exceeds limit`),
+	regexp.MustCompile(`(?i)exceeded model token limit`),
+	regexp.MustCompile(`(?i)too large for model with \d+ maximum context length`),
+	regexp.MustCompile(`(?i)model_context_window_exceeded`),
+	regexp.MustCompile(`(?i)prompt too long; exceeded (?:max )?context length`),
+	regexp.MustCompile(`(?i)context[_ ]length[_ ]exceeded`),
+	regexp.MustCompile(`(?i)token limit exceeded`),
+	regexp.MustCompile(`(?i)too many tokens`),
+}
+
+// Errors that can match a broad overflow pattern but are not overflows
+// (e.g. throttling that says "too many tokens").
+var nonOverflowPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)^(Throttling error|Service unavailable):`),
+	regexp.MustCompile(`(?i)rate limit`),
+	regexp.MustCompile(`(?i)too many requests`),
+	regexp.MustCompile(`(?i)please wait before trying again`),
+}
+
+// IsContextOverflow reports whether err is a provider context-window overflow.
+// Nil and empty messages are false.
+func IsContextOverflow(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.TrimSpace(err.Error())
+	if msg == "" {
+		return false
+	}
+	for _, p := range nonOverflowPatterns {
+		if p.MatchString(msg) {
+			return false
+		}
+	}
+	for _, p := range overflowPatterns {
+		if p.MatchString(msg) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/llm/overflow_test.go
+++ b/internal/llm/overflow_test.go
@@ -19,17 +19,31 @@ func TestIsContextOverflow(t *testing.T) {
 		{name: "unrelated", err: errors.New("connection reset"), want: false},
 		{
 			name: "claude prompt too long",
-			err:  FormatAPIError("anthropic", 400, []byte(`{"error":{"message":"prompt is too long: 210000 > 200000 tokens"}}`)),
+			err: FormatAPIError(
+				"anthropic",
+				400,
+				[]byte(`{"error":{"message":"prompt is too long: 210000 > 200000 tokens"}}`),
+			),
 			want: true,
 		},
 		{
 			name: "openai-compatible context window",
-			err:  FormatAPIError("LLM", 400, []byte(`{"error":{"message":"Your input exceeds the context window of this model"}}`)),
+			err: FormatAPIError(
+				"LLM",
+				400,
+				[]byte(`{"error":{"message":"Your input exceeds the context window of this model"}}`),
+			),
 			want: true,
 		},
 		{
 			name: "gemini token count",
-			err:  FormatAPIError("gemini", 400, []byte(`{"error":{"message":"The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)"}}`)),
+			err: FormatAPIError(
+				"gemini",
+				400,
+				[]byte(
+					`{"error":{"message":"The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)"}}`,
+				),
+			),
 			want: true,
 		},
 		{
@@ -44,7 +58,7 @@ func TestIsContextOverflow(t *testing.T) {
 		},
 		{
 			name: "throttling excluded",
-			err:  errors.New("Throttling error: Too many tokens, please wait before trying again."),
+			err:  errors.New("throttling error: too many tokens, please wait before trying again"),
 			want: false,
 		},
 		{

--- a/internal/llm/overflow_test.go
+++ b/internal/llm/overflow_test.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsContextOverflow(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "empty", err: errors.New(""), want: false},
+		{name: "unrelated", err: errors.New("connection reset"), want: false},
+		{
+			name: "claude prompt too long",
+			err:  FormatAPIError("anthropic", 400, []byte(`{"error":{"message":"prompt is too long: 210000 > 200000 tokens"}}`)),
+			want: true,
+		},
+		{
+			name: "openai-compatible context window",
+			err:  FormatAPIError("LLM", 400, []byte(`{"error":{"message":"Your input exceeds the context window of this model"}}`)),
+			want: true,
+		},
+		{
+			name: "gemini token count",
+			err:  FormatAPIError("gemini", 400, []byte(`{"error":{"message":"The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)"}}`)),
+			want: true,
+		},
+		{
+			name: "generic context_length_exceeded",
+			err:  errors.New("context_length_exceeded"),
+			want: true,
+		},
+		{
+			name: "rate limit excluded",
+			err:  errors.New("rate limit: too many tokens"),
+			want: false,
+		},
+		{
+			name: "throttling excluded",
+			err:  errors.New("Throttling error: Too many tokens, please wait before trying again."),
+			want: false,
+		},
+		{
+			name: "wrapped overflow",
+			err:  fmt.Errorf("stream: %w", errors.New("prompt is too long: 1 > 0")),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsContextOverflow(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
When a tool round hits a provider context-window overflow ("prompt is too long" etc.), force-compact once and retry the stream instead of failing the turn cold. A second overflow still fails closed.

Add llm.IsContextOverflow to recognize provider overflow errors, and rework maybeCompact into runCompact(force) so overflow recovery reuses the normal compaction path.