### PR TITLE
feat(agent): per-role model defaults for sub-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Sub-agents: optional per-role model defaults in `agents.models` (`explore` /
+  `review` / `worker`). Palette: settings → agents → models → role → model
+  (session-only; `(inherit parent)` clears). Omitted roles inherit the parent
+  model. (`project`, `agent`, `tui`)
+
 ### Changed
 
 - Sub-agents: child gates use `BashDefault=Allow` (hard deny list still applies), so explore/review/worker can run non-allowlisted shell (`make`, pipelines, tests) without Ask→Deny folding. Role hints and parent spawn guidance emphasize task contracts (recon / review report / scoped implement) rather than allowlisted bash. Hard deny now also blocks piping into `sh`/`bash`.
@@ -23,6 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Agent: mid-loop context-window overflow (`prompt is too long` and similar
   provider errors) now force-compacts once and retries the stream instead of
   failing the turn cold. A second overflow still fails closed. (`agent`, `llm`)
+- Config: `agents.enabled` omitted under an `agents:` block (e.g. only
+  `agents.models` set) no longer decodes as false; default stays on. (`project`)
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ skill_path: ~/.phi/skills # where SKILL.md files are loaded from
 
 agents:
   enabled: true           # default; set false to disable agent_* sub-agent tools
+  models:                 # optional per-role defaults; omit → inherit parent model
+    explore: cheap-model
+    review: strong-model
+    worker: coding-model
 
 permissions:
   mode: interactive       # interactive | readonly | autopilot | headless-strict
@@ -213,7 +217,7 @@ The editor supports:
 - `?` — shortcut help picker (lists `/`, `!`, `@`, and key bindings; `Esc` closes)
 - `!command` — run a shell command locally and stream its output into the
   transcript (see [Commands](#commands))
-- `Ctrl+K` — command palette: settings → model / theme / permissions / agents, skills, hooks
+- `Ctrl+K` — command palette: settings → model / theme / permissions / agents (incl. per-role models), skills, hooks
 
 ### Keyboard shortcuts
 
@@ -428,6 +432,12 @@ agents:
 
 Or toggle for the current session via the palette: settings → agents.
 When disabled, those tools are not registered and the model cannot spawn jobs.
+
+Per-role model defaults (optional) under `agents.models` pick which configured
+model name each role uses when spawned. Omitted roles inherit the parent
+session model. Switch for the current session only via
+settings → agents → models → explore|review|worker (same session-only semantics
+as settings → model; does not write `config.yaml`).
 
 Sub-agents themselves use a **role** (`explore` default | `review` | `worker`):
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -65,7 +65,16 @@ type bashDoc struct {
 }
 
 type agentsDoc struct {
-	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Enabled is a pointer so omitting the key in YAML/JSON keeps default-on
+	// when only agents.models is set.
+	Enabled *bool            `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Models  *agentsModelsDoc `yaml:"models,omitempty"  json:"models,omitempty"`
+}
+
+type agentsModelsDoc struct {
+	Explore string `yaml:"explore,omitempty" json:"explore,omitempty"`
+	Review  string `yaml:"review,omitempty"  json:"review,omitempty"`
+	Worker  string `yaml:"worker,omitempty"  json:"worker,omitempty"`
 }
 
 type modelListRequest struct {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -64,7 +64,8 @@ func TestConfigHandlerGETAndRoundTrip(t *testing.T) {
 	require.NotNil(t, got.Permissions.Bash)
 	assert.Equal(t, []string{"^git "}, got.Permissions.Bash.Allow)
 	require.NotNil(t, got.Agents)
-	assert.False(t, got.Agents.Enabled)
+	require.NotNil(t, got.Agents.Enabled)
+	assert.False(t, *got.Agents.Enabled)
 	assert.Equal(t, path, got.Path)
 
 	// Edit: drop model-b and change the api_key, keep permissions untouched.

--- a/cmd/runloop.go
+++ b/cmd/runloop.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/pulseaiclub/phi/internal/agent"
 	"github.com/pulseaiclub/phi/internal/extension"
+	"github.com/pulseaiclub/phi/internal/job"
+	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/mcp"
 	"github.com/pulseaiclub/phi/internal/session"
 	"github.com/pulseaiclub/phi/internal/tools"
@@ -85,7 +87,23 @@ func runHeadless(opts runOptions) error {
 		defer func() { _ = pool.Close() }()
 	}
 	if bs.Config.Agents.Enabled {
-		jobs, jobErr := agent.NewJobManager(bs.Proj.JobsDir(), bs.Config.Model(), nil, func() *extension.Runner {
+		parent := bs.Config.Model()
+		jobs, jobErr := agent.NewJobManager(bs.Proj.JobsDir(), parent, func(role job.Role) llm.ModelConfig {
+			m := bs.Config.Agents.Models
+			var name string
+			switch job.NormalizeRole(string(role)) {
+			case job.RoleReview:
+				name = m.Review
+			case job.RoleWorker:
+				name = m.Worker
+			default:
+				name = m.Explore
+			}
+			if cfg, ok := bs.Config.FindModel(name); ok {
+				return cfg
+			}
+			return parent
+		}, func() *extension.Runner {
 			return extRunner
 		})
 		if jobErr != nil {

--- a/doc/tui.md
+++ b/doc/tui.md
@@ -198,7 +198,8 @@ Composer input is blocked while an overlay is active (`OverlayBlocksComposer`).
   → ExtCommands (async) → ExtCommandResultMsg → palette push / toast
 ```
 
-`commandBridge` in `editor` builds `commands.CommandContext` for builtins (model switch, theme, permissions, …).
+`commandBridge` in `editor` builds `commands.CommandContext` for builtins
+(model switch, theme, permissions, agents on/off + per-role models, …).
 
 ### 6. Background chrome
 

--- a/internal/agent/engine_runner.go
+++ b/internal/agent/engine_runner.go
@@ -21,17 +21,18 @@ import (
 // <job.Dir>/session/, ParentID from the job, and no Ask handler.
 // Child engines do not receive Jobs, so they have no agent_* tools.
 // Role (explore|worker|review) selects tools and default permission mode
-// when Gate/Tools are nil.
+// when Gate/Tools are nil. ModelFn (when set) selects the model per role;
+// otherwise Model is used as a fixed snapshot.
 //
 // Extensions (or ExtensionsFn) are inherited from the parent so policy
 // tool_call handlers apply. Extension RegisterTool tools are not merged
 // into child engines. ExtensionsFn wins when set (live reload).
 type EngineRunner struct {
 	Model        llm.ModelConfig
-	ModelFn      func() llm.ModelConfig // if set, preferred over Model
-	Gate         permission.Gate        // nil → SpecForRole(job.Role).Mode on WorkDir
-	Tools        []tools.Tool           // nil → SpecForRole(job.Role).Tools
-	MaxRounds    int                    // 0 → Engine default
+	ModelFn      func(role job.Role) llm.ModelConfig // if set, preferred over Model
+	Gate         permission.Gate                     // nil → SpecForRole(job.Role).Mode on WorkDir
+	Tools        []tools.Tool                        // nil → SpecForRole(job.Role).Tools
+	MaxRounds    int                                 // 0 → Engine default
 	Extensions   *extension.Runner
 	ExtensionsFn func() *extension.Runner
 }
@@ -65,7 +66,7 @@ func (r EngineRunner) Run(ctx context.Context, env job.RunEnv) (string, error) {
 
 	model := r.Model
 	if r.ModelFn != nil {
-		model = r.ModelFn()
+		model = r.ModelFn(env.Job.Role)
 	}
 
 	extRunner := r.Extensions

--- a/internal/agent/jobs.go
+++ b/internal/agent/jobs.go
@@ -9,13 +9,14 @@ import (
 )
 
 // NewJobManager creates a process-level job manager whose runner drives child Engines.
-// modelFn may be nil; then model is used as a fixed snapshot.
+// modelFn may be nil; then model is used as a fixed snapshot for every role.
+// When set, modelFn receives the job role so callers can pick per-role models.
 // extensionsFn supplies extensions for child engines (may return nil); prefer a live
 // getter so TUI reload updates sub-agents too.
 func NewJobManager(
 	root string,
 	model llm.ModelConfig,
-	modelFn func() llm.ModelConfig,
+	modelFn func(role job.Role) llm.ModelConfig,
 	extensionsFn func() *extension.Runner,
 ) (*job.Manager, error) {
 	if root == "" {

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -28,6 +28,16 @@ type Config struct {
 // to keep ordinary sessions lean and avoid loading the extra tool schemas.
 type AgentsConfig struct {
 	Enabled bool // true when absent from config
+	// Models names optional per-role defaults (explore|review|worker).
+	// Empty → inherit the parent session model.
+	Models AgentsRoleModels
+}
+
+// AgentsRoleModels maps sub-agent roles to configured model names.
+type AgentsRoleModels struct {
+	Explore string `yaml:"explore"`
+	Review  string `yaml:"review"`
+	Worker  string `yaml:"worker"`
 }
 
 // Model returns the default model config with the skill path applied, ready
@@ -149,7 +159,16 @@ func parseConfigFile(path string) (*Config, error) {
 		applyPermissions(&cfg.Permissions, raw.Permissions)
 	}
 	if raw.Agents != nil {
-		cfg.Agents.Enabled = raw.Agents.Enabled
+		if raw.Agents.Enabled != nil {
+			cfg.Agents.Enabled = *raw.Agents.Enabled
+		}
+		if raw.Agents.Models != nil {
+			cfg.Agents.Models = AgentsRoleModels{
+				Explore: strings.TrimSpace(raw.Agents.Models.Explore),
+				Review:  strings.TrimSpace(raw.Agents.Models.Review),
+				Worker:  strings.TrimSpace(raw.Agents.Models.Worker),
+			}
+		}
 	}
 	return cfg, nil
 }
@@ -171,7 +190,9 @@ type fileConfig struct {
 }
 
 type agentsConfig struct {
-	Enabled bool `yaml:"enabled"`
+	// Enabled is a pointer so omitting the key keeps the default (on).
+	Enabled *bool             `yaml:"enabled"`
+	Models  *AgentsRoleModels `yaml:"models"`
 }
 
 type modelEntry struct {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -189,6 +189,64 @@ agents:
 	assert.False(t, p.Config().Agents.Enabled)
 }
 
+func TestLoadConfigAgentsModelsOmitsEnabledKeepsDefaultOn(t *testing.T) {
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
+models:
+  - name: m
+    api_key: k
+agents:
+  models:
+    explore: m
+`), 0o644))
+
+	require.NoError(t, p.LoadConfig())
+	assert.True(t, p.Config().Agents.Enabled)
+	assert.Equal(t, "m", p.Config().Agents.Models.Explore)
+}
+
+func TestLoadConfigAgentsRoleModels(t *testing.T) {
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
+models:
+  - name: parent
+    api_key: k
+    default: true
+  - name: cheap
+    api_key: k
+  - name: strong
+    api_key: k
+agents:
+  enabled: true
+  models:
+    explore: cheap
+    review: strong
+`), 0o644))
+
+	require.NoError(t, p.LoadConfig())
+	cfg := p.Config()
+	assert.Equal(t, "cheap", cfg.Agents.Models.Explore)
+	assert.Equal(t, "strong", cfg.Agents.Models.Review)
+	assert.Empty(t, cfg.Agents.Models.Worker)
+}
+
+func TestLoadConfigAgentsRoleModelUnknownKept(t *testing.T) {
+	p := discoverInTempHome(t)
+	require.NoError(t, os.WriteFile(p.Global().ConfigFile(), []byte(`
+models:
+  - name: parent
+    api_key: k
+agents:
+  models:
+    explore: missing-model
+`), 0o644))
+
+	require.NoError(t, p.LoadConfig())
+	assert.Equal(t, "missing-model", p.Config().Agents.Models.Explore)
+	_, ok := p.Config().FindModel("missing-model")
+	assert.False(t, ok)
+}
+
 func TestLoadConfigScalarOrInlineListForms(t *testing.T) {
 	// The old line scanner only understood block lists (and treated an inline
 	// sequence as one literal string); real YAML handles scalar and flow forms.

--- a/internal/tui/commands/builtins.go
+++ b/internal/tui/commands/builtins.go
@@ -80,7 +80,7 @@ func registerBuiltinCommands(r *CommandRegistry) {
 	r.Register(Command{
 		Name: "settings-agents",
 		PaletteRoot: func(ctx CommandContext) palette.PaletteCommand {
-			return AgentsCommand(ctx.SetAgents)
+			return AgentsCommand(ctx.SetAgents, ctx.SetRoleModel, ctx.ModelNames)
 		},
 	})
 	r.Register(Command{
@@ -181,13 +181,52 @@ func PermissionsCommand(set func(bypass bool)) palette.PaletteCommand {
 	}
 }
 
-// AgentsCommand returns settings → agents to toggle sub-agent tools.
-func AgentsCommand(set func(enabled bool)) palette.PaletteCommand {
+// AgentsCommand returns settings → agents to toggle sub-agent tools and
+// pick per-role models (session-only; empty name inherits the parent model).
+func AgentsCommand(
+	set func(enabled bool),
+	setRoleModel func(role, name string),
+	modelNames []string,
+) palette.PaletteCommand {
+	roles := []string{"explore", "review", "worker"}
+	roleCmds := make([]palette.PaletteCommand, 0, len(roles))
+	for _, role := range roles {
+		role := role
+		models := make([]palette.PaletteCommand, 0, len(modelNames)+1)
+		models = append(models, palette.PaletteCommand{
+			ID:   "agents-model-" + role + "-inherit",
+			Verb: "(inherit parent)",
+			Run: func() {
+				if setRoleModel != nil {
+					setRoleModel(role, "")
+				}
+			},
+		})
+		for _, name := range modelNames {
+			name := name
+			models = append(models, palette.PaletteCommand{
+				ID:   "agents-model-" + role + "-" + name,
+				Verb: name,
+				Run: func() {
+					if setRoleModel != nil {
+						setRoleModel(role, name)
+					}
+				},
+			})
+		}
+		roleCmds = append(roleCmds, palette.PaletteCommand{
+			ID:           "agents-models-" + role,
+			Verb:         role,
+			Keywords:     []string{role, "model"},
+			SubmenuTitle: "Model for " + role,
+			Submenu:      models,
+		})
+	}
 	return palette.PaletteCommand{
 		ID:           "settings-agents",
 		Noun:         "settings",
 		Verb:         "agents",
-		Keywords:     []string{"agent", "subagent", "spawn", "jobs", "parallel"},
+		Keywords:     []string{"agent", "subagent", "spawn", "jobs", "parallel", "model"},
 		SubmenuTitle: "Sub-agents",
 		Submenu: []palette.PaletteCommand{
 			{
@@ -209,6 +248,13 @@ func AgentsCommand(set func(enabled bool)) palette.PaletteCommand {
 						set(false)
 					}
 				},
+			},
+			{
+				ID:           "agents-models",
+				Verb:         "models",
+				Keywords:     []string{"model", "explore", "review", "worker"},
+				SubmenuTitle: "Sub-agent Models",
+				Submenu:      roleCmds,
 			},
 		},
 	}

--- a/internal/tui/commands/builtins.go
+++ b/internal/tui/commands/builtins.go
@@ -191,7 +191,6 @@ func AgentsCommand(
 	roles := []string{"explore", "review", "worker"}
 	roleCmds := make([]palette.PaletteCommand, 0, len(roles))
 	for _, role := range roles {
-		role := role
 		models := make([]palette.PaletteCommand, 0, len(modelNames)+1)
 		models = append(models, palette.PaletteCommand{
 			ID:   "agents-model-" + role + "-inherit",
@@ -203,7 +202,6 @@ func AgentsCommand(
 			},
 		})
 		for _, name := range modelNames {
-			name := name
 			models = append(models, palette.PaletteCommand{
 				ID:   "agents-model-" + role + "-" + name,
 				Verb: name,

--- a/internal/tui/commands/commands_test.go
+++ b/internal/tui/commands/commands_test.go
@@ -44,10 +44,10 @@ func TestPermissionsCommand_Toggle(t *testing.T) {
 
 func TestAgentsCommand_Toggle(t *testing.T) {
 	var enabled *bool
-	cmd := AgentsCommand(func(v bool) { enabled = &v })
+	cmd := AgentsCommand(func(v bool) { enabled = &v }, nil, nil)
 	assert.Equal(t, "settings", cmd.Noun)
 	assert.Equal(t, "agents", cmd.Verb)
-	require.Len(t, cmd.Submenu, 2)
+	require.Len(t, cmd.Submenu, 3)
 
 	cmd.Submenu[0].Run()
 	require.NotNil(t, enabled)
@@ -55,6 +55,36 @@ func TestAgentsCommand_Toggle(t *testing.T) {
 
 	cmd.Submenu[1].Run()
 	assert.False(t, *enabled)
+}
+
+func TestAgentsCommand_RoleModels(t *testing.T) {
+	var gotRole, gotName string
+	cmd := AgentsCommand(nil, func(role, name string) {
+		gotRole, gotName = role, name
+	}, []string{"cheap", "strong"})
+	require.Len(t, cmd.Submenu, 3)
+	models := cmd.Submenu[2]
+	assert.Equal(t, "models", models.Verb)
+	require.Len(t, models.Submenu, 3)
+	assert.Equal(t, "explore", models.Submenu[0].Verb)
+	assert.Equal(t, "review", models.Submenu[1].Verb)
+	assert.Equal(t, "worker", models.Submenu[2].Verb)
+
+	explore := models.Submenu[0]
+	require.GreaterOrEqual(t, len(explore.Submenu), 3)
+	assert.Equal(t, "(inherit parent)", explore.Submenu[0].Verb)
+	explore.Submenu[0].Run()
+	assert.Equal(t, "explore", gotRole)
+	assert.Empty(t, gotName)
+
+	explore.Submenu[2].Run() // strong
+	assert.Equal(t, "explore", gotRole)
+	assert.Equal(t, "strong", gotName)
+
+	review := models.Submenu[1]
+	review.Submenu[1].Run() // cheap
+	assert.Equal(t, "review", gotRole)
+	assert.Equal(t, "cheap", gotName)
 }
 
 func TestExtensionsCommand_ListAndReload(t *testing.T) {

--- a/internal/tui/commands/registry.go
+++ b/internal/tui/commands/registry.go
@@ -29,6 +29,7 @@ type CommandContext struct {
 	ApplyTheme       func(name string)
 	SetPermissions   func(bypass bool)
 	SetAgents        func(enabled bool)
+	SetRoleModel     func(role, name string) // name "" → inherit parent
 	ReloadExtensions func()
 	ListExtensions   func() []palette.PaletteCommand
 	AddSkill         func(name string)

--- a/internal/tui/controller/controller.go
+++ b/internal/tui/controller/controller.go
@@ -42,6 +42,9 @@ type EngineController struct {
 	sessionDir string
 	cwd        string
 	modelCfg   llm.ModelConfig
+	// roleModels maps sub-agent role → configured model name for this session.
+	// Empty / missing → inherit modelCfg. Seeded from config; palette can override.
+	roleModels map[job.Role]string
 	jobs       *job.Manager
 	unsubJobs  func()
 
@@ -85,6 +88,7 @@ func NewController(bus *Bus, proj *project.Project, cwd string) (*EngineControll
 		sessionDir:    proj.SessionDir(),
 		askTimeoutSec: 120,
 		modelCfg:      proj.Config().Model(),
+		roleModels:    make(map[job.Role]string),
 	}
 	// Default: no permission prompts. Toggle via command palette → settings → permissions.
 	c.allowAll.Store(true)
@@ -93,14 +97,21 @@ func NewController(bus *Bus, proj *project.Project, cwd string) (*EngineControll
 
 	c.initGate(config.Permissions)
 	c.agentsEnabled.Store(config.Agents.Enabled)
+	if s := strings.TrimSpace(config.Agents.Models.Explore); s != "" {
+		c.roleModels[job.RoleExplore] = s
+	}
+	if s := strings.TrimSpace(config.Agents.Models.Review); s != "" {
+		c.roleModels[job.RoleReview] = s
+	}
+	if s := strings.TrimSpace(config.Agents.Models.Worker); s != "" {
+		c.roleModels[job.RoleWorker] = s
+	}
 
 	extRunner := loadExtensions(proj)
 	c.extRunner.Store(extRunner)
 	c.bindExtensionHost(extRunner)
 
-	jobs, err := agent.NewJobManager(proj.JobsDir(), c.modelCfg, func() llm.ModelConfig {
-		return c.modelCfg
-	}, c.Extensions)
+	jobs, err := agent.NewJobManager(proj.JobsDir(), c.modelCfg, c.modelForRole, c.Extensions)
 	if err != nil {
 		return nil, err
 	}
@@ -223,6 +234,37 @@ func (c *EngineController) SetAgentsEnabled(v bool) {
 	if c.engine != nil {
 		c.engine.SetJobs(c.engineJobs())
 	}
+}
+
+// modelForRole returns the session override for role, or the parent modelCfg.
+func (c *EngineController) modelForRole(role job.Role) llm.ModelConfig {
+	role = job.NormalizeRole(string(role))
+	if name := c.roleModels[role]; name != "" {
+		if m, ok := c.proj.Config().FindModel(name); ok {
+			return m
+		}
+		debuglog.Logf("agents: unknown role model %q for %s; using parent", name, role)
+	}
+	return c.modelCfg
+}
+
+// SetRoleModel sets the session-only model name for a sub-agent role.
+// Empty name clears the override (inherit parent). Name must exist in config.
+func (c *EngineController) SetRoleModel(role, name string) error {
+	r, err := job.ParseRole(role)
+	if err != nil {
+		return err
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		delete(c.roleModels, r)
+		return nil
+	}
+	if _, ok := c.proj.Config().FindModel(name); !ok {
+		return fmt.Errorf("unknown model %q", name)
+	}
+	c.roleModels[r] = name
+	return nil
 }
 
 // engineJobs returns the job manager only when sub-agents are enabled.

--- a/internal/tui/editor/bridge.go
+++ b/internal/tui/editor/bridge.go
@@ -68,6 +68,7 @@ func (b *commandBridge) context() commands.CommandContext {
 		ApplyTheme:       b.applyTheme,
 		SetPermissions:   b.setPermissions,
 		SetAgents:        b.setAgents,
+		SetRoleModel:     b.setRoleModel,
 		ReloadExtensions: b.reloadExtensions,
 		ListExtensions:   b.listExtensions,
 		AddSkill:         b.addSkill,
@@ -126,6 +127,21 @@ func (b *commandBridge) setAgents(enabled bool) {
 	msg := "Sub-agents: off"
 	if enabled {
 		msg = "Sub-agents: on"
+	}
+	b.toast(msg, toast.ToastSuccess, 2*time.Second)
+}
+
+func (b *commandBridge) setRoleModel(role, name string) {
+	if b == nil || b.ctrl == nil {
+		return
+	}
+	if err := b.ctrl.SetRoleModel(role, name); err != nil {
+		b.toast(err.Error(), toast.ToastError, 3*time.Second)
+		return
+	}
+	msg := fmt.Sprintf("Sub-agent %s: inherit parent", role)
+	if name != "" {
+		msg = fmt.Sprintf("Sub-agent %s: %s", role, name)
 	}
 	b.toast(msg, toast.ToastSuccess, 2*time.Second)
 }


### PR DESCRIPTION
Add optional agents.models (explore/review/worker) to pick a configured model per sub-agent role; omitted or unknown roles inherit the parent model. Wired through the headless runloop and TUI controller, with a session-only override under settings -> agents -> models.

Also keep agents.enabled on by default when an agents: block omits it, so configs that only set agents.models do not silently disable sub-agents (enabled is now a *bool on the raw config).