### PR TITLE
refactor(tool status): centralize status constants and parsing

### DIFF
--- a/internal/components/block/bash_block.go
+++ b/internal/components/block/bash_block.go
@@ -8,19 +8,8 @@ import (
 
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/chrome"
+	"github.com/pulseaiclub/phi/internal/components/status"
 	"github.com/pulseaiclub/phi/internal/util"
-)
-
-// BashStatus mirrors bash tool status.
-type BashStatus int
-
-// Bash status values for a bash tool output row.
-const (
-	BashDone BashStatus = iota
-	BashRunning
-	BashError
-	BashCancelled
-	BashRejected
 )
 
 // BashBlock renders bash tool / "!cmd" output:
@@ -35,7 +24,7 @@ const (
 type BashBlock struct {
 	Command  string
 	Output   string
-	Status   BashStatus
+	Status   status.ToolStatus
 	ExitCode int
 	Expanded bool
 	Theme    components.Theme
@@ -96,7 +85,7 @@ func (bashBlock *BashBlock) CopyText() string {
 }
 
 func (bashBlock *BashBlock) hasBody() bool {
-	return strings.TrimSpace(bashBlock.Output) != "" || (bashBlock.Status == BashError)
+	return strings.TrimSpace(bashBlock.Output) != "" || bashBlock.Status == status.ToolError
 }
 
 // Draw renders the "$ command" title and, when expanded, the truncated output body.
@@ -135,16 +124,16 @@ func (bashBlock *BashBlock) Draw(ctx components.DrawContext) components.Surface 
 func (bashBlock *BashBlock) titleSpans(th components.Theme) []components.Span {
 	prefixStyle := th.IdentityOrSuccess()
 	switch bashBlock.Status {
-	case BashError:
+	case status.ToolError:
 		prefixStyle = th.Destructive
-	case BashRunning:
+	case status.ToolRunning, status.ToolQueued:
 		prefixStyle = th.ToolName
-	case BashCancelled, BashRejected:
+	case status.ToolCancelled, status.ToolRejected:
 		prefixStyle = th.Muted
 	}
 
 	cmdStyle := th.Foreground
-	if bashBlock.Status == BashCancelled || bashBlock.Status == BashRejected {
+	if bashBlock.Status == status.ToolCancelled || bashBlock.Status == status.ToolRejected {
 		cmdStyle.Strikethrough = true
 	}
 
@@ -152,13 +141,10 @@ func (bashBlock *BashBlock) titleSpans(th components.Theme) []components.Span {
 		{Text: chrome.BashPrompt, Style: prefixStyle},
 		{Text: bashBlock.Command, Style: cmdStyle},
 	}
-	switch bashBlock.Status {
-	case BashCancelled:
-		title = append(title, components.Span{Text: " (cancelled)", Style: th.Muted})
-	case BashRejected:
-		title = append(title, components.Span{Text: " (rejected)", Style: th.Muted})
+	if suf := chrome.StatusSuffix(bashBlock.Status); suf != "" {
+		title = append(title, components.Span{Text: suf, Style: th.Muted})
 	}
-	if bashBlock.Status == BashDone && bashBlock.ExitCode != 0 {
+	if bashBlock.Status == status.ToolDone && bashBlock.ExitCode != 0 {
 		it := xui.Style{Italic: true}
 		title = append(
 			title,

--- a/internal/components/block/blocks_test.go
+++ b/internal/components/block/blocks_test.go
@@ -17,7 +17,7 @@ func TestBashBlockRendersOutput(t *testing.T) {
 	b := &block.BashBlock{
 		Command:  "ls",
 		Output:   strings.Join(lines, "\n"),
-		Status:   block.BashDone,
+		Status:   status.ToolDone,
 		Expanded: true,
 		Theme:    components.DefaultTheme(),
 	}

--- a/internal/job/progress.go
+++ b/internal/job/progress.go
@@ -8,7 +8,7 @@ type Progress struct {
 	ParentToolUseID string // parent agent tool_use id when known
 	ToolUseID       string
 	Name            string
-	Status          string // e.g. session.ToolStatus.String(): in-progress, done, error
+	Status          string // session.ToolStatus.String(); decode with session.ParseToolStatus
 	Detail          string
 	Time            time.Time
 }

--- a/internal/session/message.go
+++ b/internal/session/message.go
@@ -110,6 +110,27 @@ func (s ToolStatus) String() string {
 	}
 }
 
+// ParseToolStatus maps a progress / persist string onto ToolStatus.
+// Unknown values (including "") become ToolInProgress so live rows keep spinning.
+func ParseToolStatus(s string) ToolStatus {
+	switch s {
+	case "queued":
+		return ToolQueued
+	case "in-progress":
+		return ToolInProgress
+	case "done":
+		return ToolDone
+	case "error":
+		return ToolError
+	case "cancelled":
+		return ToolCancelled
+	case "rejected", "rejected-by-user":
+		return ToolRejected
+	default:
+		return ToolInProgress
+	}
+}
+
 // ToolRun is the live execution state for a tool_use id.
 type ToolRun struct {
 	ToolUseID string

--- a/internal/session/message_test.go
+++ b/internal/session/message_test.go
@@ -1,0 +1,37 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseToolStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   string
+		want ToolStatus
+	}{
+		{"queued", ToolQueued},
+		{"in-progress", ToolInProgress},
+		{"done", ToolDone},
+		{"error", ToolError},
+		{"cancelled", ToolCancelled},
+		{"rejected", ToolRejected},
+		{"rejected-by-user", ToolRejected},
+		{"", ToolInProgress},
+		{"unknown", ToolInProgress},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, ParseToolStatus(tt.in), "%q", tt.in)
+	}
+}
+
+func TestToolStatusStringRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, s := range []ToolStatus{
+		ToolQueued, ToolInProgress, ToolDone, ToolError, ToolCancelled, ToolRejected,
+	} {
+		assert.Equal(t, s, ParseToolStatus(s.String()), s.String())
+	}
+}

--- a/internal/tui/transcript/mapper.go
+++ b/internal/tui/transcript/mapper.go
@@ -156,7 +156,7 @@ func (m *Mapper) patchTool(w components.Widget, it session.Item) (ok, dirty bool
 		if !ok {
 			return false, false
 		}
-		st := bashStatus(run.Status)
+		st := uiToolStatus(run.Status)
 		prevExp := b.Expanded
 		dirty = b.Command != run.Detail || b.Output != run.Output || b.Status != st || b.ExitCode != run.ExitCode
 		b.Command = run.Detail
@@ -169,7 +169,7 @@ func (m *Mapper) patchTool(w components.Widget, it session.Item) (ok, dirty bool
 		} else if run.Local {
 			// User "!cmd" results should stay open so output is visible.
 			b.Expanded = true
-		} else if b.Status == block.BashRunning && b.Output != "" {
+		} else if b.Status == status.ToolRunning && b.Output != "" {
 			b.Expanded = true
 		}
 		if b.Expanded != prevExp {
@@ -290,7 +290,7 @@ func (m *Mapper) toolWidget(it session.Item, exp bool) components.Widget {
 		return &block.BashBlock{
 			Command:  run.Detail,
 			Output:   run.Output,
-			Status:   bashStatus(run.Status),
+			Status:   uiToolStatus(run.Status),
 			ExitCode: run.ExitCode,
 			Expanded: autoExp,
 			Theme:    m.theme,
@@ -373,21 +373,6 @@ func (m *Mapper) fillAgentBlock(a *block.AgentBlock, it session.Item) {
 		a.Expanded = exp
 	} else if a.Status == status.ToolRunning || len(a.Children) > 0 || a.Summary != "" {
 		a.Expanded = true
-	}
-}
-
-func bashStatus(s session.ToolStatus) block.BashStatus {
-	switch s {
-	case session.ToolDone:
-		return block.BashDone
-	case session.ToolError:
-		return block.BashError
-	case session.ToolCancelled:
-		return block.BashCancelled
-	case session.ToolRejected:
-		return block.BashRejected
-	default:
-		return block.BashRunning
 	}
 }
 

--- a/internal/tui/transcript/subagent_store.go
+++ b/internal/tui/transcript/subagent_store.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 
 	"github.com/pulseaiclub/phi/internal/components/block"
-	"github.com/pulseaiclub/phi/internal/components/status"
 	"github.com/pulseaiclub/phi/internal/job"
+	"github.com/pulseaiclub/phi/internal/session"
 	"github.com/pulseaiclub/phi/internal/tools"
 )
 
@@ -95,7 +95,7 @@ func (s *SubagentStore) ApplyProgress(p job.Progress) bool {
 	child := block.ChildTool{
 		Name:   p.Name,
 		Detail: p.Detail,
-		Status: progressStatus(p.Status),
+		Status: uiToolStatus(session.ParseToolStatus(p.Status)),
 	}
 	if i, ok := v.childIdx[key]; ok {
 		if v.Children[i] == child {
@@ -148,21 +148,4 @@ func (s *SubagentStore) ChildrenByJob(jobID string) []block.ChildTool {
 		return nil
 	}
 	return append([]block.ChildTool(nil), v.Children...)
-}
-
-func progressStatus(s string) status.ToolStatus {
-	switch s {
-	case "done":
-		return status.ToolDone
-	case "error":
-		return status.ToolError
-	case "cancelled":
-		return status.ToolCancelled
-	case "rejected", "rejected-by-user":
-		return status.ToolRejected
-	case "queued":
-		return status.ToolQueued
-	default:
-		return status.ToolRunning
-	}
 }


### PR DESCRIPTION
Replace local BashStatus type and bashStatus/progressStatus conversion functions with the shared status.ToolStatus and session.ParseToolStatus. Add ParseToolStatus for string→ToolStatus mapping and round-trip tests.