### PR TITLE
fix(tui): delegate windows clipboard copy to xui

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/pulseaiclub/phi/ext/go v0.24.0
 	github.com/pulseaiclub/pli v0.1.0
-	github.com/pulseaiclub/xui v0.1.5
+	github.com/pulseaiclub/xui v0.1.6
 	github.com/stretchr/testify v1.12.1
 	github.com/yuin/goldmark v1.8.6
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/pulseaiclub/pli v0.1.0 h1:a9EYNXKwrz2UeULIYCJ/ctvb0GpqzS20IvqqHshBj9g=
 github.com/pulseaiclub/pli v0.1.0/go.mod h1:F8cwlTfsPJpohVahihWo5hog3J2pExjMWvh+2AOMSKw=
-github.com/pulseaiclub/xui v0.1.5 h1:NfQ6L1H5bp6pFuK0rcl4DwTTklMAtYKP9m04CPTl1cA=
-github.com/pulseaiclub/xui v0.1.5/go.mod h1:/5J54Q/LjLKKEWE6C7tx9dMH4vEd0pPZ+I02FL4nlOo=
+github.com/pulseaiclub/xui v0.1.6 h1:dPNeQtGVWNO67ruA/zn/ehwnpny/XWKNouEni/1dM4M=
+github.com/pulseaiclub/xui v0.1.6/go.mod h1:/5J54Q/LjLKKEWE6C7tx9dMH4vEd0pPZ+I02FL4nlOo=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/yuin/goldmark v1.8.6 h1:d0VcaP1sx9GkFVkoW+KtggpGi2KZ965i14b0+bDQST4=

--- a/internal/tui/editor/editor.go
+++ b/internal/tui/editor/editor.go
@@ -2,7 +2,6 @@
 package editor
 
 import (
-	"runtime"
 	"time"
 
 	"github.com/pulseaiclub/xui"
@@ -19,7 +18,6 @@ import (
 	"github.com/pulseaiclub/phi/internal/tui/pathutil"
 	"github.com/pulseaiclub/phi/internal/tui/submit"
 	"github.com/pulseaiclub/phi/internal/tui/transcript"
-	"github.com/pulseaiclub/phi/internal/util/clipboard"
 	"github.com/pulseaiclub/phi/internal/util/update"
 	"github.com/pulseaiclub/phi/internal/version"
 )
@@ -111,9 +109,6 @@ func NewEditor(
 	e.transcript.SetCopyHandlers(
 		e.bus,
 		func(text string) bool {
-			if runtime.GOOS == "windows" {
-				return clipboard.CopyText(text) == nil
-			}
 			return e.vx != nil && e.vx.CopyToClipboard(text) == nil
 		},
 	)


### PR DESCRIPTION
xui v0.1.6 handles the windows clipboard itself, so the runtime.GOOS branch in the editor copy handler is redundant. Drop the fallback and bump the dependency.