### PR TITLE
docs: reposition phi as lean and fast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Phi
 
-Minimal Go terminal coding-agent harness. Layout: [doc/project-layout.md](doc/project-layout.md). Humans: [CONTRIBUTING.md](CONTRIBUTING.md).
+Lean, high-performance Go terminal coding-agent harness. Layout: [doc/project-layout.md](doc/project-layout.md). Humans: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Communication Preferences
 
@@ -16,7 +16,7 @@ Minimal Go terminal coding-agent harness. Layout: [doc/project-layout.md](doc/pr
 - **Sub-agent transcripts stay under `~/.phi/jobs/<id>/`.** Parent context gets the wait/task summary only. Child engines have no `agent_*` tools (no nesting). Default child role is explore (no write/edit; bash allowed except hard denies).
 - **UI split:** `internal/components` render; `internal/tui` wires the shell. Non-shell pieces live under `internal/tui/controller` (Engine/Bus/Msg), `internal/tui/transcript` (Mapper); version in `internal/version`. Keep widgets dumb.
 - **TUI assembly:** `cmd` constructs `controller.Bus` / `controller.Controller` / App and passes them into `editor.NewEditor(...)`, which builds the commands registry (`commands.NewBuiltinRegistry`). Do not hide `GetDefaultProject` inside `tui` constructors; do not return half-initialized Controllers (`engineErr` zombies). Prefer constructor parameters over `XxxDeps` bags.
-- **Stay lean.** Direct module deps are few on purpose. Don't add a dependency without a clear need.
+- **Stay lean and fast.** Direct module deps are few on purpose. Don't add a dependency without a clear need. Prefer changes that keep startup, idle RSS, and rebuild time small.
 - **Format with `make fmt`** (gofumpt / goimports / golines, 120 cols, local prefix `github.com/pulseaiclub/phi`). Don't hand-fight import groups.
 - **`testing` / `testify` stay in `*_test.go`.** `depguard` will fail the lint otherwise.
 - **Tests use testify** (`assert` / `require`) for assertions — no raw `t.Fatalf` checks.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
   <a href="https://github.com/pulseaiclub/phi/releases"><img src="https://img.shields.io/github/v/release/pulseaiclub/phi?style=flat&colorA=222222&colorB=8957E5" alt="Release"></a>
 </p>
 
-A minimal terminal coding agent harness in Go — a sibling to Pi.
+A lean, high-performance terminal coding agent harness in Go — a sibling to Pi.
 
 **Docs:** [pulseaiclub.github.io](https://pulseaiclub.github.io/)
 
+- **Fast and small** — ~12 MB release binary, ~21 MB idle RSS, ~40 ms to first frame; no Node / Electron / Python runtime
 - **Sub-agents** — spawn isolated jobs and watch the full run unfold in the TUI / job logs, without stuffing every turn into the parent context
 - **Hashline edits** — edit by whole-file `@file path#TAG` plus line `LINE#HASH` anchors (same idea as [oh-my-pi](https://github.com/can1357/oh-my-pi)): the model points at anchors instead of rewriting whole files; stale tags/hashes are rejected so over-edits and silent corruption stop here
 - **Permission gate** — Gate / Ask before destructive tools fire; safety is not optional when an agent can touch your tree
@@ -92,9 +93,9 @@ fulfill your requests. External HTTP fetch is available via MCP when configured.
 
 ## Footprint
 
-phi aims to stay cheap to run and cheap to hack on. Numbers below are for a
-stripped release build (`CGO_ENABLED=0`, `-ldflags="-s -w"`), measured on
-macOS arm64 unless noted.
+Lean is not enough — phi is built to feel instant and stay cheap under load.
+Numbers below are for a stripped release build (`CGO_ENABLED=0`,
+`-ldflags="-s -w"`), measured on macOS arm64 unless noted.
 
 | Metric | phi |
 | --- | ---: |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,10 +12,11 @@
   <a href="https://github.com/pulseaiclub/phi/releases"><img src="https://img.shields.io/github/v/release/pulseaiclub/phi?style=flat&colorA=222222&colorB=8957E5" alt="Release"></a>
 </p>
 
-一个用 Go 编写的最小化终端编码代理框架（harness）——Pi 的姊妹项目。
+一个精简且性能出众的 Go 终端编码代理框架（harness）——Pi 的姊妹项目。
 
 **文档：** [pulseaiclub.github.io](https://pulseaiclub.github.io/)
 
+- **又快又小** — 发布二进制约 12 MB，空闲 RSS 约 21 MB，首帧约 40 ms；无 Node / Electron / Python 运行时
 - **子代理（Sub-agents）** — 拉起隔离任务，在 TUI / job 日志里完整看到执行过程，而不是把每一步都塞进父会话上下文
 - **Hashline 编辑** — 用整文件 `@file path#TAG` 加上行级 `LINE#HASH` 锚点改文件（思路对齐 [oh-my-pi](https://github.com/can1357/oh-my-pi)）：模型瞄锚点改，而不是整文件重写；TAG/哈希对不上就拒绝，避免过度编辑和静默写坏
 - **权限门控** — 危险工具先过 Gate / Ask；代理能碰你的代码树时，安全不是可选项
@@ -93,7 +94,7 @@ TUI 给模型提供四个核心工具——`read`、`write`、`edit` 和 `bash`�
 
 ## 资源占用
 
-phi 的目标是运行便宜、也便于动手改造。以下数据来自剥离的发布构建
+精简只是底线——phi 还要启动即开、负载下仍省内存。以下数据来自剥离的发布构建
 （`CGO_ENABLED=0`，`-ldflags="-s -w"`），除注明外均在 macOS arm64 上测得。
 
 | 指标 | phi |


### PR DESCRIPTION
Reword the "minimal harness" pitch to "lean, high-performance" in README.md, README.zh-CN.md, and AGENTS.md. Add a headline performance bullet (12 MB binary, 21 MB idle RSS, 40 ms to first frame, no Node/Electron/Python) and reframe the Footprint intro so lean reads as the floor rather than the goal. AGENTS.md's "stay lean" constraint now also asks for small startup, idle RSS, and rebuild time.