### PR TITLE
session: collapse Item tool fields into ToolRun

### DIFF
--- a/internal/session/apply_test.go
+++ b/internal/session/apply_test.go
@@ -117,7 +117,7 @@ func TestProjectOrder(t *testing.T) {
 		items[2].Kind != ItemAssistant || items[3].Kind != ItemTool {
 		t.Fatalf("order: %+v", items)
 	}
-	if items[3].ToolRun.Status != ToolDone || items[3].ToolRun.Output != "a\n" {
+	if items[3].ToolRun.Status != ToolDone || items[3].ToolRun.Output != "a\n" || items[3].ToolRun.Name != "Bash" {
 		t.Fatalf("tool item: %+v", items[3])
 	}
 }
@@ -171,7 +171,7 @@ func TestLocalBash(t *testing.T) {
 	}
 
 	items := Project(s)
-	if len(items) != 1 || items[0].Kind != ItemTool || items[0].ToolName != "bash" {
+	if len(items) != 1 || items[0].Kind != ItemTool || items[0].ToolRun.Name != "bash" {
 		t.Fatalf("project: %+v", items)
 	}
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -542,7 +542,7 @@ func TestReplaySnapshotTools(t *testing.T) {
 	items := Project(snap)
 	require.Len(t, items, 3)
 	assert.Equal(t, ItemTool, items[2].Kind)
-	assert.Equal(t, "Read", items[2].ToolName)
+	assert.Equal(t, "Read", items[2].ToolRun.Name)
 	assert.Equal(t, "package main", items[2].ToolRun.Output)
 }
 

--- a/internal/session/project.go
+++ b/internal/session/project.go
@@ -29,10 +29,7 @@ type Item struct {
 	Streaming   bool
 	Interrupted bool
 
-	ToolName  string
-	ToolInput string
-	ToolUseID string
-	ToolRun   ToolRun
+	ToolRun ToolRun
 }
 
 // Project flattens Snapshot into list items in content order:
@@ -58,23 +55,16 @@ func Project(s Snapshot) []Item {
 				Text: "Compacted",
 			})
 		case RoleLocalBash:
-			run := ToolRun{ToolUseID: m.ID, Name: "bash", Status: ToolInProgress, Detail: m.Text, Local: true}
-			if s.Tools != nil {
-				if tr, ok := s.Tools[m.ID]; ok {
-					run = tr
-					if run.Detail == "" {
-						run.Detail = m.Text
-					}
-					run.Local = true
-				}
-			}
 			items = append(items, Item{
-				ID:        "bash-" + m.ID,
-				Kind:      ItemTool,
-				ToolUseID: m.ID,
-				ToolName:  "bash",
-				ToolInput: m.Text,
-				ToolRun:   run,
+				ID:   "bash-" + m.ID,
+				Kind: ItemTool,
+				ToolRun: mergeToolRun(ToolRun{
+					ToolUseID: m.ID,
+					Name:      "bash",
+					Status:    ToolInProgress,
+					Detail:    m.Text,
+					Local:     true,
+				}, s.Tools),
 			})
 		}
 	}
@@ -125,22 +115,15 @@ func projectAssistant(m Message, tools map[string]ToolRun) []Item {
 		case BlockToolUse:
 			emitText(textBuf.String(), false)
 			textBuf.Reset()
-			run := ToolRun{ToolUseID: b.ID, Name: b.Name, Status: ToolInProgress, Detail: b.Input}
-			if tools != nil {
-				if tr, ok := tools[b.ID]; ok {
-					run = tr
-					if run.Detail == "" {
-						run.Detail = b.Input
-					}
-				}
-			}
 			items = append(items, Item{
-				ID:        "tool-" + b.ID,
-				Kind:      ItemTool,
-				ToolUseID: b.ID,
-				ToolName:  b.Name,
-				ToolInput: b.Input,
-				ToolRun:   run,
+				ID:   "tool-" + b.ID,
+				Kind: ItemTool,
+				ToolRun: mergeToolRun(ToolRun{
+					ToolUseID: b.ID,
+					Name:      b.Name,
+					Status:    ToolInProgress,
+					Detail:    b.Input,
+				}, tools),
 			})
 		}
 	}
@@ -161,6 +144,32 @@ func projectAssistant(m Message, tools map[string]ToolRun) []Item {
 		}
 	}
 	return items
+}
+
+// mergeToolRun overlays live execution state onto the content-block fallback
+// so the projected row always has Name / ToolUseID / Detail even when the
+// live run omitted them.
+func mergeToolRun(fallback ToolRun, live map[string]ToolRun) ToolRun {
+	if live == nil {
+		return fallback
+	}
+	tr, ok := live[fallback.ToolUseID]
+	if !ok {
+		return fallback
+	}
+	if tr.Name == "" {
+		tr.Name = fallback.Name
+	}
+	if tr.Detail == "" {
+		tr.Detail = fallback.Detail
+	}
+	if tr.ToolUseID == "" {
+		tr.ToolUseID = fallback.ToolUseID
+	}
+	if fallback.Local {
+		tr.Local = true
+	}
+	return tr
 }
 
 func isTrailingThinking(blocks []ContentBlock, i int) bool {

--- a/internal/tui/transcript/mapper.go
+++ b/internal/tui/transcript/mapper.go
@@ -149,27 +149,24 @@ func (m *Mapper) patchItem(w components.Widget, it session.Item) (ok, dirty bool
 }
 
 func (m *Mapper) patchTool(w components.Widget, it session.Item) (ok, dirty bool) {
-	name := strings.ToLower(it.ToolName)
+	run := it.ToolRun
+	name := strings.ToLower(run.Name)
 	if name == "bash" {
 		b, ok := w.(*block.BashBlock)
 		if !ok {
 			return false, false
 		}
-		cmd := it.ToolInput
-		if it.ToolRun.Detail != "" {
-			cmd = it.ToolRun.Detail
-		}
-		st := bashStatus(it.ToolRun.Status)
+		st := bashStatus(run.Status)
 		prevExp := b.Expanded
-		dirty = b.Command != cmd || b.Output != it.ToolRun.Output || b.Status != st || b.ExitCode != it.ToolRun.ExitCode
-		b.Command = cmd
-		b.Output = it.ToolRun.Output
+		dirty = b.Command != run.Detail || b.Output != run.Output || b.Status != st || b.ExitCode != run.ExitCode
+		b.Command = run.Detail
+		b.Output = run.Output
 		b.Status = st
-		b.ExitCode = it.ToolRun.ExitCode
+		b.ExitCode = run.ExitCode
 		b.Theme = m.theme
 		if exp, ok := m.expanded[it.ID]; ok {
 			b.Expanded = exp
-		} else if it.ToolRun.Local {
+		} else if run.Local {
 			// User "!cmd" results should stay open so output is visible.
 			b.Expanded = true
 		} else if b.Status == block.BashRunning && b.Output != "" {
@@ -204,18 +201,14 @@ func (m *Mapper) patchTool(w components.Widget, it session.Item) (ok, dirty bool
 	if !ok {
 		return false, false
 	}
-	detail := it.ToolInput
-	if it.ToolRun.Detail != "" {
-		detail = it.ToolRun.Detail
-	}
-	st := uiToolStatus(it.ToolRun.Status)
+	st := uiToolStatus(run.Status)
 	prevExp := t.Expanded
-	dirty = t.Name != it.ToolName || t.Detail != detail || t.Output != it.ToolRun.Output ||
-		t.Error != it.ToolRun.Error || t.Status != st
-	t.Name = it.ToolName
-	t.Detail = detail
-	t.Output = it.ToolRun.Output
-	t.Error = it.ToolRun.Error
+	dirty = t.Name != run.Name || t.Detail != run.Detail || t.Output != run.Output ||
+		t.Error != run.Error || t.Status != st
+	t.Name = run.Name
+	t.Detail = run.Detail
+	t.Output = run.Output
+	t.Error = run.Error
 	t.Status = st
 	t.Theme = m.theme
 	t.Spinner = m.spinner
@@ -283,25 +276,22 @@ func (m *Mapper) widgetFor(it session.Item) components.Widget {
 }
 
 func (m *Mapper) toolWidget(it session.Item, exp bool) components.Widget {
-	detail := it.ToolInput
-	if it.ToolRun.Detail != "" {
-		detail = it.ToolRun.Detail
-	}
+	run := it.ToolRun
 	autoExp := exp
 	if !exp {
-		if it.ToolRun.Local {
+		if run.Local {
 			autoExp = true
-		} else if it.ToolRun.Status == session.ToolInProgress && it.ToolRun.Output != "" {
+		} else if run.Status == session.ToolInProgress && run.Output != "" {
 			autoExp = true
 		}
 	}
 	id := it.ID
-	if strings.EqualFold(it.ToolName, "bash") {
+	if strings.EqualFold(run.Name, "bash") {
 		return &block.BashBlock{
-			Command:  detail,
-			Output:   it.ToolRun.Output,
-			Status:   bashStatus(it.ToolRun.Status),
-			ExitCode: it.ToolRun.ExitCode,
+			Command:  run.Detail,
+			Output:   run.Output,
+			Status:   bashStatus(run.Status),
+			ExitCode: run.ExitCode,
 			Expanded: autoExp,
 			Theme:    m.theme,
 			OnToggle: func(expanded bool) {
@@ -312,7 +302,7 @@ func (m *Mapper) toolWidget(it session.Item, exp bool) components.Widget {
 			},
 		}
 	}
-	if isAgentTreeTool(it.ToolName) {
+	if isAgentTreeTool(run.Name) {
 		a := &block.AgentBlock{
 			Theme:   m.theme,
 			Spinner: m.spinner,
@@ -327,11 +317,11 @@ func (m *Mapper) toolWidget(it session.Item, exp bool) components.Widget {
 		return a
 	}
 	return &block.ToolBlock{
-		Name:     it.ToolName,
-		Detail:   detail,
-		Output:   it.ToolRun.Output,
-		Error:    it.ToolRun.Error,
-		Status:   uiToolStatus(it.ToolRun.Status),
+		Name:     run.Name,
+		Detail:   run.Detail,
+		Output:   run.Output,
+		Error:    run.Error,
+		Status:   uiToolStatus(run.Status),
 		Expanded: autoExp,
 		Theme:    m.theme,
 		Spinner:  m.spinner,
@@ -354,18 +344,15 @@ func isAgentTreeTool(name string) bool {
 }
 
 func (m *Mapper) fillAgentBlock(a *block.AgentBlock, it session.Item) {
-	detail := it.ToolInput
-	if it.ToolRun.Detail != "" {
-		detail = it.ToolRun.Detail
-	}
-	a.Name = it.ToolName
-	a.Detail = detail
-	a.Status = uiToolStatus(it.ToolRun.Status)
+	run := it.ToolRun
+	a.Name = run.Name
+	a.Detail = run.Detail
+	a.Status = uiToolStatus(run.Status)
 	a.Theme = m.theme
 	a.Spinner = m.spinner
-	a.Error = it.ToolRun.Error
+	a.Error = run.Error
 
-	parsed := tools.ParseAgentResult(it.ToolRun.Output)
+	parsed := tools.ParseAgentResult(run.Output)
 	if sum := parsed.RenderableSummary(); sum != "" {
 		a.Summary = sum
 	} else {
@@ -375,8 +362,8 @@ func (m *Mapper) fillAgentBlock(a *block.AgentBlock, it session.Item) {
 	// agent_wait: summary only — the live tree already lives on agent_spawn.
 	// agent_spawn: nested child tools from SubagentStore.
 	a.Children = nil
-	if !strings.EqualFold(it.ToolName, "agent_wait") && m.Children != nil {
-		a.Children = m.Children(it.ToolUseID)
+	if !strings.EqualFold(run.Name, "agent_wait") && m.Children != nil {
+		a.Children = m.Children(run.ToolUseID)
 		if len(a.Children) == 0 && parsed.JobID != "" && m.ChildrenByJob != nil {
 			a.Children = m.ChildrenByJob(parsed.JobID)
 		}


### PR DESCRIPTION
Remove ToolName, ToolInput, ToolUseID from Item and merge their role into ToolRun. Add mergeToolRun() to overlay live execution state onto the content-block fallback so the projected row always has Name / ToolUseID / Detail even when the live run omitted them. Update mapper and tests accordingly.