### PR TITLE
feat(ext): add ToolResult.Expanded to open tool rows by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Extensions: `ToolResult.Expanded` opens the TUI tool row by default (e.g. plan
+  body). User toggle still wins after the first interaction.
+
 ### Changed
 
 ### Deprecated

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -80,6 +80,9 @@ Set `DetailFromArgs` so the TUI tool row shows a one-line summary (path, URL, â€
 instead of raw JSON while the tool is in progress. The host RPCs the extension
 with a short default timeout (not `TimeoutSec`).
 
+Set `Expanded: true` on `ToolResult` when the tool body should start open in the
+TUI (e.g. a plan). The user can still collapse it; toggle state wins after that.
+
 Set `Readable: true` on side-effect-free tools (read-only lookups, pure
 computation) so the host may run a batch of all-readable calls concurrently.
 

--- a/ext/go/phi/sdk.go
+++ b/ext/go/phi/sdk.go
@@ -407,7 +407,7 @@ func (extension *ExtensionAPI) Run() error {
 					tr.Error = err.Error()
 					tr.Content = err.Error()
 				} else {
-					tr.Content, tr.Detail, tr.Output = res.Content, res.Detail, res.Output
+					tr.Content, tr.Detail, tr.Output, tr.Expanded = res.Content, res.Detail, res.Output, res.Expanded
 				}
 			} else {
 				tr.IsError = true

--- a/ext/go/pxb/compat_test.go
+++ b/ext/go/pxb/compat_test.go
@@ -167,6 +167,21 @@ func TestToolDetailResultRoundTrip(t *testing.T) {
 	assert.Equal(t, in.Detail, out.Detail)
 }
 
+func TestToolResultExpandedRoundTrip(t *testing.T) {
+	in := pxb.ToolResultMsg{
+		Content: "plan body", Detail: "plan", Output: "plan body", Expanded: true,
+	}
+	out, err := pxb.DecodeToolResult(pxb.EncodeToolResult(in))
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+
+	// False omits the field (old hosts stay collapsed).
+	raw := pxb.EncodeToolResult(pxb.ToolResultMsg{Content: "c"})
+	collapsed, err := pxb.DecodeToolResult(raw)
+	require.NoError(t, err)
+	assert.False(t, collapsed.Expanded)
+}
+
 func TestUnknownEventCodeMapsEmpty(t *testing.T) {
 	assert.Empty(t, pxb.EventName(999))
 	assert.Equal(t, uint16(0), pxb.EventCode("nope"))

--- a/ext/go/pxb/msg.go
+++ b/ext/go/pxb/msg.go
@@ -53,11 +53,12 @@ const (
 	fToolInvName uint16 = 1
 	fToolInvArgs uint16 = 2
 
-	fToolResContent uint16 = 1
-	fToolResDetail  uint16 = 2
-	fToolResOutput  uint16 = 3
-	fToolResIsError uint16 = 4
-	fToolResError   uint16 = 5
+	fToolResContent  uint16 = 1
+	fToolResDetail   uint16 = 2
+	fToolResOutput   uint16 = 3
+	fToolResIsError  uint16 = 4
+	fToolResError    uint16 = 5
+	fToolResExpanded uint16 = 6 // TUI tool row starts expanded
 
 	fIxReqEvent      uint16 = 1
 	fIxReqToolName   uint16 = 2
@@ -497,11 +498,12 @@ func DecodeToolInvoke(b []byte) (ToolInvoke, error) {
 
 // ToolResultMsg is ext→host tool outcome.
 type ToolResultMsg struct {
-	Content string
-	Detail  string
-	Output  string
-	IsError bool
-	Error   string
+	Content  string
+	Detail   string
+	Output   string
+	IsError  bool
+	Error    string
+	Expanded bool // TUI tool row starts expanded (user toggle still wins)
 }
 
 func EncodeToolResult(t ToolResultMsg) []byte {
@@ -511,6 +513,9 @@ func EncodeToolResult(t ToolResultMsg) []byte {
 	fw.PutString(fToolResOutput, t.Output)
 	fw.PutBool(fToolResIsError, t.IsError)
 	fw.PutString(fToolResError, t.Error)
+	if t.Expanded {
+		fw.PutBool(fToolResExpanded, true)
+	}
 	return fw.Bytes()
 }
 
@@ -537,6 +542,10 @@ func DecodeToolResult(b []byte) (ToolResultMsg, error) {
 		case fToolResError:
 			s, err := takeString(kind, fr)
 			t.Error = s
+			return err
+		case fToolResExpanded:
+			v, err := takeU64(kind, fr)
+			t.Expanded = v != 0
 			return err
 		default:
 			return fr.Skip(kind)

--- a/ext/go/types.go
+++ b/ext/go/types.go
@@ -137,6 +137,8 @@ type ToolResult struct {
 	Content string
 	Detail  string
 	Output  string
+	// Expanded asks the TUI to start the tool row open (user toggle still wins).
+	Expanded bool
 }
 
 // Tool registers an LLM-callable tool.

--- a/ext/rust/src/phi/mod.rs
+++ b/ext/rust/src/phi/mod.rs
@@ -148,6 +148,8 @@ pub struct ToolResult {
     pub content: String,
     pub detail: String,
     pub output: String,
+    /// Ask the TUI to start the tool row open (user toggle still wins).
+    pub expanded: bool,
 }
 
 /// A slash command. The handler receives the raw argument string and a
@@ -626,6 +628,7 @@ fn serve_tool(
                 content: res.content,
                 detail: res.detail,
                 output: res.output,
+                expanded: res.expanded,
                 ..Default::default()
             },
             Err(e) => tool_error(e),

--- a/ext/rust/src/pxb/msg.rs
+++ b/ext/rust/src/pxb/msg.rs
@@ -52,6 +52,7 @@ const F_TOOL_RES_DETAIL: u16 = 2;
 const F_TOOL_RES_OUTPUT: u16 = 3;
 const F_TOOL_RES_IS_ERROR: u16 = 4;
 const F_TOOL_RES_ERROR: u16 = 5;
+const F_TOOL_RES_EXPANDED: u16 = 6; // TUI tool row starts expanded
 
 const F_IX_REQ_EVENT: u16 = 1;
 const F_IX_REQ_TOOL_NAME: u16 = 2;
@@ -444,6 +445,8 @@ pub struct ToolResultMsg {
     pub output: String,
     pub is_error: bool,
     pub error: String,
+    /// TUI tool row starts expanded (user toggle still wins).
+    pub expanded: bool,
 }
 
 pub fn encode_tool_result(t: &ToolResultMsg) -> Vec<u8> {
@@ -453,6 +456,9 @@ pub fn encode_tool_result(t: &ToolResultMsg) -> Vec<u8> {
     fw.put_string(F_TOOL_RES_OUTPUT, &t.output);
     fw.put_bool(F_TOOL_RES_IS_ERROR, t.is_error);
     fw.put_string(F_TOOL_RES_ERROR, &t.error);
+    if t.expanded {
+        fw.put_bool(F_TOOL_RES_EXPANDED, true);
+    }
     fw.into_vec()
 }
 
@@ -465,6 +471,7 @@ pub fn decode_tool_result(b: &[u8]) -> Result<ToolResultMsg, Error> {
             F_TOOL_RES_OUTPUT => t.output = take_string(kind, fr)?,
             F_TOOL_RES_IS_ERROR => t.is_error = take_u64(kind, fr)? != 0,
             F_TOOL_RES_ERROR => t.error = take_string(kind, fr)?,
+            F_TOOL_RES_EXPANDED => t.expanded = take_u64(kind, fr)? != 0,
             _ => fr.skip(kind)?,
         }
         Ok(())
@@ -847,6 +854,7 @@ mod tests {
                     output: "o".into(),
                     is_error: true,
                     error: "e".into(),
+                    expanded: true,
                 }),
                 |b| Ok(encode_tool_result(&decode_tool_result(b)?)),
             ),

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -280,7 +280,9 @@ func (e *Executor) runOne(
 		_ = emit(session.ToolData{Run: e.toolRun(call, session.ToolError, detail, errText, output)})
 		return e.toolMessage(call.ID, modelContent), postStop, postReason
 	}
-	_ = emit(session.ToolData{Run: e.toolRun(call, session.ToolDone, detail, "", output)})
+	run := e.toolRun(call, session.ToolDone, detail, "", output)
+	run.Expanded = result.Expanded
+	_ = emit(session.ToolData{Run: run})
 	return e.toolMessage(call.ID, modelContent), postStop, postReason
 }
 

--- a/internal/extension/proc.go
+++ b/internal/extension/proc.go
@@ -389,7 +389,8 @@ func (p *Proc) CallTool(ctx context.Context, name string, args json.RawMessage) 
 		if tr.Error == "" {
 			tr.Error = tr.Content
 		}
-		return ext.ToolResult{Content: tr.Content, Detail: tr.Detail, Output: tr.Output, Expanded: tr.Expanded}, errors.New(tr.Error)
+		res := ext.ToolResult{Content: tr.Content, Detail: tr.Detail, Output: tr.Output, Expanded: tr.Expanded}
+		return res, errors.New(tr.Error)
 	}
 	return ext.ToolResult{Content: tr.Content, Detail: tr.Detail, Output: tr.Output, Expanded: tr.Expanded}, nil
 }

--- a/internal/extension/proc.go
+++ b/internal/extension/proc.go
@@ -389,9 +389,9 @@ func (p *Proc) CallTool(ctx context.Context, name string, args json.RawMessage) 
 		if tr.Error == "" {
 			tr.Error = tr.Content
 		}
-		return ext.ToolResult{Content: tr.Content, Detail: tr.Detail, Output: tr.Output}, errors.New(tr.Error)
+		return ext.ToolResult{Content: tr.Content, Detail: tr.Detail, Output: tr.Output, Expanded: tr.Expanded}, errors.New(tr.Error)
 	}
-	return ext.ToolResult{Content: tr.Content, Detail: tr.Detail, Output: tr.Output}, nil
+	return ext.ToolResult{Content: tr.Content, Detail: tr.Detail, Output: tr.Output, Expanded: tr.Expanded}, nil
 }
 
 // CallToolDetail asks the extension for a one-line TUI detail for raw args.

--- a/internal/extension/runner.go
+++ b/internal/extension/runner.go
@@ -293,7 +293,7 @@ func toolFromDef(def ext.Tool) tools.Tool {
 			if out == "" {
 				out = res.Content
 			}
-			return tools.Result{Content: res.Content, Detail: res.Detail, Output: out}, nil
+			return tools.Result{Content: res.Content, Detail: res.Detail, Output: out, Expanded: res.Expanded}, nil
 		},
 	}
 }

--- a/internal/session/apply.go
+++ b/internal/session/apply.go
@@ -103,6 +103,9 @@ func Apply(s Snapshot, ev Event) Snapshot {
 			if prev.Local {
 				run.Local = true
 			}
+			if prev.Expanded {
+				run.Expanded = true
+			}
 		}
 		out.Tools[run.ToolUseID] = run
 	case CancelStreaming:

--- a/internal/session/message.go
+++ b/internal/session/message.go
@@ -141,6 +141,7 @@ type ToolRun struct {
 	Detail    string // optional one-line detail (path, cmd summary)
 	ExitCode  int    // set when a local bash run finishes (Status Done/Error)
 	Local     bool   // user "!cmd" bash; ignored by agent streaming/busy checks
+	Expanded  bool   // TUI starts the tool row open (user toggle still wins)
 }
 
 // Message is one session message. Assistant rows carry Content blocks and State.

--- a/internal/tools/tooldef/tool.go
+++ b/internal/tools/tooldef/tool.go
@@ -15,6 +15,8 @@ type Result struct {
 	Detail string
 	// Output is the display body for the TUI (may equal Content).
 	Output string
+	// Expanded asks the TUI to start the tool row open.
+	Expanded bool
 }
 
 // Handler runs a tool given raw JSON arguments.

--- a/internal/tui/transcript/mapper.go
+++ b/internal/tui/transcript/mapper.go
@@ -166,8 +166,8 @@ func (m *Mapper) patchTool(w components.Widget, it session.Item) (ok, dirty bool
 		b.Theme = m.theme
 		if exp, ok := m.expanded[it.ID]; ok {
 			b.Expanded = exp
-		} else if run.Local {
-			// User "!cmd" results should stay open so output is visible.
+		} else if run.Local || run.Expanded {
+			// User "!cmd" / plugin Expanded: keep body visible.
 			b.Expanded = true
 		} else if b.Status == status.ToolRunning && b.Output != "" {
 			b.Expanded = true
@@ -214,6 +214,8 @@ func (m *Mapper) patchTool(w components.Widget, it session.Item) (ok, dirty bool
 	t.Spinner = m.spinner
 	if exp, ok := m.expanded[it.ID]; ok {
 		t.Expanded = exp
+	} else if run.Expanded {
+		t.Expanded = true
 	} else if t.Status == status.ToolRunning && t.Output != "" {
 		t.Expanded = true
 	}
@@ -279,7 +281,7 @@ func (m *Mapper) toolWidget(it session.Item, exp bool) components.Widget {
 	run := it.ToolRun
 	autoExp := exp
 	if !exp {
-		if run.Local {
+		if run.Local || run.Expanded {
 			autoExp = true
 		} else if run.Status == session.ToolInProgress && run.Output != "" {
 			autoExp = true

--- a/internal/tui/transcript/mapper_sync_test.go
+++ b/internal/tui/transcript/mapper_sync_test.go
@@ -3,6 +3,9 @@ package transcript_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/block"
 	"github.com/pulseaiclub/phi/internal/job"
@@ -86,4 +89,26 @@ func TestApplyProgressReportsChange(t *testing.T) {
 	if !s.ApplyProgress(p) {
 		t.Fatal("status change should dirty")
 	}
+}
+
+func TestMapperToolExpandedFromRun(t *testing.T) {
+	m := transcript.NewMapper(components.DefaultTheme(), nil, nil)
+	snap := session.Snapshot{
+		Messages: []session.Message{{
+			ID: "a1", Role: session.RoleAssistant, State: session.StateComplete,
+			Content: []session.ContentBlock{{Type: session.BlockToolUse, ID: "t1", Name: "plan"}},
+		}},
+		Tools: map[string]session.ToolRun{
+			"t1": {
+				ToolUseID: "t1", Name: "plan", Status: session.ToolDone,
+				Detail: "plan", Output: "# steps\n1. a", Expanded: true,
+			},
+		},
+	}
+	entries, _, _ := m.Sync(nil, nil, snap)
+	require.Len(t, entries, 1)
+	tb, ok := entries[0].(*block.ToolBlock)
+	require.True(t, ok)
+	assert.True(t, tb.Expanded)
+	assert.Equal(t, "# steps\n1. a", tb.Output)
 }


### PR DESCRIPTION
Extensions that render a body (e.g. plans) had no way to ask the TUI to start the tool row open; only local "!cmd" runs auto-expanded.

Carry Expanded through pxb (field 6, written only when true so old hosts decode unchanged), the Go/Rust SDKs, tools.Result and session.ToolRun, and honor it in the transcript mapper. An explicit user toggle still wins after the first interaction.

Docs and CHANGELOG updated; round-trip and mapper tests added.