### PR TITLE
ci: lint markdown with markdownlint

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,34 @@
+name: Markdown
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.md"
+      - ".markdownlint.yaml"
+      - ".github/workflows/markdown.yml"
+  pull_request:
+    paths:
+      - "**.md"
+      - ".markdownlint.yaml"
+      - ".github/workflows/markdown.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: markdown-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Lint markdown
+        uses: docker://avtodev/markdown-lint:v1@sha256:6aeedc2f49138ce7a1cd0adffc1b1c0321b841dc2102408967d9301c031949ee
+        with:
+          config: .markdownlint.yaml
+          args: "**/*.md"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,31 @@
+# Default state for all rules
+default: true
+
+# ul-style
+MD004: false
+
+# hard-tabs
+MD010: false
+
+# line-length
+MD013: false
+
+# no-duplicate-header
+MD024:
+  siblings_only: true
+
+# single-title
+MD025: false
+
+# ol-prefix
+MD029:
+  style: ordered
+
+# no-inline-html
+MD033: false
+
+# fenced-code-language
+MD040: false
+
+# first-line-h1 — bilingual READMEs start with a language switcher
+MD041: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Extensions: `ToolResult.Expanded` opens the TUI tool row by default (e.g. plan
   body). User toggle still wins after the first interaction.
+- CI / `make lint-markdown`: markdownlint on `**/*.md`.
 
 ### Changed
 
@@ -154,7 +155,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Slash commands can declare `NeedsArgs` (Go) / `needs_args` (Rust). Picker accept or bare submit of `/name` leaves `/name ` in the composer so the user can type arguments instead of auto-running and toasting usage. Built-in `/resume` uses this.
+- Slash commands can declare `NeedsArgs` (Go) / `needs_args` (Rust). Picker accept or bare submit of `/name` leaves `/name` plus a trailing space in the composer so the user can type arguments instead of auto-running and toasting usage. Built-in `/resume` uses this.
 
 ### Changed
 
@@ -415,9 +416,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [0.13.0] - 2026-08-18
 
 ### Added
+
 - TUI hot-reloads the git branch in the path label: switching branches outside the app (another terminal, an editor) refreshes the label automatically.
 
 ### Changed
+
 - TUI activity: tool rows keep a 1-cell braille spinner; the footer uses an
   Knight-Rider scan bar so the two don't share the same glyph.
 - Tool routing: bash is no longer described as an inspection tool; grep/glob no
@@ -430,6 +433,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Deprecated
 
 ### Removed
+
 - Per-hook `hook.json` directories. Use `plugin.json` instead.
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ make test        # go test ./...
 make fmt         # apply gofumpt / goimports / golines
 make fmt-check   # fail if formatting would change files (same as CI)
 make lint        # golangci-lint run ./...
+make lint-markdown # markdownlint via Docker (needs a local daemon)
 make deadcode    # unreachable functions vs baseline (deadcode -test)
 make check       # fmt-check + lint + deadcode (same as CI)
 ```

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ GO       ?= go
 GOFLAGS  ?= -ldflags="-s -w"
 CGO      ?= 0
 
-.PHONY: all build install run clean test fmt fmt-check lint deadcode check help
+# Pin digest so CI / local make use the same markdownlint image.
+MARKDOWN_LINT_IMAGE ?= avtodev/markdown-lint:v1@sha256:6aeedc2f49138ce7a1cd0adffc1b1c0321b841dc2102408967d9301c031949ee
+
+.PHONY: all build install run clean test fmt fmt-check lint lint-markdown deadcode check help
 
 all: build
 
@@ -52,6 +55,10 @@ lint:
 	golangci-lint run ./...
 	cd ext/go && golangci-lint run ./...
 
+# Markdown structure lint (Docker). Needs a local Docker daemon.
+lint-markdown:
+	docker run --rm -v "$(CURDIR):/work" -w /work $(MARKDOWN_LINT_IMAGE) -c /work/.markdownlint.yaml $$(find . -name '*.md' -type f | sort)
+
 deadcode:
 	./scripts/deadcode-check.sh
 
@@ -71,6 +78,7 @@ help:
 	@echo "  make fmt      - format Go sources (gofumpt/goimports/golines)"
 	@echo "  make fmt-check - check formatting without writing (CI)"
 	@echo "  make lint     - run golangci-lint"
+	@echo "  make lint-markdown - lint Markdown (Docker; needs daemon)"
 	@echo "  make deadcode - unreachable func check (deadcode -test vs baseline)"
 	@echo "  make check    - fmt-check + lint + deadcode (CI)"
 	@echo "  make test-rust - test Rust extension SDK (ext/rust)"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A lean, high-performance terminal coding agent harness in Go — a sibling to Pi
 - [Headless mode](#headless-mode)
 - [Skills](#skills)
 - [Permissions](#permissions)
-- [Hooks](#hooks)
+- [Extensions](#extensions)
 - [MCP](#mcp)
 - [Tools](#tools)
 - [Project layout](doc/project-layout.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,7 +28,7 @@
 
 ![phi TUI](assets/image.png)
 
-你可以通过 [Skills（技能）](#skills技能)、[Hooks（钩子）](#hooks钩子)
+你可以通过 [Skills（技能）](#skills技能)、[Extensions（扩展）](#extensions扩展)
 和 [MCP](#mcp) 扩展它——不必做成插件框架。
 
 - [文档](https://pulseaiclub.github.io/docs/getting-started/)
@@ -41,7 +41,7 @@
 - [无头模式](#无头模式)
 - [Skills（技能）](#skills技能)
 - [权限](#权限)
-- [Hooks（钩子）](#hooks钩子)
+- [Extensions（扩展）](#extensions扩展)
 - [MCP](#mcp)
 - [子代理](#子代理)
 - [工具](#工具)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,4 +33,4 @@ Out of scope examples:
 - Vulnerabilities only present in third-party MCP servers or extensions you installed
 - Social engineering of API keys stored in the user’s own config
 
-Product overview of local-first design: https://pulseaiclub.github.io/security/
+Product overview of local-first design: [pulseaiclub.github.io/security](https://pulseaiclub.github.io/security/)


### PR DESCRIPTION
Add a `Markdown` workflow and a `make lint-markdown` target, both pinned to the same `avtodev/markdown-lint` digest so CI and local runs agree. The config disables the rules the docs trip over on purpose: line length, inline HTML, and first-line H1 (the bilingual READMEs open with a language switcher).

Fix the dangling anchors the linter surfaced: README and README.zh-CN listed a Hooks section that no longer exists, and SECURITY.md pointed at a bare URL. Document the new target in CONTRIBUTING.md and the changelog.