### PR TITLE
fix(mcp): pick the json-rpc response frame from interleaved sse bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- MCP HTTP transport: SSE bodies that interleave server notifications
+  (e.g. `notifications/message` log frames, no `id`) before the JSON-RPC
+  response frame now resolve to the response frame instead of the first
+  parseable frame, which previously made `tools/call` return an empty
+  result when a server streams log frames before answering.
+
 ### Security
 
 <!-- Released section -->

--- a/internal/mcp/rpc.go
+++ b/internal/mcp/rpc.go
@@ -91,17 +91,32 @@ func extractToolContent(raw json.RawMessage) string {
 }
 
 // parseHTTPOrSSEBody accepts plain JSON or SSE lines starting with "data: ".
+// Servers may interleave log notifications (notifications/message, no id)
+// before the response frame, so the first frame that is an actual response
+// (id set, no method) wins. If none matches, the first parseable frame is
+// returned (previous behavior).
 func parseHTTPOrSSEBody(body []byte) (jsonRPCResponse, error) {
 	text := string(body)
+	var first jsonRPCResponse
+	found := false
 	for line := range strings.SplitSeq(text, "\n") {
 		s := strings.TrimSpace(line)
 		if !strings.HasPrefix(s, "data: ") {
 			continue
 		}
 		var rpc jsonRPCResponse
-		if err := json.Unmarshal([]byte(s[len("data: "):]), &rpc); err == nil {
+		if err := json.Unmarshal([]byte(s[len("data: "):]), &rpc); err != nil {
+			continue
+		}
+		if !found {
+			first, found = rpc, true
+		}
+		if rpc.Method == "" && rpc.ID != nil {
 			return rpc, nil
 		}
+	}
+	if found {
+		return first, nil
 	}
 	var rpc jsonRPCResponse
 	if err := json.Unmarshal(body, &rpc); err != nil {

--- a/internal/mcp/rpc_parse_test.go
+++ b/internal/mcp/rpc_parse_test.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHTTPOrSSEBodySkipsNotifications(t *testing.T) {
+	// A server may stream a log notification (no id, method set) before the
+	// JSON-RPC response frame. The response frame must win.
+	var b strings.Builder
+	b.WriteString("event: message\n")
+	b.WriteString("data: " + `{"jsonrpc":"2.0","method":"notifications/message",` +
+		`"params":{"level":"info","data":"Search successful"}}` + "\n\n")
+	b.WriteString("event: message\n")
+	b.WriteString("data: " + `{"jsonrpc":"2.0","id":3,"result":` +
+		`{"content":[{"type":"text","text":"ok"}]}}` + "\n\n")
+
+	rpc, err := parseHTTPOrSSEBody([]byte(b.String()))
+	require.NoError(t, err)
+	require.Empty(t, rpc.Method)
+	require.NotNil(t, rpc.ID)
+
+	var res struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal(rpc.Result, &res))
+	require.Len(t, res.Content, 1)
+	require.Equal(t, "ok", res.Content[0].Text)
+}
+
+func TestParseHTTPOrSSEBodySkipsNotificationsForErrorResponse(t *testing.T) {
+	// Same interleaving, but the response frame carries an error: it must
+	// still win over the earlier notification.
+	body := []byte(
+		"data: " + `{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}` + "\n\n" +
+			"data: " + `{"jsonrpc":"2.0","id":7,"error":{"code":-32601,"message":"no such tool"}}` + "\n\n")
+
+	rpc, err := parseHTTPOrSSEBody(body)
+	require.NoError(t, err)
+	require.Empty(t, rpc.Method)
+	require.NotNil(t, rpc.ID)
+	require.Equal(t, -32601, rpc.Error.Code)
+	require.Equal(t, "no such tool", rpc.Error.Message)
+}
+
+func TestParseHTTPOrSSEBodyFirstFrameKeptWhenNoResponse(t *testing.T) {
+	// Only notifications in the body: keep the first parseable frame
+	// (previous behavior) rather than erroring out.
+	body := []byte("data: " +
+		`{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}` + "\n\n")
+
+	rpc, err := parseHTTPOrSSEBody(body)
+	require.NoError(t, err)
+	require.Equal(t, "notifications/message", rpc.Method)
+}
+
+func TestParseHTTPOrSSEBodyPlainJSON(t *testing.T) {
+	rpc, err := parseHTTPOrSSEBody([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}`))
+	require.NoError(t, err)
+	require.NotNil(t, rpc.ID)
+	require.Empty(t, rpc.Method)
+}


### PR DESCRIPTION
parseHTTPOrSSEBody returned the first parseable data: frame. Servers that stream log notifications (notifications/message, no id) before the response frame made tools/call return an empty result. Prefer the first frame that is an actual response (id set, no method); keep the first parseable frame when none matches (previous behavior).