### PR TITLE
fix(session): keep compaction file-op details across rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Compaction file-op details are a typed `session.CompactionDetails` (not `any`),
+  so persist/reload and later compact rounds keep prior read/modified files.
+
 ### Security
 
 <!-- Released section -->

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -431,17 +431,12 @@ func (engine *Engine) runCompact(
 		return false, context.Canceled
 	}
 
-	result, err := compaction.Compact(ctx, *prep, engine.client)
+	comp, err := compaction.Compact(ctx, *prep, engine.client)
 	if err != nil {
 		_ = yield(session.CompactionComplete{ID: id, Failed: true}, nil)
 		return false, err
 	}
-	if err := engine.session.AppendCompaction(session.Compaction{
-		Summary:          result.Summary,
-		FirstKeptEntryID: result.FirstKeptEntryID,
-		TokensBefore:     result.TokensBefore,
-		Details:          result.Details,
-	}); err != nil {
+	if err := engine.session.AppendCompaction(comp); err != nil {
 		_ = yield(session.CompactionComplete{ID: id, Failed: true}, nil)
 		return false, err
 	}

--- a/internal/session/compaction/compact.go
+++ b/internal/session/compaction/compact.go
@@ -110,25 +110,13 @@ func PrepareCompact(
 	}, nil
 }
 
-// CompactionResult is the outcome of a compaction run: the generated
-// summary plus the bookkeeping needed to persist the compaction entry.
-type CompactionResult struct {
-	Summary          string
-	FirstKeptEntryID string
-	TokensBefore     int
-	// HookDefinition-specific data (e.g., ArtifactIndex, version markers for structured compaction)
-	Details any
-	// HookDefinition-provided data to persist alongside compaction entry.
-	PreserveData map[string]any
-}
-
 // Compact generates a summary for preparation via llm and returns the
-// resulting CompactionResult.
+// session.Compaction to persist.
 func Compact(
 	ctx context.Context,
 	preparation CompactionPreparation,
 	llm llm.Compactor,
-) (CompactionResult, error) {
+) (session.Compaction, error) {
 	var (
 		summary string
 		err     error
@@ -139,7 +127,7 @@ func Compact(
 		summary, err = summarizeHistory(ctx, preparation, llm)
 	}
 	if err != nil {
-		return CompactionResult{}, err
+		return session.Compaction{}, err
 	}
 
 	readFiles, modifiedFiles := computeFileLists(&preparation.FileOps)
@@ -148,11 +136,14 @@ func Compact(
 		summary += "\n\n" + fileOperations
 	}
 
-	return CompactionResult{
+	return session.Compaction{
 		Summary:          summary,
 		FirstKeptEntryID: preparation.FirstKeptEntryId,
 		TokensBefore:     preparation.TokensBefore,
-		Details:          CompactionDetails{ReadFiles: readFiles, ModifiedFiles: modifiedFiles},
+		Details: session.CompactionDetails{
+			ReadFiles:     readFiles,
+			ModifiedFiles: modifiedFiles,
+		},
 	}, nil
 }
 
@@ -223,13 +214,6 @@ func summarizeHistory(
 		preparation.MessagesToSummarize,
 		preparation.PreviousSummary,
 	)
-}
-
-// CompactionDetails lists the files read and modified in the summarized
-// history; it is persisted with the compaction entry.
-type CompactionDetails struct {
-	ReadFiles     []string
-	ModifiedFiles []string
 }
 
 func getLastAssistantUsage(entries []session.MessageEntry) llm.Usage {

--- a/internal/session/compaction/fileops.go
+++ b/internal/session/compaction/fileops.go
@@ -60,19 +60,22 @@ func extractFileOperations(
 	entries []session.MessageEntry,
 	prevCompactionIndex int,
 ) *FileOperation {
-	fileOps := &FileOperation{}
-	// Collect from previous compaction's details (if extension-generated)
+	var prevRead, prevWritten []string
 	if prevCompactionIndex >= 0 {
-		comp := entries[prevCompactionIndex].(session.CompactionEntry)
-		if comp.Compaction.FromExtension != nil {
-			details, ok := comp.Compaction.Details.(session.CompactionDetails)
-			if ok {
-				fileOps.read = append(fileOps.read, details.ReadFiles...)
-				fileOps.written = append(fileOps.written, details.ModifiedFiles...)
-			}
-		}
+		d := entries[prevCompactionIndex].(session.CompactionEntry).Compaction.Details
+		prevRead, prevWritten = d.ReadFiles, d.ModifiedFiles
 	}
-
+	extra := 0
+	for _, msg := range messages {
+		extra += len(msg.ToolCalls)
+	}
+	fileOps := &FileOperation{
+		read:    make([]string, 0, len(prevRead)+extra),
+		written: make([]string, 0, len(prevWritten)+extra),
+		edited:  make([]string, 0, extra),
+	}
+	fileOps.read = append(fileOps.read, prevRead...)
+	fileOps.written = append(fileOps.written, prevWritten...)
 	for _, msg := range messages {
 		fileOps.extractMessageContent(msg)
 	}

--- a/internal/session/compaction/fileops_test.go
+++ b/internal/session/compaction/fileops_test.go
@@ -120,8 +120,6 @@ func TestFileOperation_extractMessageContent(t *testing.T) {
 
 func TestExtractFileOperations(t *testing.T) {
 	ts := time.Now()
-	trueVal := true
-	falseVal := false
 
 	t.Run("no previous compaction", func(t *testing.T) {
 		messages := []llm.Message{
@@ -138,39 +136,6 @@ func TestExtractFileOperations(t *testing.T) {
 		assert.Empty(t, got.edited)
 	})
 
-	t.Run("prevCompactionIndex >= 0 but FromExtension is nil", func(t *testing.T) {
-		entries := []session.MessageEntry{
-			session.CompactionEntry{
-				SessionBaseEntry: session.SessionBaseEntry{ID: "c1", Type: session.EntryCompaction, Timestamp: ts},
-				Compaction: session.Compaction{
-					Details: session.CompactionDetails{
-						ReadFiles:     []string{"prev.go"},
-						ModifiedFiles: []string{"prev2.go"},
-					},
-					FromExtension: nil,
-				},
-			},
-		}
-		got := extractFileOperations(nil, entries, 0)
-		assert.Empty(t, got.read)
-		assert.Empty(t, got.written)
-	})
-
-	t.Run("prevCompactionIndex >= 0 but Details is not CompactionDetails", func(t *testing.T) {
-		entries := []session.MessageEntry{
-			session.CompactionEntry{
-				SessionBaseEntry: session.SessionBaseEntry{ID: "c1", Type: session.EntryCompaction, Timestamp: ts},
-				Compaction: session.Compaction{
-					Details:       "other type",
-					FromExtension: &trueVal,
-				},
-			},
-		}
-		got := extractFileOperations(nil, entries, 0)
-		assert.Empty(t, got.read)
-		assert.Empty(t, got.written)
-	})
-
 	t.Run("merge from previous compaction details", func(t *testing.T) {
 		entries := []session.MessageEntry{
 			session.CompactionEntry{
@@ -180,7 +145,6 @@ func TestExtractFileOperations(t *testing.T) {
 						ReadFiles:     []string{"r1.go", "r2.go"},
 						ModifiedFiles: []string{"w1.go"},
 					},
-					FromExtension: &trueVal,
 				},
 			},
 		}
@@ -199,7 +163,6 @@ func TestExtractFileOperations(t *testing.T) {
 						ReadFiles:     []string{"prev_read.go"},
 						ModifiedFiles: []string{"prev_written.go"},
 					},
-					FromExtension: &trueVal,
 				},
 			},
 		}
@@ -218,22 +181,15 @@ func TestExtractFileOperations(t *testing.T) {
 		assert.Equal(t, []string{"msg_edit.go"}, got.edited)
 	})
 
-	t.Run("FromExtension non-nil uses details regardless of true/false", func(t *testing.T) {
+	t.Run("empty previous details is a no-op", func(t *testing.T) {
 		entries := []session.MessageEntry{
 			session.CompactionEntry{
 				SessionBaseEntry: session.SessionBaseEntry{ID: "c1", Type: session.EntryCompaction, Timestamp: ts},
-				Compaction: session.Compaction{
-					Details: session.CompactionDetails{
-						ReadFiles:     []string{"x.go"},
-						ModifiedFiles: []string{"y.go"},
-					},
-					FromExtension: &falseVal,
-				},
 			},
 		}
 		got := extractFileOperations(nil, entries, 0)
-		assert.Equal(t, []string{"x.go"}, got.read)
-		assert.Equal(t, []string{"y.go"}, got.written)
+		assert.Empty(t, got.read)
+		assert.Empty(t, got.written)
 	})
 }
 

--- a/internal/session/entry.go
+++ b/internal/session/entry.go
@@ -77,12 +77,12 @@ func (s SessionMessageEntry) GetParent() *string { return s.ParentID }
 
 // Compaction is the data attached to a compaction entry.
 type Compaction struct {
-	Summary          string         `json:"summary"`
-	FirstKeptEntryID string         `json:"firstKeptEntryId"`
-	TokensBefore     int            `json:"tokensBefore"`
-	Details          any            `json:"details,omitempty"`
-	PreserveData     map[string]any `json:"preserveData,omitempty"`
-	FromExtension    *bool          `json:"fromExtension,omitempty"`
+	Summary          string            `json:"summary"`
+	FirstKeptEntryID string            `json:"firstKeptEntryId"`
+	TokensBefore     int               `json:"tokensBefore"`
+	Details          CompactionDetails `json:"details,omitempty"`
+	PreserveData     map[string]any    `json:"preserveData,omitempty"`
+	FromExtension    *bool             `json:"fromExtension,omitempty"`
 }
 
 // CompactionEntry is a compaction node in the session tree.
@@ -93,8 +93,8 @@ type CompactionEntry struct {
 
 // CompactionDetails records file reads/modifications captured at compaction.
 type CompactionDetails struct {
-	ReadFiles     []string
-	ModifiedFiles []string
+	ReadFiles     []string `json:"readFiles,omitempty"`
+	ModifiedFiles []string `json:"modifiedFiles,omitempty"`
 }
 
 // GetType implements MessageEntry.

--- a/internal/session/load_test.go
+++ b/internal/session/load_test.go
@@ -95,6 +95,10 @@ func TestSessionPersistCompaction(t *testing.T) {
 	_, err = m.AppendCompaction(Compaction{
 		Summary:          "conversation summary",
 		FirstKeptEntryID: keptID,
+		Details: CompactionDetails{
+			ReadFiles:     []string{"a.go"},
+			ModifiedFiles: []string{"b.go"},
+		},
 	})
 	require.NoError(t, err)
 	_, err = m.Append(llm.Message{Role: llm.RoleUser, Content: "after"})
@@ -108,6 +112,8 @@ func TestSessionPersistCompaction(t *testing.T) {
 	assert.Equal(t, EntryCompaction, ctx[0].GetType())
 	ce := ctx[0].(CompactionEntry)
 	assert.Equal(t, "conversation summary", ce.Compaction.Summary)
+	assert.Equal(t, []string{"a.go"}, ce.Compaction.Details.ReadFiles)
+	assert.Equal(t, []string{"b.go"}, ce.Compaction.Details.ModifiedFiles)
 
 	got := messageContents(ctx)
 	want := messageContents(m.BuildContext())


### PR DESCRIPTION
Compaction details were untyped (any) while file-op extraction asserted session.CompactionDetails, but Compact stored the compaction package's own CompactionDetails, so the assertion never held and the read/modified file lists recorded by a compaction were dropped from every later round. A reload lost them as well: any decodes to map[string]any, and the FromExtension guard on that path was never written by anything.

Type Details as session.CompactionDetails, drop the duplicate struct, and let Compact return the session.Compaction to persist so the engine stops rebuilding it field by field. Existing entries still load: encoding/json matches the old capitalized field names case-insensitively.