### PR TITLE
test: replace all manual assertions with testify

### DIFF
--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -86,7 +86,7 @@ func TestEnsureSearchToolsAttemptsAllDownloads(t *testing.T) {
 		case <-time.After(time.Second):
 			close(release)
 			<-result
-			t.Fatal("downloads did not start concurrently")
+			require.Fail(t, "downloads did not start concurrently")
 		}
 	}
 	close(release)

--- a/internal/agent/engine_mcp_test.go
+++ b/internal/agent/engine_mcp_test.go
@@ -3,6 +3,8 @@ package agent_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/agent"
 	"github.com/pulseaiclub/phi/internal/llm"
 	"github.com/pulseaiclub/phi/internal/mcp"
@@ -14,37 +16,25 @@ func TestEngineRegistersMCPMetaTools(t *testing.T) {
 	})
 
 	sess, err := agent.NewSession(agent.WithCwd(t.TempDir()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	eng, err := agent.NewEngine(
 		llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
 		sess,
 		agent.WithMCP(pool),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for _, name := range []string{"mcp_list", "mcp_inspect", "mcp_call", "bash"} {
-		if !eng.HasTool(name) {
-			t.Fatalf("missing tool %s", name)
-		}
+		require.True(t, eng.HasTool(name), "missing tool %s", name)
 	}
 
 	// Explicit child tool list without MCP → no meta tools (sub-agent path).
 	sess2, err := agent.NewSession(agent.WithCwd(t.TempDir()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	eng2, err := agent.NewEngine(
 		llm.ModelConfig{Name: "test", APIKey: "x", BaseURL: "http://127.0.0.1:9"},
 		sess2,
 		agent.WithTools(agent.ChildTools()),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if eng2.HasTool("mcp_list") {
-		t.Fatal("child tools should not include mcp_list")
-	}
+	require.NoError(t, err)
+	require.False(t, eng2.HasTool("mcp_list"), "child tools should not include mcp_list")
 }

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -141,9 +140,7 @@ func TestLoopMaxRoundsDoesNotExecuteExtraToolRound(t *testing.T) {
 		}
 	}
 	require.Error(t, lastErr, "loop should stop when the model requests a third tool round")
-	if !errors.Is(lastErr, ErrMaxRounds) {
-		t.Fatalf("expected ErrMaxRounds to be wrapped, got %v", lastErr)
-	}
+	require.ErrorIs(t, lastErr, ErrMaxRounds)
 	require.Equal(t, int32(2), runs.Load())
 	require.Equal(t, int32(3), requests.Load())
 

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -60,21 +59,10 @@ func TestExecutorDenyDoesNotRunHandler(t *testing.T) {
 		statuses = append(statuses, td.Run.Status)
 		return true
 	})
-	if ran.Load() != 0 {
-		t.Fatal("handler should not run on deny")
-	}
-	if len(msgs) != 1 || msgs[0].Content != "denied by test" {
-		t.Fatalf("tool message: %+v", msgs)
-	}
-	found := false
-	for _, s := range statuses {
-		if s == session.ToolRejected {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("expected ToolRejected in %v", statuses)
-	}
+	require.Equal(t, int32(0), ran.Load(), "handler should not run on deny")
+	require.Len(t, msgs, 1)
+	require.Equal(t, "denied by test", msgs[0].Content)
+	require.Contains(t, statuses, session.ToolRejected)
 }
 
 func TestExecutorAskFalseRejects(t *testing.T) {
@@ -96,12 +84,9 @@ func TestExecutorAskFalseRejects(t *testing.T) {
 		ID:       "c1",
 		Function: llm.Function{Name: "bash", Arguments: `{"command":"curl x"}`},
 	}}, func(session.ToolData) bool { return true })
-	if ran.Load() != 0 {
-		t.Fatal("handler should not run when ask denied")
-	}
-	if len(msgs) != 1 || msgs[0].Content == "" {
-		t.Fatalf("expected rejection message, got %+v", msgs)
-	}
+	require.Equal(t, int32(0), ran.Load(), "handler should not run when ask denied")
+	require.Len(t, msgs, 1)
+	require.NotEmpty(t, msgs[0].Content, "expected rejection message")
 }
 
 func TestExecutorEmitsToolName(t *testing.T) {
@@ -122,13 +107,9 @@ func TestExecutorEmitsToolName(t *testing.T) {
 		names = append(names, td.Run.Name)
 		return true
 	})
-	if len(names) == 0 {
-		t.Fatal("expected tool events")
-	}
+	require.NotEmpty(t, names, "expected tool events")
 	for _, n := range names {
-		if n != "bash" {
-			t.Fatalf("expected Name=bash on every ToolData, got %q in %v", n, names)
-		}
+		require.Equal(t, "bash", n, "expected Name=bash on every ToolData")
 	}
 }
 
@@ -154,21 +135,10 @@ func TestExecutorAskNilRejectsHeadless(t *testing.T) {
 		statuses = append(statuses, td.Run.Status)
 		return true
 	})
-	if ran.Load() != 0 {
-		t.Fatal("handler should not run when ask handler is nil (headless)")
-	}
-	if len(msgs) != 1 || msgs[0].Content == "" {
-		t.Fatalf("expected rejection message, got %+v", msgs)
-	}
-	found := false
-	for _, s := range statuses {
-		if s == session.ToolRejected {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("expected ToolRejected in %v", statuses)
-	}
+	require.Equal(t, int32(0), ran.Load(), "handler should not run when ask handler is nil (headless)")
+	require.Len(t, msgs, 1)
+	require.NotEmpty(t, msgs[0].Content, "expected rejection message")
+	require.Contains(t, statuses, session.ToolRejected)
 }
 
 func TestExecutorAskTrueRuns(t *testing.T) {
@@ -190,12 +160,9 @@ func TestExecutorAskTrueRuns(t *testing.T) {
 		ID:       "c1",
 		Function: llm.Function{Name: "bash", Arguments: `{"command":"curl x"}`},
 	}}, func(session.ToolData) bool { return true })
-	if ran.Load() != 1 {
-		t.Fatal("handler should run when ask approved")
-	}
-	if len(msgs) != 1 || msgs[0].Content != "ran" {
-		t.Fatalf("got %+v", msgs)
-	}
+	require.Equal(t, int32(1), ran.Load(), "handler should run when ask approved")
+	require.Len(t, msgs, 1)
+	require.Equal(t, "ran", msgs[0].Content)
 }
 
 func TestExecutorAskFeedbackMessage(t *testing.T) {
@@ -215,9 +182,8 @@ func TestExecutorAskFeedbackMessage(t *testing.T) {
 		ID:       "c1",
 		Function: llm.Function{Name: "bash", Arguments: `{"command":"curl x"}`},
 	}}, func(session.ToolData) bool { return true })
-	if len(msgs) != 1 || !strings.Contains(msgs[0].Content, "use go test instead") {
-		t.Fatalf("expected feedback in message, got %+v", msgs)
-	}
+	require.Len(t, msgs, 1)
+	require.Contains(t, msgs[0].Content, "use go test instead")
 }
 
 func TestExecutorNilAskOnAskDenies(t *testing.T) {
@@ -234,9 +200,8 @@ func TestExecutorNilAskOnAskDenies(t *testing.T) {
 		ID:       "c1",
 		Function: llm.Function{Name: "bash", Arguments: `{"command":"curl x"}`},
 	}}, func(session.ToolData) bool { return true })
-	if len(msgs) != 1 || msgs[0].Content == "" {
-		t.Fatalf("expected deny message, got %+v", msgs)
-	}
+	require.Len(t, msgs, 1)
+	require.NotEmpty(t, msgs[0].Content, "expected deny message")
 }
 
 func TestExecutorExtDenySkipsGateAsk(t *testing.T) {
@@ -465,7 +430,7 @@ func TestExecutorRunsReadableBatchConcurrently(t *testing.T) {
 		select {
 		case <-entered:
 		case <-time.After(2 * time.Second):
-			t.Fatal("readable batch did not run concurrently")
+			require.Fail(t, "readable batch did not run concurrently")
 		}
 	}
 	close(release)
@@ -512,12 +477,12 @@ func TestExecutorMixedBatchStaysSequential(t *testing.T) {
 	case name := <-entered:
 		assert.Equal(t, "readA", name, "readable call should run first")
 	case <-time.After(2 * time.Second):
-		t.Fatal("first call never started")
+		require.Fail(t, "first call never started")
 	}
 	// The write tool must not start while the first call is still running.
 	select {
 	case name := <-entered:
-		t.Fatalf("second call %q started before the first finished", name)
+		require.Failf(t, "second call %q started before the first finished", name)
 	case <-time.After(150 * time.Millisecond):
 	}
 	close(release)
@@ -525,7 +490,7 @@ func TestExecutorMixedBatchStaysSequential(t *testing.T) {
 	case name := <-entered:
 		assert.Equal(t, "bash", name)
 	case <-time.After(2 * time.Second):
-		t.Fatal("second call never started after first released")
+		require.Fail(t, "second call never started after first released")
 	}
 	<-done
 

--- a/internal/agent/prompt/context_test.go
+++ b/internal/agent/prompt/context_test.go
@@ -3,8 +3,9 @@ package prompt
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadContextFileFromDirPrefersAGENTS(t *testing.T) {
@@ -13,12 +14,8 @@ func TestLoadContextFileFromDirPrefersAGENTS(t *testing.T) {
 	mustWrite(t, filepath.Join(dir, "AGENTS.md"), "agents rules")
 
 	got := loadContextFileFromDir(dir)
-	if got == nil {
-		t.Fatal("expected a context file")
-	}
-	if got.Content != "agents rules" {
-		t.Fatalf("prefer AGENTS.md, got %q", got.Content)
-	}
+	require.NotNil(t, got, "expected a context file")
+	require.Equal(t, "agents rules", got.Content, "prefer AGENTS.md")
 }
 
 func TestLoadContextFileFromDirFallsBackToCLAUDE(t *testing.T) {
@@ -26,9 +23,8 @@ func TestLoadContextFileFromDirFallsBackToCLAUDE(t *testing.T) {
 	mustWrite(t, filepath.Join(dir, "CLAUDE.md"), "claude only")
 
 	got := loadContextFileFromDir(dir)
-	if got == nil || got.Content != "claude only" {
-		t.Fatalf("got %+v", got)
-	}
+	require.NotNil(t, got)
+	require.Equal(t, "claude only", got.Content)
 }
 
 func TestLoadProjectContextFilesOrder(t *testing.T) {
@@ -44,14 +40,10 @@ func TestLoadProjectContextFilesOrder(t *testing.T) {
 	mustWrite(t, filepath.Join(cwd, "CLAUDE.md"), "cwd")
 
 	files := loadProjectContextFiles(cwd, agentDir)
-	if len(files) != 3 {
-		t.Fatalf("expected 3 files, got %d: %+v", len(files), files)
-	}
+	require.Len(t, files, 3)
 	want := []string{"global", "mid", "cwd"}
 	for i, w := range want {
-		if files[i].Content != w {
-			t.Fatalf("files[%d]=%q want %q", i, files[i].Content, w)
-		}
+		require.Equal(t, w, files[i].Content, "files[%d]", i)
 	}
 }
 
@@ -60,27 +52,17 @@ func TestLoadProjectContextFilesDedupesAgentDir(t *testing.T) {
 	mustWrite(t, filepath.Join(dir, "AGENTS.md"), "once")
 
 	files := loadProjectContextFiles(dir, dir)
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file, got %d", len(files))
-	}
+	require.Len(t, files, 1)
 }
 
 func TestFormatProjectContext(t *testing.T) {
 	got := formatProjectContext([]ContextFile{
 		{Path: "/tmp/AGENTS.md", Content: "use gofmt"},
 	})
-	if !strings.Contains(got, "<project_context>") {
-		t.Fatalf("missing wrapper: %q", got)
-	}
-	if !strings.Contains(got, `<project_instructions path="/tmp/AGENTS.md">`) {
-		t.Fatalf("missing path attr: %q", got)
-	}
-	if !strings.Contains(got, "use gofmt") {
-		t.Fatalf("missing body: %q", got)
-	}
-	if formatProjectContext(nil) != "" {
-		t.Fatal("empty files should yield empty string")
-	}
+	require.Contains(t, got, "<project_context>")
+	require.Contains(t, got, `<project_instructions path="/tmp/AGENTS.md">`)
+	require.Contains(t, got, "use gofmt")
+	require.Empty(t, formatProjectContext(nil), "empty files should yield empty string")
 }
 
 func TestBuildIncludesContext(t *testing.T) {
@@ -88,21 +70,15 @@ func TestBuildIncludesContext(t *testing.T) {
 	mustWrite(t, filepath.Join(dir, "AGENTS.md"), "always use tabs")
 
 	ctx := formatProjectContext(loadProjectContextFiles(dir, t.TempDir()))
-	if !strings.Contains(ctx, "always use tabs") {
-		t.Fatalf("expected cwd AGENTS.md in context, got %q", ctx)
-	}
+	require.Contains(t, ctx, "always use tabs")
 }
 
 func mustWrite(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }
 
 func mustMkdir(t *testing.T, path string) {
 	t.Helper()
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(path, 0o755))
 }

--- a/internal/agent/prompt/prompt_test.go
+++ b/internal/agent/prompt/prompt_test.go
@@ -1,79 +1,46 @@
 package prompt
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildAgentsEnabledToggle(t *testing.T) {
 	with := Build("", true, 4, nil)
 	without := Build("", false, 0, nil)
 
-	if !strings.Contains(with, "agent_spawn") {
-		t.Fatal("expected agent_spawn guidance when agents enabled")
-	}
-	if !strings.Contains(with, "Sub-agents:") {
-		t.Fatal("expected Sub-agents section when agents enabled")
-	}
-	if !strings.Contains(with, "At most 4 sub-agents run concurrently") {
-		t.Fatal("expected sub-agent concurrency cap when agents enabled")
-	}
-	if strings.Contains(without, "agent_spawn") {
-		t.Fatal("did not expect sub-agent tool names when agents disabled")
-	}
-	if strings.Contains(without, "sub-agents run concurrently") {
-		t.Fatal("did not expect sub-agent concurrency cap when agents disabled")
-	}
-	if !strings.Contains(without, "`find` / `grep` / `ls` yourself") {
-		t.Fatal("expected direct-search guidance when agents disabled")
-	}
+	require.Contains(t, with, "agent_spawn")
+	require.Contains(t, with, "Sub-agents:")
+	require.Contains(t, with, "At most 4 sub-agents run concurrently")
+	require.NotContains(t, without, "agent_spawn")
+	require.NotContains(t, without, "sub-agents run concurrently")
+	require.Contains(t, without, "`find` / `grep` / `ls` yourself")
 }
 
 func TestBuildEditHashCopyIsUnambiguous(t *testing.T) {
 	got := Build("", false, 0, nil)
-	if strings.Contains(got, "copy `@file path#TAG` into") {
-		t.Fatal("prompt must not tell the model to paste the whole @file header into edit.hash")
-	}
-	if !strings.Contains(got, "4 hex chars after `#`") {
-		t.Fatal("expected edit.hash to be described as the 4 hex chars after #")
-	}
-	if strings.Contains(got, "Known path or exact symbol") {
-		t.Fatal("known-path routing must not bundle ls/find/grep/read together")
-	}
-	if strings.Contains(got, "creates a new file only") || strings.Contains(got, "fails if it already exists") {
-		t.Fatal("write must not be described as create-only")
-	}
-	if !strings.Contains(got, "`write` creates or overwrites") {
-		t.Fatal("expected write to create or overwrite")
-	}
-	if !strings.Contains(got, "Prefer cwd-relative paths") {
-		t.Fatal("expected tools to prefer cwd-relative paths")
-	}
+	require.NotContains(t, got, "copy `@file path#TAG` into")
+	require.Contains(t, got, "4 hex chars after `#`")
+	require.NotContains(t, got, "Known path or exact symbol")
+	require.NotContains(t, got, "creates a new file only")
+	require.NotContains(t, got, "fails if it already exists")
+	require.Contains(t, got, "`write` creates or overwrites")
+	require.Contains(t, got, "Prefer cwd-relative paths")
 }
 
 func TestBuildMCPCatalog(t *testing.T) {
 	none := Build("", false, 0, nil)
-	if strings.Contains(none, "# MCP") {
-		t.Fatal("expected no MCP section without servers")
-	}
-	if strings.Contains(none, "External docs/URLs") {
-		t.Fatal("Discovery must not mention MCP/URLs when no servers are configured")
-	}
+	require.NotContains(t, none, "# MCP")
+	require.NotContains(t, none, "External docs/URLs")
 	got := Build("", false, 0, []string{"browsermcp", "github"})
-	if !strings.Contains(got, "# MCP") {
-		t.Fatal("expected MCP section")
-	}
-	if !strings.Contains(got, "- browsermcp") || !strings.Contains(got, "- github") {
-		t.Fatalf("expected server names in catalog, got:\n%s", got)
-	}
-	if !strings.Contains(got, "mcp_list") || !strings.Contains(got, "mcp_inspect") ||
-		!strings.Contains(got, "mcp_call") {
-		t.Fatal("expected mcp_* usage guidance")
-	}
-	if !strings.Contains(got, "docs/URLs") {
-		t.Fatal("expected MCP block to mention external docs/URLs when servers are configured")
-	}
-	if strings.Contains(got, `"properties"`) || strings.Contains(got, "inputSchema") {
-		t.Fatal("MCP catalog must not include tool schemas")
-	}
+	require.Contains(t, got, "# MCP")
+	require.Contains(t, got, "- browsermcp")
+	require.Contains(t, got, "- github")
+	require.Contains(t, got, "mcp_list")
+	require.Contains(t, got, "mcp_inspect")
+	require.Contains(t, got, "mcp_call")
+	require.Contains(t, got, "docs/URLs")
+	require.NotContains(t, got, `"properties"`)
+	require.NotContains(t, got, "inputSchema")
 }

--- a/internal/components/block/assistant_block_test.go
+++ b/internal/components/block/assistant_block_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pulseaiclub/xui"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/session"
@@ -159,9 +160,8 @@ func TestAssistantBlockDraw(t *testing.T) {
 			}
 
 			for _, cc := range tt.wantCells {
-				if cc.y >= surface.Size.Height || cc.x >= surface.Size.Width {
-					t.Fatalf("cell (%d,%d) outside surface %dx%d", cc.x, cc.y, surface.Size.Width, surface.Size.Height)
-				}
+				require.True(t, cc.y < surface.Size.Height && cc.x < surface.Size.Width,
+					"cell (%d,%d) outside surface %dx%d", cc.x, cc.y, surface.Size.Width, surface.Size.Height)
 				got := surface.Buffer[cc.y*surface.Size.Width+cc.x]
 				assert.True(
 					t,

--- a/internal/components/block/blocks_test.go
+++ b/internal/components/block/blocks_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/block"
 	"github.com/pulseaiclub/phi/internal/components/status"
@@ -23,30 +25,24 @@ func TestBashBlockRendersOutput(t *testing.T) {
 	}
 	s := b.Draw(components.DrawContext{Max: components.Size{Width: 60, Height: 40}})
 	joined := components.SurfaceText(s)
-	if !strings.Contains(joined, "$") || !strings.Contains(joined, "ls") {
-		t.Fatalf("missing command: %q", joined)
-	}
-	if strings.Contains(joined, "Show more") || strings.Contains(joined, "lines truncated") {
-		t.Fatalf("must not show Show-more chrome: %q", joined)
-	}
-	if !strings.Contains(joined, "file.go") {
-		t.Fatalf("missing output: %q", joined)
-	}
+	require.Contains(t, joined, "$")
+	require.Contains(t, joined, "ls")
+	require.NotContains(t, joined, "Show more")
+	require.NotContains(t, joined, "lines truncated")
+	require.Contains(t, joined, "file.go")
 }
 
 func TestUserAndAssistant(t *testing.T) {
 	u := &block.UserBlock{Text: "hello", Theme: components.DefaultTheme()}
 	us := u.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: 5}})
-	if !strings.Contains(components.SurfaceText(us), "$ hello") &&
-		!strings.Contains(components.SurfaceText(us), "hello") {
-		t.Fatalf("user: %q", components.SurfaceText(us))
-	}
+	usText := components.SurfaceText(us)
+	require.True(t, strings.Contains(usText, "$ hello") || strings.Contains(usText, "hello"),
+		"user: %q", usText)
 	a := &block.AssistantBlock{Text: "see `xui` and examples/", Theme: components.DefaultTheme()}
 	as := a.Draw(components.DrawContext{Max: components.Size{Width: 60, Height: 5}})
 	txt := components.SurfaceText(as)
-	if !strings.Contains(txt, "xui") || !strings.Contains(txt, "examples") {
-		t.Fatalf("assistant: %q", txt)
-	}
+	require.Contains(t, txt, "xui")
+	require.Contains(t, txt, "examples")
 }
 
 func TestAgentBlockRendersTreeAndMarkdown(t *testing.T) {
@@ -64,21 +60,16 @@ func TestAgentBlockRendersTreeAndMarkdown(t *testing.T) {
 	}
 	s := a.Draw(components.DrawContext{Max: components.Size{Width: 80, Height: 40}})
 	txt := components.SurfaceText(s)
-	if !strings.Contains(txt, "agent_spawn") || !strings.Contains(txt, "find bug") {
-		t.Fatalf("title: %q", txt)
-	}
-	if !strings.Contains(txt, "├──") || !strings.Contains(txt, "╰──") {
-		t.Fatalf("missing tree connectors: %q", txt)
-	}
-	if !strings.Contains(txt, "read") || !strings.Contains(txt, "bash") {
-		t.Fatalf("missing children: %q", txt)
-	}
-	if !strings.Contains(txt, "Findings") || !strings.Contains(txt, "fixed") {
-		t.Fatalf("missing markdown summary: %q", txt)
-	}
-	if strings.Contains(txt, `"job_id"`) || strings.Contains(txt, `"summary"`) {
-		t.Fatalf("must not show raw JSON: %q", txt)
-	}
+	require.Contains(t, txt, "agent_spawn")
+	require.Contains(t, txt, "find bug")
+	require.Contains(t, txt, "├──")
+	require.Contains(t, txt, "╰──")
+	require.Contains(t, txt, "read")
+	require.Contains(t, txt, "bash")
+	require.Contains(t, txt, "Findings")
+	require.Contains(t, txt, "fixed")
+	require.NotContains(t, txt, `"job_id"`)
+	require.NotContains(t, txt, `"summary"`)
 }
 
 func TestUserBlockImplementsWidget(_ *testing.T) {

--- a/internal/components/block/cjk_render_test.go
+++ b/internal/components/block/cjk_render_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
@@ -29,9 +31,7 @@ func TestCJKSampleNoBlankGapsAfterClearRender(t *testing.T) {
 
 	txt := components.SurfaceText(s)
 	for _, want := range []string{"翻出几篇你满意的", "把每次", "笔记"} {
-		if !strings.Contains(txt, want) {
-			t.Fatalf("surface missing %q", want)
-		}
+		require.Contains(t, txt, want, "surface missing %q", want)
 	}
 
 	var b strings.Builder
@@ -50,15 +50,11 @@ func TestCJKSampleNoBlankGapsAfterClearRender(t *testing.T) {
 	}
 	got := b.String()
 	for _, want := range []string{"翻出几篇你满意的", "把每次"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("screen missing %q\n%s", want, got)
-		}
+		require.Contains(t, got, want, "screen missing %q\n%s", want, got)
 	}
 
 	screen.MarkRefresh()
 	for _, d := range screen.Diff() {
-		if d.Cell.Trail {
-			t.Fatalf("Diff emitted Trail at (%d,%d)", d.X, d.Y)
-		}
+		require.False(t, d.Cell.Trail, "Diff emitted Trail at (%d,%d)", d.X, d.Y)
 	}
 }

--- a/internal/components/block/user_block_test.go
+++ b/internal/components/block/user_block_test.go
@@ -1,8 +1,9 @@
 package block
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/xui"
 
@@ -13,10 +14,6 @@ func TestExtractUserMessageSkipsRuleChrome(t *testing.T) {
 	ub := &UserBlock{Text: "13个技能 你把这个 skills挪动过去", Theme: components.DefaultTheme()}
 	s := ub.Draw(components.DrawContext{Max: components.Size{Width: 60, Height: 5}, Method: xui.WidthUnicode})
 	got := components.ExtractSurfaceText(s, 0, 0, 59, 0)
-	if strings.Contains(got, "▎") {
-		t.Fatalf("selection must not include rule chrome: %q", got)
-	}
-	if got != ub.Text {
-		t.Fatalf("got %q, want %q", got, ub.Text)
-	}
+	require.NotContains(t, got, "▎")
+	require.Equal(t, ub.Text, got)
 }

--- a/internal/components/chat/mention_test.go
+++ b/internal/components/chat/mention_test.go
@@ -1,6 +1,10 @@
 package chat
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestActiveMention(t *testing.T) {
 	tests := []struct {
@@ -26,16 +30,13 @@ func TestActiveMention(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			q, start, end, ok := ActiveMention(tt.value, tt.cursor)
-			if ok != tt.ok {
-				t.Fatalf("ok=%v want %v (q=%q)", ok, tt.ok, q)
-			}
+			require.Equal(t, tt.ok, ok, "q=%q", q)
 			if !ok {
 				return
 			}
-			if q != tt.query || start != tt.start || end != tt.cursor {
-				t.Fatalf("q=%q start=%d end=%d want q=%q start=%d end=%d",
-					q, start, end, tt.query, tt.start, tt.cursor)
-			}
+			require.Equal(t, tt.query, q, "query")
+			require.Equal(t, tt.start, start, "start")
+			require.Equal(t, tt.cursor, end, "end")
 		})
 	}
 }
@@ -43,10 +44,6 @@ func TestActiveMention(t *testing.T) {
 func TestReplaceRange(t *testing.T) {
 	c := &ChatInput{Value: "see @man", Cursor: 8}
 	c.ReplaceRange(4, 8, "@internal/session/manager.go")
-	if c.Value != "see @internal/session/manager.go" {
-		t.Fatalf("value=%q", c.Value)
-	}
-	if c.Cursor != len(c.Value) {
-		t.Fatalf("cursor=%d", c.Cursor)
-	}
+	require.Equal(t, "see @internal/session/manager.go", c.Value)
+	require.Equal(t, len(c.Value), c.Cursor)
 }

--- a/internal/components/chat/slash_test.go
+++ b/internal/components/chat/slash_test.go
@@ -3,6 +3,8 @@ package chat
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestActiveSlash(t *testing.T) {
@@ -27,21 +29,14 @@ func TestActiveSlash(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			q, start, end, ok := ActiveSlash(tt.value, tt.cursor)
-			if ok != tt.ok {
-				t.Fatalf("ok=%v want %v", ok, tt.ok)
-			}
+			require.Equal(t, tt.ok, ok)
 			if !ok {
 				return
 			}
-			if q != tt.query {
-				t.Fatalf("query=%q want %q", q, tt.query)
-			}
-			if start != 0 || end != tt.cursor {
-				t.Fatalf("range=[%d,%d) want [0,%d)", start, end, tt.cursor)
-			}
-			if !strings.HasPrefix(tt.value, "/") {
-				t.Fatal("expected slash prefix")
-			}
+			require.Equal(t, tt.query, q)
+			require.Equal(t, 0, start, "start")
+			require.Equal(t, tt.cursor, end, "end")
+			require.True(t, strings.HasPrefix(tt.value, "/"), "expected slash prefix")
 		})
 	}
 }

--- a/internal/components/cjk_render_test.go
+++ b/internal/components/cjk_render_test.go
@@ -4,15 +4,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/xui"
 )
 
 func TestCJKTrailNotPaintedColumnByColumn(t *testing.T) {
 	s := NewSurface(10, 1, nil)
 	s.Print(0, 0, "笔记", xui.Style{}, xui.WidthUnicode)
-	if !s.Buffer[1].Trail {
-		t.Fatalf("expected trail at col 1, got %+v", s.Buffer[1])
-	}
+	require.True(t, s.Buffer[1].Trail, "expected trail at col 1, got %+v", s.Buffer[1])
 	screen := xui.NewScreen(10, 1)
 	win := xui.NewWindow(screen)
 	win.Clear()
@@ -23,19 +23,15 @@ func TestCJKTrailNotPaintedColumnByColumn(t *testing.T) {
 			win.SetCell(x, 0, c)
 		}
 	}
-	if got := screen.GetCell(0, 0); got.Char != "笔" || got.Width != 2 {
-		t.Fatalf("primary = %+v", got)
-	}
-	if got := screen.GetCell(1, 0); !got.Trail {
-		t.Fatalf("screen trail = %+v", got)
-	}
+	got0 := screen.GetCell(0, 0)
+	require.Equal(t, "笔", got0.Char, "primary")
+	require.Equal(t, uint8(2), got0.Width, "primary width")
+	got1 := screen.GetCell(1, 0)
+	require.True(t, got1.Trail, "screen trail = %+v", got1)
 	r := xui.NewRenderer()
 	screen.MarkRefresh()
 	var buf strings.Builder
-	if _, err := r.RenderDiff(&buf, screen.Diff(), -1, -1, false, 0); err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(buf.String(), "笔\x1b[1;2H") {
-		t.Fatal("ANSI writes into trail column after 笔")
-	}
+	_, err := r.RenderDiff(&buf, screen.Diff(), -1, -1, false, 0)
+	require.NoError(t, err)
+	require.NotContains(t, buf.String(), "笔\x1b[1;2H", "ANSI writes into trail column after 笔")
 }

--- a/internal/components/mention/picker_test.go
+++ b/internal/components/mention/picker_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pulseaiclub/xui"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 )
 
@@ -18,15 +20,9 @@ func TestPickerAccept(t *testing.T) {
 	}
 	p.Show()
 	p.Selected = 1
-	if !p.Accept() {
-		t.Fatal("accept failed")
-	}
-	if got != "a/b.go" {
-		t.Fatalf("got %q", got)
-	}
-	if p.Open {
-		t.Fatal("should be closed")
-	}
+	require.True(t, p.Accept(), "accept failed")
+	require.Equal(t, "a/b.go", got)
+	require.False(t, p.Open, "should be closed")
 }
 
 func TestPickerHandleNav(t *testing.T) {
@@ -34,18 +30,10 @@ func TestPickerHandleNav(t *testing.T) {
 		Items: []Item{{Path: "a"}, {Path: "b"}, {Path: "c"}},
 	}
 	p.Show()
-	if !p.HandleNav(xui.KeyEvent{Press: true, Code: xui.KeyDown}) {
-		t.Fatal("expected consume")
-	}
-	if p.Selected != 1 {
-		t.Fatalf("selected=%d", p.Selected)
-	}
-	if !p.HandleNav(xui.KeyEvent{Press: true, Code: xui.KeyEscape}) {
-		t.Fatal("expected consume")
-	}
-	if p.Open {
-		t.Fatal("should close on escape")
-	}
+	require.True(t, p.HandleNav(xui.KeyEvent{Press: true, Code: xui.KeyDown}), "expected consume")
+	require.Equal(t, 1, p.Selected)
+	require.True(t, p.HandleNav(xui.KeyEvent{Press: true, Code: xui.KeyEscape}), "expected consume")
+	require.False(t, p.Open, "should close on escape")
 }
 
 func TestPickerDrawClosed(t *testing.T) {
@@ -54,9 +42,7 @@ func TestPickerDrawClosed(t *testing.T) {
 		Max:    components.Size{Width: 80, Height: 24},
 		Method: xui.WidthUnicode,
 	})
-	if len(surf.Children) != 0 {
-		t.Fatal("closed picker should have no children")
-	}
+	require.Empty(t, surf.Children, "closed picker should have no children")
 }
 
 func TestPickerDrawOpen(t *testing.T) {
@@ -72,11 +58,8 @@ func TestPickerDrawOpen(t *testing.T) {
 		Max:    components.Size{Width: 80, Height: 24},
 		Method: xui.WidthUnicode,
 	})
-	if len(surf.Children) != 1 {
-		t.Fatalf("children=%d", len(surf.Children))
-	}
+	require.Len(t, surf.Children, 1)
 	child := surf.Children[0]
-	if child.Origin.Y+child.Surface.Size.Height > 20 {
-		t.Fatalf("panel should sit above anchor: oy=%d h=%d", child.Origin.Y, child.Surface.Size.Height)
-	}
+	require.LessOrEqual(t, child.Origin.Y+child.Surface.Size.Height, 20,
+		"panel should sit above anchor: oy=%d h=%d", child.Origin.Y, child.Surface.Size.Height)
 }

--- a/internal/components/palette/command_palette_test.go
+++ b/internal/components/palette/command_palette_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pulseaiclub/xui"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 )
 
@@ -21,21 +23,17 @@ func TestCommandPaletteFilterAndAccept(t *testing.T) {
 		OnAccept: func(c PaletteCommand) { accepted = c.ID },
 	}
 	p.Show()
-	if !p.Open || len(p.filtered) != 3 {
-		t.Fatalf("open=%v filtered=%d", p.Open, len(p.filtered))
-	}
+	require.True(t, p.Open && len(p.filtered) == 3, "open=%v filtered=%d", p.Open, len(p.filtered))
 
 	ctx := &components.EventContext{}
 	for _, r := range "help" {
 		p.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: r, Press: true})
 	}
-	if len(p.filtered) != 1 || p.Commands[p.filtered[0]].ID != "2" {
-		t.Fatalf("filter help → %#v", p.filtered)
-	}
+	require.Len(t, p.filtered, 1)
+	require.Equal(t, "2", p.Commands[p.filtered[0]].ID)
 	p.Handle(ctx, xui.KeyEvent{Code: xui.KeyEnter, Press: true})
-	if accepted != "2" || p.Open {
-		t.Fatalf("accept id=%q open=%v", accepted, p.Open)
-	}
+	require.Equal(t, "2", accepted)
+	require.False(t, p.Open)
 }
 
 func TestCommandPaletteDraw(t *testing.T) {
@@ -48,9 +46,7 @@ func TestCommandPaletteDraw(t *testing.T) {
 	}
 	p.Show()
 	s := p.Draw(components.DrawContext{Max: components.Size{Width: 80, Height: 24}, Method: xui.WidthUnicode})
-	if len(s.Children) != 1 {
-		t.Fatalf("children=%d", len(s.Children))
-	}
+	require.Len(t, s.Children, 1)
 	panel := s.Children[0].Surface
 	var b strings.Builder
 	for x := 0; x < panel.Size.Width; x++ {
@@ -61,24 +57,16 @@ func TestCommandPaletteDraw(t *testing.T) {
 		b.WriteString(ch)
 	}
 	top := b.String()
-	if !strings.Contains(top, "Command Palette") {
-		t.Fatalf("missing title: %q", top)
-	}
+	require.Contains(t, top, "Command Palette")
 }
 
 func TestFuzzyMatch(t *testing.T) {
 	ok, _ := fuzzyMatch("", "mode use boost")
-	if !ok {
-		t.Fatal("empty query should match")
-	}
+	require.True(t, ok, "empty query should match")
 	ok, score := fuzzyMatch("boost", "mode use boost")
-	if !ok || score < 0.15 {
-		t.Fatalf("boost score=%v", score)
-	}
+	require.True(t, ok && score >= 0.15, "boost score=%v", score)
 	ok, _ = fuzzyMatch("zzz", "mode use boost")
-	if ok {
-		t.Fatal("zzz should not match")
-	}
+	require.False(t, ok, "zzz should not match")
 }
 
 func TestCommandPaletteNestedSubmenu(t *testing.T) {
@@ -106,14 +94,14 @@ func TestCommandPaletteNestedSubmenu(t *testing.T) {
 		p.Handle(ctx, xui.KeyEvent{Code: xui.KeyRune, Rune: r, Press: true})
 	}
 	p.Handle(ctx, xui.KeyEvent{Code: xui.KeyEnter, Press: true})
-	if !p.Open || p.Title != "Select Theme" || len(p.stack) != 1 {
-		t.Fatalf("expected nested open title=%q stack=%d open=%v", p.Title, len(p.stack), p.Open)
-	}
+	require.True(t, p.Open, "expected nested open title=%q stack=%d open=%v", p.Title, len(p.stack), p.Open)
+	require.Equal(t, "Select Theme", p.Title)
+	require.Len(t, p.stack, 1)
 	// Esc pops back
 	p.Handle(ctx, xui.KeyEvent{Code: xui.KeyEscape, Press: true})
-	if !p.Open || p.Title != "Command Palette" || len(p.stack) != 0 {
-		t.Fatalf("pop failed title=%q stack=%d", p.Title, len(p.stack))
-	}
+	require.True(t, p.Open, "pop failed title=%q stack=%d", p.Title, len(p.stack))
+	require.Equal(t, "Command Palette", p.Title)
+	require.Empty(t, p.stack)
 	// Enter submenu again and pick Dark
 	p.Query = ""
 	p.Cursor = 0
@@ -124,7 +112,6 @@ func TestCommandPaletteNestedSubmenu(t *testing.T) {
 	}
 	p.Handle(ctx, xui.KeyEvent{Code: xui.KeyEnter, Press: true})
 	p.Handle(ctx, xui.KeyEvent{Code: xui.KeyEnter, Press: true}) // first theme
-	if picked != "dark" || p.Open {
-		t.Fatalf("pick=%q open=%v", picked, p.Open)
-	}
+	require.Equal(t, "dark", picked)
+	require.False(t, p.Open)
 }

--- a/internal/components/selection_test.go
+++ b/internal/components/selection_test.go
@@ -3,6 +3,8 @@ package components
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/xui"
 )
 
@@ -11,13 +13,9 @@ func TestExtractSurfaceText(t *testing.T) {
 	s.Print(0, 0, "hello", xui.Style{}, xui.WidthUnicode)
 	s.Print(0, 1, "world", xui.Style{}, xui.WidthUnicode)
 	got := ExtractSurfaceText(s, 0, 0, 4, 1)
-	if got != "hello\nworld" {
-		t.Fatalf("got %q", got)
-	}
+	require.Equal(t, "hello\nworld", got)
 	partial := ExtractSurfaceText(s, 1, 0, 3, 0)
-	if partial != "ell" {
-		t.Fatalf("partial=%q", partial)
-	}
+	require.Equal(t, "ell", partial)
 }
 
 func TestExtractSurfaceTextCJKNoContinuationSpaces(t *testing.T) {
@@ -27,14 +25,10 @@ func TestExtractSurfaceTextCJKNoContinuationSpaces(t *testing.T) {
 	s.Print(0, 0, "二进制文件 phi", xui.Style{}, xui.WidthUnicode)
 	got := ExtractSurfaceText(s, 0, 0, 19, 0)
 	want := "二进制文件 phi"
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
-	}
+	require.Equal(t, want, got)
 	// Selecting only the trail half of the first glyph still yields the rune.
 	half := ExtractSurfaceText(s, 1, 0, 1, 0)
-	if half != "二" {
-		t.Fatalf("half-select=%q, want 二", half)
-	}
+	require.Equal(t, "二", half)
 }
 
 func TestExtractSurfaceTextSkipsRuleChrome(t *testing.T) {
@@ -43,19 +37,11 @@ func TestExtractSurfaceTextSkipsRuleChrome(t *testing.T) {
 	s.SetCell(1, 0, xui.Cell{Char: " ", Width: 1})
 	s.Print(2, 0, "你好", xui.Style{}, xui.WidthUnicode)
 	got := ExtractSurfaceText(s, 0, 0, 19, 0)
-	if got != "你好" {
-		t.Fatalf("got %q, want 你好", got)
-	}
+	require.Equal(t, "你好", got)
 }
 
 func TestInTextSelection(t *testing.T) {
-	if !InTextSelection(2, 0, 0, 0, 5, 0) {
-		t.Fatal("mid single line")
-	}
-	if InTextSelection(0, 1, 2, 0, 5, 0) {
-		t.Fatal("below single line")
-	}
-	if !InTextSelection(0, 1, 2, 0, 3, 2) {
-		t.Fatal("middle of multi-line")
-	}
+	require.True(t, InTextSelection(2, 0, 0, 0, 5, 0), "mid single line")
+	require.False(t, InTextSelection(0, 1, 2, 0, 5, 0), "below single line")
+	require.True(t, InTextSelection(0, 1, 2, 0, 3, 2), "middle of multi-line")
 }

--- a/internal/components/splash/screen_test.go
+++ b/internal/components/splash/screen_test.go
@@ -3,6 +3,8 @@ package splash
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
@@ -18,7 +20,5 @@ func TestScreenDrawLayout(t *testing.T) {
 		Max:    components.Size{Width: 100, Height: 40},
 		Method: xui.WidthUnicode,
 	})
-	if len(surf.Children) != 2 {
-		t.Fatalf("children = %d, want 2 (sphere + text)", len(surf.Children))
-	}
+	require.Len(t, surf.Children, 2, "sphere + text")
 }

--- a/internal/components/splash/sphere_test.go
+++ b/internal/components/splash/sphere_test.go
@@ -3,6 +3,8 @@ package splash
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
@@ -14,16 +16,13 @@ func TestSphereDrawFillsEllipse(t *testing.T) {
 		Max:    components.Size{Width: 20, Height: 20},
 		Method: xui.WidthUnicode,
 	})
-	if surf.Size.Width != 20 || surf.Size.Height != 20 {
-		t.Fatalf("size = %dx%d", surf.Size.Width, surf.Size.Height)
-	}
+	require.Equal(t, 20, surf.Size.Width, "surface width")
+	require.Equal(t, 20, surf.Size.Height, "surface height")
 	nonEmpty := 0
 	for _, c := range surf.Buffer {
 		if c.Char != "" && c.Char != " " {
 			nonEmpty++
 		}
 	}
-	if nonEmpty < 40 {
-		t.Fatalf("expected sphere cells, got %d non-empty", nonEmpty)
-	}
+	require.GreaterOrEqual(t, nonEmpty, 40, "expected sphere cells")
 }

--- a/internal/components/surface_test.go
+++ b/internal/components/surface_test.go
@@ -3,6 +3,8 @@ package components
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/xui"
 )
 
@@ -20,20 +22,21 @@ func TestSurfaceRenderWideCharAfterFill(t *testing.T) {
 	s.Print(0, 0, "中文", xui.Style{}, xui.WidthUnicode)
 	s.Render(win)
 
-	if got := screen.GetCell(0, 0); got.Char != "中" || got.Width != 2 {
-		t.Fatalf("cell0 = %+v, want 中 width 2", got)
-	}
+	cell0 := screen.GetCell(0, 0)
+	require.Equal(t, "中", cell0.Char, "cell0 char")
+	require.Equal(t, uint8(2), cell0.Width, "cell0 width")
 	// Column 1 is the wide-char trail owned by screen.SetCell — not a second glyph.
-	if got := screen.GetCell(1, 0); got.Char != " " || got.Width != 1 || !got.Trail {
-		t.Fatalf("cell1 continuation = %+v", got)
-	}
-	if got := screen.GetCell(2, 0); got.Char != "文" || got.Width != 2 {
-		t.Fatalf("cell2 = %+v, want 文 width 2", got)
-	}
+	cell1 := screen.GetCell(1, 0)
+	require.Equal(t, " ", cell1.Char, "cell1 char")
+	require.Equal(t, uint8(1), cell1.Width, "cell1 width")
+	require.True(t, cell1.Trail, "cell1 trail")
+	cell2 := screen.GetCell(2, 0)
+	require.Equal(t, "文", cell2.Char, "cell2 char")
+	require.Equal(t, uint8(2), cell2.Width, "cell2 width")
 	// No gap: column 1 must not be an independent printable CJK / reverse block.
-	if screen.GetCell(1, 0).Char == "中" || screen.GetCell(1, 0).Char == "文" {
-		t.Fatal("continuation column overwritten with a real glyph")
-	}
+	c1Char := screen.GetCell(1, 0).Char
+	require.NotEqual(t, "中", c1Char, "continuation column overwritten with a real glyph")
+	require.NotEqual(t, "文", c1Char, "continuation column overwritten with a real glyph")
 }
 
 // TestSurfaceRenderClipsChildren ensures scrolled content cannot paint past the parent box
@@ -67,23 +70,15 @@ func TestSurfaceRenderClipsChildren(t *testing.T) {
 	root.Render(win)
 
 	// Visible list rows: leak rows 1..2 → BBBB, CCCC at screen y=0,1
-	if screen.GetCell(0, 0).Char != "B" {
-		t.Fatalf("y0 want B got %q", screen.GetCell(0, 0).Char)
-	}
-	if screen.GetCell(0, 1).Char != "C" {
-		t.Fatalf("y1 want C got %q", screen.GetCell(0, 1).Char)
-	}
+	require.Equal(t, "B", screen.GetCell(0, 0).Char, "y0")
+	require.Equal(t, "C", screen.GetCell(0, 1).Char, "y1")
 	// DDDD would be at list-local y=3 which is outside list height 3 — must not leak into tui.
 	for y := 3; y < 8; y++ {
 		ch := screen.GetCell(0, y).Char
-		if ch == "D" {
-			t.Fatalf("leaked D into row %d", y)
-		}
+		require.NotEqual(t, "D", ch, "leaked D into row %d", y)
 	}
 	// AAAA was above the clip (Y=-1) — must not appear.
 	for y := range 8 {
-		if screen.GetCell(0, y).Char == "A" {
-			t.Fatalf("leaked A at row %d", y)
-		}
+		require.NotEqual(t, "A", screen.GetCell(0, y).Char, "leaked A at row %d", y)
 	}
 }

--- a/internal/components/text/markdown_test.go
+++ b/internal/components/text/markdown_test.go
@@ -94,7 +94,7 @@ func TestRenderMarkdown_Basics(t *testing.T) {
 						return
 					}
 				}
-				t.Fatal("docs span not found")
+				require.Fail(t, "docs span not found")
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestRenderMarkdown_Basics(t *testing.T) {
 						return
 					}
 				}
-				t.Fatal("path span not found")
+				require.Fail(t, "path span not found")
 			},
 		},
 	}

--- a/internal/components/toast/toast_test.go
+++ b/internal/components/toast/toast_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/xui"
 
 	"github.com/pulseaiclub/phi/internal/components"
@@ -14,9 +16,7 @@ func TestToastDrawSuccess(t *testing.T) {
 	toast := Toast{Theme: components.DefaultTheme()}
 	toast.Show("Selection copied to clipboard", ToastSuccess, time.Second)
 	s := toast.Draw(components.DrawContext{Max: components.Size{Width: 80, Height: 24}, Method: xui.WidthUnicode})
-	if len(s.Children) != 1 {
-		t.Fatalf("children=%d", len(s.Children))
-	}
+	require.Len(t, s.Children, 1)
 	panel := s.Children[0].Surface
 	var row strings.Builder
 	for x := 0; x < panel.Size.Width; x++ {
@@ -27,10 +27,6 @@ func TestToastDrawSuccess(t *testing.T) {
 		row.WriteString(ch)
 	}
 	got := row.String()
-	if !strings.Contains(got, "Selection copied") {
-		t.Fatalf("toast row=%q", got)
-	}
-	if !strings.Contains(got, "✓") {
-		t.Fatalf("missing checkmark: %q", got)
-	}
+	require.Contains(t, got, "Selection copied")
+	require.Contains(t, got, "✓")
 }

--- a/internal/components/transcript/message_test.go
+++ b/internal/components/transcript/message_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pulseaiclub/xui"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 )
 
@@ -36,13 +38,10 @@ func TestMessageListBottomPin(t *testing.T) {
 		},
 	}
 	s := list.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: 4}})
-	if len(s.Children) == 0 {
-		t.Fatal("expected visible children")
-	}
+	require.NotEmpty(t, s.Children, "expected visible children")
 	last := s.Children[len(s.Children)-1]
-	if last.Origin.Y+last.Surface.Size.Height > 4 {
-		t.Fatalf("last overflows: origin=%+v h=%d", last.Origin, last.Surface.Size.Height)
-	}
+	require.LessOrEqual(t, last.Origin.Y+last.Surface.Size.Height, 4,
+		"last overflows: origin=%+v h=%d", last.Origin, last.Surface.Size.Height)
 }
 
 func TestMessageListInvalidateHeightsAt(t *testing.T) {
@@ -54,17 +53,15 @@ func TestMessageListInvalidateHeightsAt(t *testing.T) {
 		},
 	}
 	_ = list.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: 20}})
-	if list.CachedHeight(0) != 2 || list.CachedHeight(1) != 3 || list.CachedHeight(2) != 4 {
-		t.Fatalf("heights %d %d %d", list.CachedHeight(0), list.CachedHeight(1), list.CachedHeight(2))
-	}
+	require.Equal(t, 2, list.CachedHeight(0))
+	require.Equal(t, 3, list.CachedHeight(1))
+	require.Equal(t, 4, list.CachedHeight(2))
 	list.InvalidateHeightsAt(1)
-	if list.CachedHeight(0) != 2 || list.CachedHeight(1) != 0 || list.CachedHeight(2) != 4 {
-		t.Fatalf("after invalidate: %d %d %d", list.CachedHeight(0), list.CachedHeight(1), list.CachedHeight(2))
-	}
+	require.Equal(t, 2, list.CachedHeight(0))
+	require.Equal(t, 0, list.CachedHeight(1))
+	require.Equal(t, 4, list.CachedHeight(2))
 	_ = list.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: 20}})
-	if list.CachedHeight(1) != 3 {
-		t.Fatalf("remeasured h=%d", list.CachedHeight(1))
-	}
+	require.Equal(t, 3, list.CachedHeight(1))
 }
 
 func TestMessageListReindexHeights(t *testing.T) {
@@ -85,21 +82,13 @@ func TestMessageListReindexHeights(t *testing.T) {
 		&rowStub{text: "c", h: 3},
 	}
 	list.ReindexHeights(oldIDs, []string{"a", "x", "b", "c"})
-	if list.CachedHeight(0) != 2 || list.CachedHeight(1) != 0 || list.CachedHeight(2) != 5 ||
-		list.CachedHeight(3) != 3 {
-		t.Fatalf(
-			"reindex: %d %d %d %d",
-			list.CachedHeight(0),
-			list.CachedHeight(1),
-			list.CachedHeight(2),
-			list.CachedHeight(3),
-		)
-	}
+	require.Equal(t, 2, list.CachedHeight(0))
+	require.Equal(t, 0, list.CachedHeight(1))
+	require.Equal(t, 5, list.CachedHeight(2))
+	require.Equal(t, 3, list.CachedHeight(3))
 	list.InvalidateHeightsAt(1)
 	_ = list.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: 20}})
-	if list.CachedHeight(1) != 7 {
-		t.Fatalf("new row h=%d", list.CachedHeight(1))
-	}
+	require.Equal(t, 7, list.CachedHeight(1))
 }
 
 func TestMessageListVirtualizes(t *testing.T) {
@@ -111,23 +100,22 @@ func TestMessageListVirtualizes(t *testing.T) {
 	list := &MessageList{Entries: entries}
 	const viewH = 6
 	s := list.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: viewH}})
-	if len(s.Children) >= n {
-		t.Fatalf("expected windowed draw, children=%d for %d entries", len(s.Children), n)
-	}
-	if len(s.Children) > viewH+2 {
-		t.Fatalf("too many realized children: %d (viewH=%d)", len(s.Children), viewH)
-	}
+	require.Less(t, len(s.Children), n, "expected windowed draw, children=%d for %d entries", len(s.Children), n)
+	require.LessOrEqual(
+		t,
+		len(s.Children),
+		viewH+2,
+		"too many realized children: %d (viewH=%d)",
+		len(s.Children),
+		viewH,
+	)
 	first, last := list.VisibleRange()
-	if first < 0 || last < first {
-		t.Fatalf("visible range %d..%d", first, last)
-	}
-	if last != n-1 {
-		t.Fatalf("bottom pin: last visible=%d want %d", last, n-1)
-	}
+	require.GreaterOrEqual(t, first, 0, "visible range %d..%d", first, last)
+	require.GreaterOrEqual(t, last, first, "visible range %d..%d", first, last)
+	require.Equal(t, n-1, last, "bottom pin: last visible=%d want %d", last, n-1)
 	list.ScrollFromBottom = 40
 	s2 := list.Draw(components.DrawContext{Max: components.Size{Width: 40, Height: viewH}})
 	f2, l2 := list.VisibleRange()
-	if len(s2.Children) == 0 || l2 >= n-1 && f2 == first {
-		t.Fatalf("scroll did not move window: %d..%d (was %d..%d)", f2, l2, first, last)
-	}
+	require.NotEmpty(t, s2.Children, "scroll did not move window: %d..%d (was %d..%d)", f2, l2, first, last)
+	require.False(t, l2 >= n-1 && f2 == first, "scroll did not move window: %d..%d (was %d..%d)", f2, l2, first, last)
 }

--- a/internal/components/tree/tree_test.go
+++ b/internal/components/tree/tree_test.go
@@ -3,20 +3,16 @@ package tree_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components/tree"
 )
 
 func TestPrefixForSiblings(t *testing.T) {
 	st := tree.DefaultStyle()
-	if got := tree.PrefixForSiblings(3, 0, st); got != "├── " {
-		t.Fatalf("first: %q", got)
-	}
-	if got := tree.PrefixForSiblings(3, 1, st); got != "├── " {
-		t.Fatalf("mid: %q", got)
-	}
-	if got := tree.PrefixForSiblings(3, 2, st); got != "╰── " {
-		t.Fatalf("last: %q", got)
-	}
+	require.Equal(t, "├── ", tree.PrefixForSiblings(3, 0, st), "first")
+	require.Equal(t, "├── ", tree.PrefixForSiblings(3, 1, st), "mid")
+	require.Equal(t, "╰── ", tree.PrefixForSiblings(3, 2, st), "last")
 }
 
 func TestFlattenNested(t *testing.T) {
@@ -31,17 +27,11 @@ func TestFlattenNested(t *testing.T) {
 		{Item: "b"},
 	}
 	flat := tree.Flatten(roots)
-	if len(flat) != 4 {
-		t.Fatalf("len=%d", len(flat))
-	}
+	require.Len(t, flat, 4)
 	// a2 under a: ancestor a is not last among roots? a is first of 2, so ancestor last=false
 	// Wait: a2's parent walk: when walking a's children, ancestors = [isLast of a among roots] = [false]
 	p := tree.Prefix(flat[2], tree.DefaultStyle()) // a2, last child of a
-	if p != "│   ╰── " {
-		t.Fatalf("nested last under non-last parent: %q", p)
-	}
+	require.Equal(t, "│   ╰── ", p, "nested last under non-last parent")
 	pLast := tree.Prefix(flat[3], tree.DefaultStyle()) // b
-	if pLast != "╰── " {
-		t.Fatalf("root last: %q", pLast)
-	}
+	require.Equal(t, "╰── ", pLast, "root last")
 }

--- a/internal/extension/spec_test.go
+++ b/internal/extension/spec_test.go
@@ -157,7 +157,7 @@ func TestInstallFromReleaseArchive(t *testing.T) {
 			return os.WriteFile(dest, []byte(body), 0o644)
 		},
 		RunGit: func(context.Context, string, ...string) error {
-			t.Fatal("git should not run when release succeeds")
+			require.Fail(t, "git should not run when release succeeds")
 			return nil
 		},
 	})
@@ -199,11 +199,11 @@ func TestInstallRejectsExisting(t *testing.T) {
 		Spec: extension.Spec{Owner: "alice", Repo: "greet"},
 		Git:  "git",
 		FetchRelease: func(context.Context, string, string) (githubrelease.Release, error) {
-			t.Fatal("release should not be queried when dest exists")
+			require.Fail(t, "release should not be queried when dest exists")
 			return githubrelease.Release{}, nil
 		},
 		RunGit: func(context.Context, string, ...string) error {
-			t.Fatal("git should not run")
+			require.Fail(t, "git should not run")
 			return nil
 		},
 	})

--- a/internal/extension/update_test.go
+++ b/internal/extension/update_test.go
@@ -134,7 +134,7 @@ func TestUpdateUpToDate(t *testing.T) {
 			return githubrelease.Release{TagName: "v2.0.0"}, nil
 		},
 		DownloadFile: func(context.Context, string, string) error {
-			t.Fatal("no download when up to date")
+			require.Fail(t, "no download when up to date")
 			return nil
 		},
 	})
@@ -161,7 +161,7 @@ func TestUpdateCheckOnlyDoesNotInstall(t *testing.T) {
 			return githubrelease.Release{TagName: "v2.0.0"}, nil
 		},
 		DownloadFile: func(context.Context, string, string) error {
-			t.Fatal("check must not download")
+			require.Fail(t, "check must not download")
 			return nil
 		},
 	})

--- a/internal/job/manager_test.go
+++ b/internal/job/manager_test.go
@@ -79,7 +79,7 @@ func TestCancelStopsRunner(t *testing.T) {
 	select {
 	case <-started:
 	case <-time.After(2 * time.Second):
-		t.Fatal("runner did not start")
+		require.Fail(t, "runner did not start")
 	}
 
 	require.NoError(t, m.Cancel(ctx, info.ID))
@@ -326,7 +326,7 @@ func TestSubscribeProgress(t *testing.T) {
 			require.True(t, ok)
 			got = append(got, p)
 		case <-deadline:
-			t.Fatalf("timeout, got %d events", len(got))
+			require.Failf(t, "timeout", "got %d events", len(got))
 		}
 	}
 	assert.Equal(t, info.ID, got[0].JobID)

--- a/internal/llm/anthropic/anthropic_test.go
+++ b/internal/llm/anthropic/anthropic_test.go
@@ -18,32 +18,20 @@ func TestBuildRequestSystemIsArray(t *testing.T) {
 	}, nil)
 
 	body, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+	require.NoError(t, err)
 
 	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(body, &raw))
 
 	systemRaw, ok := raw["system"]
-	if !ok {
-		t.Fatal("expected system field in request body")
-	}
+	require.True(t, ok, "expected system field in request body")
 	var asBlocks []sysBlock
-	if err := json.Unmarshal(systemRaw, &asBlocks); err != nil {
-		t.Fatalf("system must be an array, got: %s", string(systemRaw))
-	}
-	if len(asBlocks) != 1 {
-		t.Fatalf("expected 1 system block, got %d", len(asBlocks))
-	}
-	if asBlocks[0].Type != "text" || !strings.Contains(asBlocks[0].Text, "helpful") {
-		t.Fatalf("unexpected system block: %+v", asBlocks[0])
-	}
-	if asBlocks[0].CacheControl == nil {
-		t.Fatal("expected cache_control on system block")
-	}
+	err = json.Unmarshal(systemRaw, &asBlocks)
+	require.NoError(t, err, "system must be an array, got: %s", string(systemRaw))
+	require.Len(t, asBlocks, 1)
+	require.Equal(t, "text", asBlocks[0].Type)
+	require.Contains(t, asBlocks[0].Text, "helpful")
+	require.NotNil(t, asBlocks[0].CacheControl, "expected cache_control on system block")
 }
 
 func TestBuildRequestMergesToolResults(t *testing.T) {
@@ -63,36 +51,21 @@ func TestBuildRequestMergesToolResults(t *testing.T) {
 		{Role: llm.RoleTool, ToolCallID: "call_03", Content: "c"},
 	}, nil)
 
-	if len(req.Messages) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(req.Messages))
-	}
+	require.Len(t, req.Messages, 3)
 
 	results, ok := req.Messages[2].Content.([]anthropicContentBlock)
-	if !ok {
-		t.Fatalf("expected tool results as content blocks, got %T", req.Messages[2].Content)
-	}
-	if len(results) != 3 {
-		t.Fatalf("expected 3 merged tool_result blocks, got %d", len(results))
-	}
+	require.True(t, ok, "expected tool results as content blocks, got %T", req.Messages[2].Content)
+	require.Len(t, results, 3)
 	for i, wantID := range []string{"call_01", "call_02", "call_03"} {
-		if results[i].Type != "tool_result" {
-			t.Fatalf("block %d: expected tool_result, got %s", i, results[i].Type)
-		}
-		if results[i].ToolUseID != wantID {
-			t.Fatalf("block %d: expected tool_use_id %s, got %s", i, wantID, results[i].ToolUseID)
-		}
+		require.Equal(t, "tool_result", results[i].Type, "block %d", i)
+		require.Equal(t, wantID, results[i].ToolUseID, "block %d", i)
 	}
 
 	body, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if strings.Count(string(body), `"tool_result"`) != 3 {
-		t.Fatalf("expected 3 tool_result entries in JSON, got: %s", string(body))
-	}
-	if strings.Count(string(body), `"role":"user"`) != 2 {
-		t.Fatalf("expected 2 user messages (prompt + tool results), got: %s", string(body))
-	}
+	require.NoError(t, err)
+	sbody := string(body)
+	require.Equal(t, 3, strings.Count(sbody, `"tool_result"`))
+	require.Equal(t, 2, strings.Count(sbody, `"role":"user"`))
 }
 
 func TestBuildRequestUserImages(t *testing.T) {
@@ -156,18 +129,10 @@ func TestBuildRequestToolsSchema(t *testing.T) {
 	}}
 
 	req := BuildRequest(cfg, "", []llm.Message{{Role: llm.RoleUser, Content: "hi"}}, tools)
-	if len(req.Tools) != 1 {
-		t.Fatalf("expected 1 tool, got %d", len(req.Tools))
-	}
-	if req.Tools[0].Name != "read" {
-		t.Fatalf("unexpected tool name: %s", req.Tools[0].Name)
-	}
-	if !strings.Contains(string(req.Tools[0].InputSchema), `"required"`) {
-		t.Fatalf("input_schema missing required list: %s", string(req.Tools[0].InputSchema))
-	}
-	if req.Tools[0].CacheControl == nil {
-		t.Fatal("expected cache_control on last tool")
-	}
+	require.Len(t, req.Tools, 1)
+	require.Equal(t, "read", req.Tools[0].Name)
+	require.Contains(t, string(req.Tools[0].InputSchema), `"required"`)
+	require.NotNil(t, req.Tools[0].CacheControl, "expected cache_control on last tool")
 }
 
 func TestProcessStreamTextAndUsage(t *testing.T) {
@@ -191,9 +156,7 @@ func TestProcessStreamTextAndUsage(t *testing.T) {
 	var text strings.Builder
 	var done *llm.StreamEvent
 	for _, ev := range events {
-		if ev.Type == llm.StreamEventTypeError {
-			t.Fatalf("stream error: %s", ev.Err)
-		}
+		require.NotEqual(t, llm.StreamEventTypeError, ev.Type, "stream error: %s", ev.Err)
 		switch ev.Type {
 		case llm.StreamEventTypeDelta:
 			text.WriteString(ev.Delta.Content)
@@ -202,23 +165,14 @@ func TestProcessStreamTextAndUsage(t *testing.T) {
 		}
 	}
 
-	if text.String() != "Hello world" {
-		t.Fatalf("expected delta text 'Hello world', got %q", text.String())
-	}
-	if done == nil {
-		t.Fatal("expected done event")
-	}
+	require.Equal(t, "Hello world", text.String())
+	require.NotNil(t, done, "expected done event")
 	msg := done.Partial.Choices[0].Message
-	if msg.Content != "Hello world" {
-		t.Fatalf("expected content 'Hello world', got %q", msg.Content)
-	}
-	if done.Partial.Usage.PromptTokens != 962 || done.Partial.Usage.CompletionTokens != 7 ||
-		done.Partial.Usage.TotalTokens != 969 {
-		t.Fatalf("unexpected usage: %+v", done.Partial.Usage)
-	}
-	if done.Partial.Usage.CachedTokens() != 900 {
-		t.Fatalf("expected cached tokens 900, got %d", done.Partial.Usage.CachedTokens())
-	}
+	require.Equal(t, "Hello world", msg.Content)
+	require.Equal(t, 962, done.Partial.Usage.PromptTokens, "PromptTokens")
+	require.Equal(t, 7, done.Partial.Usage.CompletionTokens, "CompletionTokens")
+	require.Equal(t, 969, done.Partial.Usage.TotalTokens, "TotalTokens")
+	require.Equal(t, 900, done.Partial.Usage.CachedTokens())
 }
 
 func TestProcessStreamToolUseAndThinking(t *testing.T) {
@@ -244,9 +198,7 @@ func TestProcessStreamToolUseAndThinking(t *testing.T) {
 	var thinking, args string
 	var done *llm.StreamEvent
 	for _, ev := range events {
-		if ev.Type == llm.StreamEventTypeError {
-			t.Fatalf("stream error: %s", ev.Err)
-		}
+		require.NotEqual(t, llm.StreamEventTypeError, ev.Type, "stream error: %s", ev.Err)
 		switch ev.Type {
 		case llm.StreamEventTypeDelta:
 			thinking += ev.Delta.ReasoningContent
@@ -258,29 +210,16 @@ func TestProcessStreamToolUseAndThinking(t *testing.T) {
 		}
 	}
 
-	if thinking != "let me think" {
-		t.Fatalf("expected thinking 'let me think', got %q", thinking)
-	}
-	if done == nil {
-		t.Fatal("expected done event")
-	}
+	require.Equal(t, "let me think", thinking)
+	require.NotNil(t, done, "expected done event")
 	msg := done.Partial.Choices[0].Message
-	if msg.ReasoningContent != "let me think" {
-		t.Fatalf("expected reasoning in final message, got %q", msg.ReasoningContent)
-	}
-	if len(msg.ToolCalls) != 1 {
-		t.Fatalf("expected 1 tool call, got %d", len(msg.ToolCalls))
-	}
+	require.Equal(t, "let me think", msg.ReasoningContent)
+	require.Len(t, msg.ToolCalls, 1)
 	tc := msg.ToolCalls[0]
-	if tc.ID != "toolu_01" || tc.Function.Name != "read" {
-		t.Fatalf("unexpected tool call: %+v", tc)
-	}
-	if tc.Function.Arguments != `{"path":"a.go"}` {
-		t.Fatalf("expected accumulated args, got %q", tc.Function.Arguments)
-	}
-	if args != `{"path":"a.go"}` {
-		t.Fatalf("expected delta tool args, got %q", args)
-	}
+	require.Equal(t, "toolu_01", tc.ID)
+	require.Equal(t, "read", tc.Function.Name)
+	require.JSONEq(t, `{"path":"a.go"}`, tc.Function.Arguments)
+	require.JSONEq(t, `{"path":"a.go"}`, args)
 }
 
 func TestNormalizeBaseURL(t *testing.T) {
@@ -292,9 +231,7 @@ func TestNormalizeBaseURL(t *testing.T) {
 		{"http://localhost:8080", "http://localhost:8080/v1"},
 	}
 	for _, c := range cases {
-		if got := normalizeBaseURL(c.in); got != c.want {
-			t.Fatalf("normalizeBaseURL(%q) = %q, want %q", c.in, got, c.want)
-		}
+		require.Equal(t, c.want, normalizeBaseURL(c.in), "normalizeBaseURL(%q)", c.in)
 	}
 }
 

--- a/internal/llm/client/client_test.go
+++ b/internal/llm/client/client_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/llm"
 )
 
@@ -21,9 +23,7 @@ func TestIsAnthropicProvider(t *testing.T) {
 		{llm.ModelConfig{Name: "deepseek-chat", BaseURL: "https://api.deepseek.com/v1"}, false},
 	}
 	for i, c := range cases {
-		if got := isAnthropicProvider(c.cfg); got != c.want {
-			t.Fatalf("case %d: isAnthropicProvider(%+v) = %v, want %v", i, c.cfg, got, c.want)
-		}
+		require.Equal(t, c.want, isAnthropicProvider(c.cfg), "case %d: isAnthropicProvider(%+v)", i, c.cfg)
 	}
 }
 
@@ -54,21 +54,13 @@ func TestClientStreamAnthropicEndToEnd(t *testing.T) {
 	)
 	events := collectEvents(client.Stream(t.Context(), []llm.Message{{Role: llm.RoleUser, Content: "hello"}}))
 
-	if gotPath != "/v1/messages" {
-		t.Fatalf("expected POST /v1/messages, got %q", gotPath)
-	}
-	if gotKey != "sk-test" {
-		t.Fatalf("expected X-Api-Key sk-test, got %q", gotKey)
-	}
-	if gotVersion == "" {
-		t.Fatal("expected Anthropic-Version header")
-	}
+	require.Equal(t, "/v1/messages", gotPath)
+	require.Equal(t, "sk-test", gotKey)
+	require.NotEmpty(t, gotVersion, "expected Anthropic-Version header")
 	var text strings.Builder
 	var done *llm.StreamEvent
 	for _, ev := range events {
-		if ev.Err != "" {
-			t.Fatalf("stream error: %v", ev.Err)
-		}
+		require.Empty(t, ev.Err, "stream error")
 		switch ev.Type {
 		case llm.StreamEventTypeDelta:
 			text.WriteString(ev.Delta.Content)
@@ -76,12 +68,10 @@ func TestClientStreamAnthropicEndToEnd(t *testing.T) {
 			done = &ev
 		}
 	}
-	if text.String() != "hi" || done == nil || done.Partial.Choices[0].Message.Content != "hi" {
-		t.Fatalf("unexpected stream result: text=%q done=%v", text.String(), done)
-	}
-	if done.Partial.Usage.TotalTokens != 5 {
-		t.Fatalf("unexpected total tokens: %+v", done.Partial.Usage)
-	}
+	require.Equal(t, "hi", text.String())
+	require.NotNil(t, done, "unexpected stream result")
+	require.Equal(t, "hi", done.Partial.Choices[0].Message.Content)
+	require.Equal(t, 5, done.Partial.Usage.TotalTokens)
 }
 
 func TestClientStreamOpenAIEndToEnd(t *testing.T) {
@@ -105,15 +95,11 @@ func TestClientStreamOpenAIEndToEnd(t *testing.T) {
 	client := NewClient(llm.ModelConfig{Name: "gpt-4o", BaseURL: srv.URL, APIKey: "sk-test"}, nil, "")
 	events := collectEvents(client.Stream(t.Context(), []llm.Message{{Role: llm.RoleUser, Content: "hello"}}))
 
-	if gotPath != "/chat/completions" {
-		t.Fatalf("expected POST /chat/completions, got %q", gotPath)
-	}
+	require.Equal(t, "/chat/completions", gotPath)
 	var text strings.Builder
 	var done *llm.StreamEvent
 	for _, ev := range events {
-		if ev.Err != "" {
-			t.Fatalf("stream error: %v", ev.Err)
-		}
+		require.Empty(t, ev.Err, "stream error")
 		switch ev.Type {
 		case llm.StreamEventTypeDelta:
 			text.WriteString(ev.Delta.Content)
@@ -121,12 +107,10 @@ func TestClientStreamOpenAIEndToEnd(t *testing.T) {
 			done = &ev
 		}
 	}
-	if text.String() != "hello" || done == nil || done.Partial.Choices[0].Message.Content != "hello" {
-		t.Fatalf("unexpected stream result: text=%q done=%v", text.String(), done)
-	}
-	if done.Partial.Usage.TotalTokens != 6 {
-		t.Fatalf("unexpected total tokens: %+v", done.Partial.Usage)
-	}
+	require.Equal(t, "hello", text.String())
+	require.NotNil(t, done, "unexpected stream result")
+	require.Equal(t, "hello", done.Partial.Choices[0].Message.Content)
+	require.Equal(t, 6, done.Partial.Usage.TotalTokens)
 }
 
 func TestClientCompactAnthropic(t *testing.T) {
@@ -140,15 +124,9 @@ func TestClientCompactAnthropic(t *testing.T) {
 
 	client := NewClient(llm.ModelConfig{Name: "claude-sonnet-4-20250514", BaseURL: srv.URL, APIKey: "sk-test"}, nil, "")
 	out, err := client.Compact(t.Context(), "summarize")
-	if err != nil {
-		t.Fatalf("compact: %v", err)
-	}
-	if gotPath != "/v1/messages" {
-		t.Fatalf("expected POST /v1/messages, got %q", gotPath)
-	}
-	if out != "summary here" {
-		t.Fatalf("expected 'summary here', got %q", out)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "/v1/messages", gotPath)
+	require.Equal(t, "summary here", out)
 }
 
 func TestClientCompactOpenAI(t *testing.T) {
@@ -162,15 +140,9 @@ func TestClientCompactOpenAI(t *testing.T) {
 
 	client := NewClient(llm.ModelConfig{Name: "gpt-4o", BaseURL: srv.URL, APIKey: "sk-test"}, nil, "")
 	out, err := client.Compact(t.Context(), "summarize")
-	if err != nil {
-		t.Fatalf("compact: %v", err)
-	}
-	if gotPath != "/chat/completions" {
-		t.Fatalf("expected POST /chat/completions, got %q", gotPath)
-	}
-	if out != "summary here" {
-		t.Fatalf("expected 'summary here', got %q", out)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "/chat/completions", gotPath)
+	require.Equal(t, "summary here", out)
 }
 
 // collectEvents drains an iter.Seq2 into a slice.

--- a/internal/llm/gemini/client_test.go
+++ b/internal/llm/gemini/client_test.go
@@ -145,9 +145,7 @@ func TestProcessStreamTextAndUsage(t *testing.T) {
 	var text strings.Builder
 	var done *llm.StreamEvent
 	for _, ev := range events {
-		if ev.Type == llm.StreamEventTypeError {
-			t.Fatalf("stream error: %s", ev.Err)
-		}
+		require.NotEqual(t, llm.StreamEventTypeError, ev.Type, "stream error: %s", ev.Err)
 		switch ev.Type {
 		case llm.StreamEventTypeDelta:
 			text.WriteString(ev.Delta.Content)
@@ -178,9 +176,7 @@ func TestProcessStreamThinking(t *testing.T) {
 	var text, reasoning strings.Builder
 	var done *llm.StreamEvent
 	for _, ev := range events {
-		if ev.Type == llm.StreamEventTypeError {
-			t.Fatalf("stream error: %s", ev.Err)
-		}
+		require.NotEqual(t, llm.StreamEventTypeError, ev.Type, "stream error: %s", ev.Err)
 		switch ev.Type {
 		case llm.StreamEventTypeDelta:
 			text.WriteString(ev.Delta.Content)

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -3,8 +3,9 @@ package mcp_test
 import (
 	"encoding/json"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/mcp"
 )
@@ -18,34 +19,20 @@ func TestConfigLoadSave(t *testing.T) {
 		Command:   []string{"npx"},
 		Args:      []string{"-y", "pkg"},
 	}
-	if err := mcp.AddServer("demo", cfg); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, mcp.AddServer("demo", cfg))
 
 	servers, err := mcp.Load(filepath.Join(t.TempDir(), ".phi", "mcp.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := servers["demo"]; !ok {
-		t.Fatal("expected demo server")
-	}
-	if got := servers["demo"].Command; len(got) != 1 || got[0] != "npx" {
-		t.Fatalf("command = %v", got)
-	}
+	require.NoError(t, err)
+	require.Contains(t, servers, "demo", "expected demo server")
+	require.Equal(t, []string{"npx"}, servers["demo"].Command, "command mismatch")
 
 	ok, err := mcp.RemoveServer("demo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("expected remove ok")
-	}
+	require.NoError(t, err)
+	require.True(t, ok, "expected remove ok")
 }
 
 func TestCompactAndSlim(t *testing.T) {
-	if got := mcp.CompactServerList([]string{"a", "b"}); got != "a b" {
-		t.Fatalf("got %q", got)
-	}
+	require.Equal(t, "a b", mcp.CompactServerList([]string{"a", "b"}))
 	tools := []mcp.ToolDef{
 		{
 			Name:        "echo",
@@ -55,25 +42,16 @@ func TestCompactAndSlim(t *testing.T) {
 			),
 		},
 	}
-	if got := mcp.CompactToolNames(tools); got != "echo" {
-		t.Fatalf("got %q", got)
-	}
+	require.Equal(t, "echo", mcp.CompactToolNames(tools))
 	slim := mcp.SlimTool(tools[0])
-	if !strings.Contains(slim, "echo") || !strings.Contains(slim, "message:s*") {
-		t.Fatalf("slim = %q", slim)
-	}
+	require.Contains(t, slim, "echo")
+	require.Contains(t, slim, "message:s*")
 }
 
 func TestDisabled(t *testing.T) {
 	t.Setenv("PHI_MCP", "off")
-	if !mcp.Disabled() {
-		t.Fatal("expected disabled")
-	}
+	require.True(t, mcp.Disabled(), "expected disabled")
 	pool, err := mcp.LoadPool(filepath.Join(t.TempDir(), ".phi", "mcp.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if pool != nil {
-		t.Fatal("expected nil pool")
-	}
+	require.NoError(t, err)
+	require.Nil(t, pool, "expected nil pool")
 }

--- a/internal/mcp/http_client_test.go
+++ b/internal/mcp/http_client_test.go
@@ -6,10 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/mcp"
 )
@@ -97,37 +98,24 @@ func TestHTTPClientJSONAndSSE(t *testing.T) {
 		URL:       srv.URL,
 		Headers:   map[string]string{"Authorization": "Bearer test"},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 
-	if err := c.Initialize(ctx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, c.Initialize(ctx))
 	tools, err := c.ListTools(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(tools) != 1 || tools[0].Name != "echo" {
-		t.Fatalf("tools = %+v", tools)
-	}
+	require.NoError(t, err)
+	require.Len(t, tools, 1, "tools = %+v", tools)
+	require.Equal(t, "echo", tools[0].Name, "tools = %+v", tools)
 	out, err := c.CallTool(ctx, "echo", map[string]any{"message": "hi"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out, "hi") {
-		t.Fatalf("out = %q", out)
-	}
+	require.NoError(t, err)
+	require.Contains(t, out, "hi", "out = %q", out)
 	mu.Lock()
 	okHeader := sawHeader
 	mu.Unlock()
-	if !okHeader {
-		t.Fatal("expected Authorization header")
-	}
+	require.True(t, okHeader, "expected Authorization header")
 }
 
 func writeJSONRPC(w http.ResponseWriter, id, result any) {
@@ -141,17 +129,12 @@ func writeJSONRPC(w http.ResponseWriter, id, result any) {
 
 func TestNewClientUnsupportedTransport(t *testing.T) {
 	_, err := mcp.NewClient("x", mcp.ServerConfig{Transport: "grpc", Command: []string{"true"}})
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !strings.Contains(err.Error(), "unsupported transport") {
-		t.Fatalf("got %v", err)
-	}
+	require.Error(t, err, "expected error")
+	require.Contains(t, err.Error(), "unsupported transport")
 }
 
 func TestNewClientHTTPRequiresURL(t *testing.T) {
 	_, err := mcp.NewClient("x", mcp.ServerConfig{Transport: "http"})
-	if err == nil || !strings.Contains(err.Error(), "url") {
-		t.Fatalf("got %v", err)
-	}
+	require.Error(t, err, "got %v", err)
+	require.Contains(t, err.Error(), "url")
 }

--- a/internal/permission/extract_test.go
+++ b/internal/permission/extract_test.go
@@ -4,49 +4,37 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractBash(t *testing.T) {
 	req, err := Extract("bash", json.RawMessage(`{"command":"git status"}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.Action != ActionBash || req.Command != "git status" {
-		t.Fatalf("got %+v", req)
-	}
+	require.NoError(t, err)
+	require.Equal(t, ActionBash, req.Action)
+	require.Equal(t, "git status", req.Command)
 }
 
 func TestExtractWritePath(t *testing.T) {
 	req, err := Extract("write", json.RawMessage(`{"path":"out.txt","content":"x"}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.Action != ActionWrite || len(req.Paths) != 1 {
-		t.Fatalf("got %+v", req)
-	}
-	if !filepath.IsAbs(req.Paths[0]) {
-		t.Fatalf("path not abs: %s", req.Paths[0])
-	}
+	require.NoError(t, err)
+	require.Equal(t, ActionWrite, req.Action)
+	require.Len(t, req.Paths, 1)
+	require.True(t, filepath.IsAbs(req.Paths[0]))
 }
 
 func TestExtractAtUsesExplicitCwd(t *testing.T) {
 	root := t.TempDir()
 	req, err := ExtractAt("write", json.RawMessage(`{"path":"out.txt","content":"x"}`), root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "out.txt")
-	if len(req.Paths) != 1 || req.Paths[0] != want {
-		t.Fatalf("got %v, want %s", req.Paths, want)
-	}
+	require.Len(t, req.Paths, 1)
+	require.Equal(t, want, req.Paths[0])
 }
 
 func TestExtractEditFilePath(t *testing.T) {
 	req, err := Extract("edit", json.RawMessage(`{"file_path":"a.go","edits":[]}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if req.Action != ActionEdit || len(req.Paths) != 1 {
-		t.Fatalf("got %+v", req)
-	}
+	require.NoError(t, err)
+	require.Equal(t, ActionEdit, req.Action)
+	require.Len(t, req.Paths, 1)
 }

--- a/internal/permission/gate_test.go
+++ b/internal/permission/gate_test.go
@@ -4,156 +4,110 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInWorkspace(t *testing.T) {
 	ws := "/Users/me/proj"
-	if !InWorkspace("/Users/me/proj", ws) {
-		t.Fatal("workspace root should be inside itself")
-	}
-	if !InWorkspace("/Users/me/proj/src/a.go", ws) {
-		t.Fatal("child should be inside")
-	}
-	if InWorkspace("/Users/me/other", ws) {
-		t.Fatal("sibling should be outside")
-	}
-	if InWorkspace("/Users/me/proj-evil/x", ws) {
-		t.Fatal("prefix-sibling should be outside")
-	}
-	if InWorkspace("/Users/me", ws) {
-		t.Fatal("parent should be outside")
-	}
+	require.True(t, InWorkspace("/Users/me/proj", ws), "workspace root should be inside itself")
+	require.True(t, InWorkspace("/Users/me/proj/src/a.go", ws), "child should be inside")
+	require.False(t, InWorkspace("/Users/me/other", ws), "sibling should be outside")
+	require.False(t, InWorkspace("/Users/me/proj-evil/x", ws), "prefix-sibling should be outside")
+	require.False(t, InWorkspace("/Users/me", ws), "parent should be outside")
 }
 
 func TestCheckWriteOutsideWorkspace(t *testing.T) {
 	ws := t.TempDir()
 	g, err := NewGate(DefaultPolicy(), ws)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	outside := filepath.Join(os.TempDir(), "phi-perm-test-outside")
-	dec, reason := g.Check(t.Context(), Request{
+	dec, _ := g.Check(t.Context(), Request{
 		Action: ActionWrite,
 		Tool:   "write",
 		Paths:  []string{outside},
 	})
-	if dec != Deny {
-		t.Fatalf("want Deny, got %v (%s)", dec, reason)
-	}
+	require.Equal(t, Deny, dec)
 }
 
 func TestCheckWriteInsideWorkspace(t *testing.T) {
 	ws := t.TempDir()
 	g, err := NewGate(DefaultPolicy(), ws)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	inside := filepath.Join(ws, "out.txt")
-	dec, reason := g.Check(t.Context(), Request{
+	dec, _ := g.Check(t.Context(), Request{
 		Action: ActionWrite,
 		Tool:   "write",
 		Paths:  []string{inside},
 	})
-	if dec != Allow {
-		t.Fatalf("want Allow, got %v (%s)", dec, reason)
-	}
+	require.Equal(t, Allow, dec)
 }
 
 func TestCheckWriteSensitiveConfig(t *testing.T) {
 	ws := t.TempDir()
 	g, err := NewGate(DefaultPolicy(), ws)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	home, _ := os.UserHomeDir()
 	cfgPath := filepath.Join(home, ".phi", "config.yaml")
-	dec, reason := g.Check(t.Context(), Request{
+	dec, _ := g.Check(t.Context(), Request{
 		Action: ActionWrite,
 		Tool:   "write",
 		Paths:  []string{cfgPath},
 	})
-	if dec != Deny {
-		t.Fatalf("want Deny for config.yaml, got %v (%s)", dec, reason)
-	}
+	require.Equal(t, Deny, dec)
 }
 
 func TestCheckBashAllowDenyAsk(t *testing.T) {
 	g, err := NewGate(DefaultPolicy(), t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ctx := t.Context()
 
 	dec, _ := g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "git status"})
-	if dec != Allow {
-		t.Fatalf("git status: want Allow, got %v", dec)
-	}
+	require.Equal(t, Allow, dec, "git status")
 	dec, _ = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "go test ./..."})
-	if dec != Allow {
-		t.Fatalf("go test: want Allow, got %v", dec)
-	}
-	dec, reason := g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "sudo true"})
-	if dec != Deny {
-		t.Fatalf("sudo: want Deny, got %v (%s)", dec, reason)
-	}
-	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "curl https://example.com"})
-	if dec != Ask {
-		t.Fatalf("curl: want Ask, got %v (%s)", dec, reason)
-	}
+	require.Equal(t, Allow, dec, "go test")
+	dec, _ = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "sudo true"})
+	require.Equal(t, Deny, dec, "sudo")
+	dec, _ = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "curl https://example.com"})
+	require.Equal(t, Ask, dec, "curl")
 }
 
 func TestCheckBashCompoundNotAllowlisted(t *testing.T) {
 	g, err := NewGate(DefaultPolicy(), t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ctx := t.Context()
 
 	// Prefix ^ls\b must NOT allow chained rm.
 	cmd := `ls -la todo.list 2>/dev/null && rm -rf todo.list && echo "removed"`
-	dec, reason := g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: cmd})
-	if dec != Deny {
-		t.Fatalf("ls && rm -rf: want Deny, got %v (%s)", dec, reason)
-	}
+	dec, _ := g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: cmd})
+	require.Equal(t, Deny, dec, "ls && rm -rf")
 
 	// Plain ls still allowed.
-	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "ls -la todo.list"})
-	if dec != Allow {
-		t.Fatalf("ls alone: want Allow, got %v (%s)", dec, reason)
-	}
+	dec, _ = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "ls -la todo.list"})
+	require.Equal(t, Allow, dec, "ls alone")
 
 	// rm -rf without trailing / must still deny.
-	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "rm -rf todo.list"})
-	if dec != Deny {
-		t.Fatalf("rm -rf file: want Deny, got %v (%s)", dec, reason)
-	}
+	dec, _ = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "rm -rf todo.list"})
+	require.Equal(t, Deny, dec, "rm -rf file")
 
 	// Pipe / redirect out of allowlist.
-	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "cat foo | sh"})
-	if dec == Allow {
-		t.Fatalf("pipe: must not Allow (%s)", reason)
-	}
-	dec, reason = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "cat secret > /tmp/out"})
-	if dec == Allow {
-		t.Fatalf("redirect: must not Allow (%s)", reason)
-	}
+	dec, _ = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "cat foo | sh"})
+	require.NotEqual(t, Allow, dec, "pipe: must not Allow")
+	dec, _ = g.Check(ctx, Request{Action: ActionBash, Tool: "bash", Command: "cat secret > /tmp/out"})
+	require.NotEqual(t, Allow, dec, "redirect: must not Allow")
 }
 
 func TestModeHeadlessStrictFoldsAsk(t *testing.T) {
 	p := DefaultPolicy()
 	p.Mode = ModeHeadlessStrict
 	g, err := NewGate(p, t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	dec, reason := g.Check(t.Context(), Request{
+	require.NoError(t, err)
+	dec, _ := g.Check(t.Context(), Request{
 		Action:  ActionBash,
 		Tool:    "bash",
 		Command: "curl https://example.com",
 	})
-	if dec != Deny {
-		t.Fatalf("want Deny, got %v (%s)", dec, reason)
-	}
+	require.Equal(t, Deny, dec)
 }
 
 func TestModeReadonlyDeniesWrite(t *testing.T) {
@@ -161,57 +115,43 @@ func TestModeReadonlyDeniesWrite(t *testing.T) {
 	p := DefaultPolicy()
 	p.Mode = ModeReadonly
 	g, err := NewGate(p, ws)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dec, reason := g.Check(t.Context(), Request{
+	require.NoError(t, err)
+	dec, _ := g.Check(t.Context(), Request{
 		Action: ActionWrite,
 		Tool:   "write",
 		Paths:  []string{filepath.Join(ws, "a.txt")},
 	})
-	if dec != Deny {
-		t.Fatalf("want Deny, got %v (%s)", dec, reason)
-	}
+	require.Equal(t, Deny, dec)
 	// allowlisted bash still ok
-	dec, reason = g.Check(t.Context(), Request{
+	dec, _ = g.Check(t.Context(), Request{
 		Action:  ActionBash,
 		Tool:    "bash",
 		Command: "git status",
 	})
-	if dec != Allow {
-		t.Fatalf("git status in readonly: want Allow, got %v (%s)", dec, reason)
-	}
+	require.Equal(t, Allow, dec, "git status in readonly")
 }
 
 func TestModeAutopilotFoldsAsk(t *testing.T) {
 	p := DefaultPolicy()
 	p.Mode = ModeAutopilot
 	g, err := NewGate(p, t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	dec, _ := g.Check(t.Context(), Request{
 		Action:  ActionBash,
 		Tool:    "bash",
 		Command: "curl https://example.com",
 	})
-	if dec != Deny {
-		t.Fatalf("want Deny, got %v", dec)
-	}
+	require.Equal(t, Deny, dec)
 }
 
 func TestReadSensitiveDeny(t *testing.T) {
 	g, err := NewGate(DefaultPolicy(), t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	home, _ := os.UserHomeDir()
-	dec, reason := g.Check(t.Context(), Request{
+	dec, _ := g.Check(t.Context(), Request{
 		Action: ActionRead,
 		Tool:   "read",
 		Paths:  []string{filepath.Join(home, ".ssh", "id_rsa")},
 	})
-	if dec != Deny {
-		t.Fatalf("want Deny, got %v (%s)", dec, reason)
-	}
+	require.Equal(t, Deny, dec)
 }

--- a/internal/session/apply_test.go
+++ b/internal/session/apply_test.go
@@ -3,39 +3,37 @@ package session
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/llm"
 )
 
 func TestApplyStreamingUpdates(t *testing.T) {
 	var s Snapshot
 	s = Apply(s, UserAppend{ID: "u1", Text: "hello"})
-	if len(s.Messages) != 1 || s.Messages[0].Role != RoleUser {
-		t.Fatalf("user: %+v", s.Messages)
-	}
+	require.Len(t, s.Messages, 1)
+	require.Equal(t, RoleUser, s.Messages[0].Role)
 
 	s = Apply(s, AssistantMessageUpdate{Message: Message{
 		ID: "a1", State: StateStreaming,
 		Content: []ContentBlock{{Type: BlockText, Text: "Hi"}},
 	}})
-	if len(s.Messages) != 2 || !IsStreaming(s) {
-		t.Fatalf("start: %+v", s.Messages)
-	}
+	require.Len(t, s.Messages, 2)
+	require.True(t, IsStreaming(s))
 
 	s = Apply(s, AssistantMessageUpdate{Message: Message{
 		ID: "a1", State: StateStreaming,
 		Content: []ContentBlock{{Type: BlockText, Text: "Hi there"}},
 	}})
-	if len(s.Messages) != 2 || s.Messages[1].FlatText() != "Hi there" {
-		t.Fatalf("delta replace: %+v", s.Messages)
-	}
+	require.Len(t, s.Messages, 2)
+	require.Equal(t, "Hi there", s.Messages[1].FlatText())
 
 	s = Apply(s, AssistantMessageUpdate{Message: Message{
 		ID: "a1", State: StateComplete,
 		Content: []ContentBlock{{Type: BlockText, Text: "Hi there!"}},
 	}})
-	if IsStreaming(s) || s.Messages[1].State != StateComplete {
-		t.Fatalf("complete: %+v", s.Messages)
-	}
+	require.False(t, IsStreaming(s))
+	require.Equal(t, StateComplete, s.Messages[1].State)
 }
 
 func TestCancelStreaming(t *testing.T) {
@@ -52,12 +50,8 @@ func TestCancelStreaming(t *testing.T) {
 		},
 	}
 	s = Apply(s, CancelStreaming{})
-	if s.Messages[1].State != StateCancelled {
-		t.Fatalf("assistant: %+v", s.Messages[1])
-	}
-	if s.Tools["t1"].Status != ToolCancelled {
-		t.Fatalf("tool: %+v", s.Tools["t1"])
-	}
+	require.Equal(t, StateCancelled, s.Messages[1].State)
+	require.Equal(t, ToolCancelled, s.Tools["t1"].Status)
 }
 
 func TestToolDataAndSecondTurn(t *testing.T) {
@@ -70,26 +64,18 @@ func TestToolDataAndSecondTurn(t *testing.T) {
 			{Type: BlockToolUse, ID: "t1", Name: "Read", Input: "a.go", Complete: true},
 		},
 	}})
-	if s.Tools["t1"].Status != ToolInProgress {
-		t.Fatalf("synthetic tool: %+v", s.Tools)
-	}
-	if s.Tools["t1"].Name != "Read" {
-		t.Fatalf("expected Name=Read from tool_use block, got %q", s.Tools["t1"].Name)
-	}
+	require.Equal(t, ToolInProgress, s.Tools["t1"].Status)
+	require.Equal(t, "Read", s.Tools["t1"].Name)
 	s = Apply(s, ToolData{Run: ToolRun{ToolUseID: "t1", Status: ToolDone, Output: "ok"}})
-	if s.Tools["t1"].Status != ToolDone || s.Tools["t1"].Output != "ok" {
-		t.Fatalf("tool done: %+v", s.Tools["t1"])
-	}
-	if s.Tools["t1"].Name != "Read" {
-		t.Fatalf("expected Name preserved across ToolData, got %q", s.Tools["t1"].Name)
-	}
+	require.Equal(t, ToolDone, s.Tools["t1"].Status)
+	require.Equal(t, "ok", s.Tools["t1"].Output)
+	require.Equal(t, "Read", s.Tools["t1"].Name, "Name preserved across ToolData")
 	s = Apply(s, AssistantMessageUpdate{Message: Message{
 		ID: "a2", State: StateStreaming,
 		Content: []ContentBlock{{Type: BlockText, Text: "done"}},
 	}})
-	if len(s.Messages) != 3 || s.Messages[2].ID != "a2" {
-		t.Fatalf("second turn: %+v", s.Messages)
-	}
+	require.Len(t, s.Messages, 3)
+	require.Equal(t, "a2", s.Messages[2].ID)
 }
 
 func TestProjectOrder(t *testing.T) {
@@ -110,70 +96,56 @@ func TestProjectOrder(t *testing.T) {
 		},
 	}
 	items := Project(s)
-	if len(items) != 4 {
-		t.Fatalf("len=%d %+v", len(items), items)
-	}
-	if items[0].Kind != ItemUser || items[1].Kind != ItemThinking ||
-		items[2].Kind != ItemAssistant || items[3].Kind != ItemTool {
-		t.Fatalf("order: %+v", items)
-	}
-	if items[3].ToolRun.Status != ToolDone || items[3].ToolRun.Output != "a\n" || items[3].ToolRun.Name != "Bash" {
-		t.Fatalf("tool item: %+v", items[3])
-	}
+	require.Len(t, items, 4)
+	require.Equal(t, ItemUser, items[0].Kind)
+	require.Equal(t, ItemThinking, items[1].Kind)
+	require.Equal(t, ItemAssistant, items[2].Kind)
+	require.Equal(t, ItemTool, items[3].Kind)
+	require.Equal(t, ToolDone, items[3].ToolRun.Status)
+	require.Equal(t, "a\n", items[3].ToolRun.Output)
+	require.Equal(t, "Bash", items[3].ToolRun.Name)
 }
 
 func TestCompactionEvents(t *testing.T) {
 	var s Snapshot
 	s = Apply(s, UserAppend{Text: "hi"})
 	s = Apply(s, CompactionStarted{})
-	if !s.Compacting || !IsStreaming(s) {
-		t.Fatalf("compacting: %+v", s)
-	}
+	require.True(t, s.Compacting)
+	require.True(t, IsStreaming(s))
 	s = Apply(s, CompactionComplete{ID: "c1"})
-	if s.Compacting {
-		t.Fatal("should clear compacting")
-	}
-	if len(s.Messages) != 2 || s.Messages[1].Role != RoleCompaction {
-		t.Fatalf("marker: %+v", s.Messages)
-	}
+	require.False(t, s.Compacting)
+	require.Len(t, s.Messages, 2)
+	require.Equal(t, RoleCompaction, s.Messages[1].Role)
 	items := Project(s)
-	if len(items) < 2 || items[len(items)-1].Kind != ItemCompaction {
-		t.Fatalf("project: %+v", items)
-	}
+	require.GreaterOrEqual(t, len(items), 2)
+	require.Equal(t, ItemCompaction, items[len(items)-1].Kind)
 
 	s = Apply(s, CompactionStarted{})
 	s = Apply(s, CompactionComplete{ID: "c2", Failed: true})
-	if s.Compacting {
-		t.Fatal("failed should clear")
-	}
+	require.False(t, s.Compacting)
 	nMarkers := 0
 	for _, m := range s.Messages {
 		if m.Role == RoleCompaction {
 			nMarkers++
 		}
 	}
-	if nMarkers != 1 {
-		t.Fatalf("markers=%d", nMarkers)
-	}
+	require.Equal(t, 1, nMarkers)
 }
 
 func TestLocalBash(t *testing.T) {
 	var s Snapshot
 	s = Apply(s, LocalBashStart{ID: "b1", Command: "echo hi"})
-	if len(s.Messages) != 1 || s.Messages[0].Role != RoleLocalBash {
-		t.Fatalf("msg: %+v", s.Messages)
-	}
-	if !s.Tools["b1"].Local || s.Tools["b1"].Status != ToolInProgress {
-		t.Fatalf("tool: %+v", s.Tools["b1"])
-	}
-	if IsStreaming(s) || HasRunningTools(s) {
-		t.Fatal("local bash must not count as agent streaming")
-	}
+	require.Len(t, s.Messages, 1)
+	require.Equal(t, RoleLocalBash, s.Messages[0].Role)
+	require.True(t, s.Tools["b1"].Local)
+	require.Equal(t, ToolInProgress, s.Tools["b1"].Status)
+	require.False(t, IsStreaming(s))
+	require.False(t, HasRunningTools(s))
 
 	items := Project(s)
-	if len(items) != 1 || items[0].Kind != ItemTool || items[0].ToolRun.Name != "bash" {
-		t.Fatalf("project: %+v", items)
-	}
+	require.Len(t, items, 1)
+	require.Equal(t, ItemTool, items[0].Kind)
+	require.Equal(t, "bash", items[0].ToolRun.Name)
 
 	s = Apply(s, ToolData{Run: ToolRun{
 		ToolUseID: "b1",
@@ -182,16 +154,13 @@ func TestLocalBash(t *testing.T) {
 		ExitCode:  0,
 		Local:     true,
 	}})
-	if s.Tools["b1"].Status != ToolDone || !s.Tools["b1"].Local {
-		t.Fatalf("done: %+v", s.Tools["b1"])
-	}
+	require.Equal(t, ToolDone, s.Tools["b1"].Status)
+	require.True(t, s.Tools["b1"].Local)
 
 	// CancelStreaming must leave local bash alone.
 	s = Apply(s, LocalBashStart{ID: "b2", Command: "sleep 9"})
 	s = Apply(s, CancelStreaming{})
-	if s.Tools["b2"].Status != ToolInProgress {
-		t.Fatalf("cancel must skip local: %+v", s.Tools["b2"])
-	}
+	require.Equal(t, ToolInProgress, s.Tools["b2"].Status)
 }
 
 func TestApplyUserAppendImages(t *testing.T) {
@@ -200,10 +169,7 @@ func TestApplyUserAppendImages(t *testing.T) {
 		Text:   "Images: a.png",
 		Images: []llm.Image{{Data: "QUJD", MimeType: "image/png"}},
 	})
-	if len(s.Messages) != 1 {
-		t.Fatalf("messages=%d", len(s.Messages))
-	}
-	if len(s.Messages[0].Images) != 1 || s.Messages[0].Images[0].MimeType != "image/png" {
-		t.Fatalf("images: %+v", s.Messages[0].Images)
-	}
+	require.Len(t, s.Messages, 1)
+	require.Len(t, s.Messages[0].Images, 1)
+	require.Equal(t, "image/png", s.Messages[0].Images[0].MimeType)
 }

--- a/internal/session/compaction/setting_test.go
+++ b/internal/session/compaction/setting_test.go
@@ -1,6 +1,10 @@
 package compaction
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestShouldCompact(t *testing.T) {
 	settings := Settings{
@@ -10,34 +14,20 @@ func TestShouldCompact(t *testing.T) {
 	}
 
 	// threshold = contextWindow - reverseTokens = 90
-	if ShouldCompact(50, 100, settings) {
-		t.Fatalf("expected ShouldCompact=false when contextTokens below threshold")
-	}
-	if ShouldCompact(90, 100, settings) {
-		t.Fatalf("expected ShouldCompact=false when contextTokens equals threshold")
-	}
-	if !ShouldCompact(95, 100, settings) {
-		t.Fatalf("expected ShouldCompact=true when contextTokens above threshold")
-	}
+	require.False(t, ShouldCompact(50, 100, settings), "below threshold")
+	require.False(t, ShouldCompact(90, 100, settings), "at threshold")
+	require.True(t, ShouldCompact(95, 100, settings), "above threshold")
 
 	disabled := settings
 	disabled.enabled = false
-	if ShouldCompact(95, 100, disabled) {
-		t.Fatalf("expected ShouldCompact=false when compaction disabled")
-	}
+	require.False(t, ShouldCompact(95, 100, disabled), "compaction disabled")
 
-	if ShouldCompact(95, 0, settings) {
-		t.Fatalf("expected ShouldCompact=false when contextWindow <= 0")
-	}
+	require.False(t, ShouldCompact(95, 0, settings), "contextWindow <= 0")
 
 	// threshold clamping when reverseTokens > contextWindow
 	settings2 := settings
 	settings2.reverseTokens = 200
 	// threshold becomes 0
-	if ShouldCompact(0, 100, settings2) {
-		t.Fatalf("expected ShouldCompact=false when contextTokens==0 and threshold clamped to 0")
-	}
-	if !ShouldCompact(1, 100, settings2) {
-		t.Fatalf("expected ShouldCompact=true when contextTokens>0 and threshold clamped to 0")
-	}
+	require.False(t, ShouldCompact(0, 100, settings2), "threshold clamped, contextTokens==0")
+	require.True(t, ShouldCompact(1, 100, settings2), "threshold clamped, contextTokens>0")
 }

--- a/internal/session/manager_concurrent_test.go
+++ b/internal/session/manager_concurrent_test.go
@@ -5,6 +5,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/llm"
 )
 
@@ -12,9 +15,7 @@ import (
 // must not race or corrupt the tree. Run with -race.
 func TestManagerConcurrentAccess(t *testing.T) {
 	m, err := NewSessionManager(t.TempDir(), WithShouldFlush(false))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var wg sync.WaitGroup
 	for w := range 8 {
@@ -27,8 +28,8 @@ func TestManagerConcurrentAccess(t *testing.T) {
 					Content: fmt.Sprintf("w%d-%d", w, i),
 				}
 				id, err := m.Append(msg)
+				assert.NoError(t, err)
 				if err != nil {
-					t.Errorf("append: %v", err)
 					return
 				}
 				_ = m.BuildContext()
@@ -39,7 +40,5 @@ func TestManagerConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 
-	if m.Len() < 8*50 {
-		t.Fatalf("expected >= %d entries, got %d", 8*50, m.Len())
-	}
+	require.GreaterOrEqual(t, m.Len(), 8*50)
 }

--- a/internal/toolmanager/download_integration_test.go
+++ b/internal/toolmanager/download_integration_test.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/util/githubrelease"
 )
@@ -34,19 +35,13 @@ func TestDownloadToolsFromGitHub(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 			defer cancel()
 			path, err := DownloadTool(ctx, test.tool)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			commandCtx, commandCancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer commandCancel()
 			out, err := exec.CommandContext(commandCtx, path, "--version").CombinedOutput()
-			if err != nil {
-				t.Fatalf("run downloaded %s: %v: %s", test.tool, err, out)
-			}
-			if !strings.Contains(string(out), test.versionOut) {
-				t.Fatalf("unexpected %s version output: %s", test.tool, out)
-			}
+			require.NoError(t, err, "run downloaded %s: %v: %s", test.tool, err, out)
+			require.Contains(t, string(out), test.versionOut, "unexpected %s version output: %s", test.tool, out)
 		})
 	}
 }
@@ -59,19 +54,13 @@ func TestSelectCompatibleFdReleaseFromGitHub(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	releases, err := githubrelease.FetchRecent(ctx, Tools["fd"].Repo, compatibleReleaseLookback)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	asset, err := selectCompatibleAsset(
 		Tools["fd"],
 		releases,
 		PlatformDarwin,
 		ArchAMD64,
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(asset.Name, "x86_64-apple-darwin") {
-		t.Fatalf("unexpected Intel macOS fd asset: %s", asset.Name)
-	}
+	require.NoError(t, err)
+	require.Contains(t, asset.Name, "x86_64-apple-darwin", "unexpected Intel macOS fd asset: %s", asset.Name)
 }

--- a/internal/toolmanager/download_test.go
+++ b/internal/toolmanager/download_test.go
@@ -1,8 +1,9 @@
 package toolmanager
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/util/githubrelease"
 )
@@ -15,12 +16,8 @@ func TestFindReleaseAssetUsesCandidateOrder(t *testing.T) {
 	}
 
 	got, ok := findReleaseAsset(assets, []string{"tool-musl.tar.gz", "tool-gnu.tar.gz"})
-	if !ok {
-		t.Fatal("findReleaseAsset() did not find a compatible asset")
-	}
-	if got.Name != "tool-musl.tar.gz" {
-		t.Fatalf("findReleaseAsset() = %q, want musl candidate", got.Name)
-	}
+	require.True(t, ok, "findReleaseAsset() did not find a compatible asset")
+	require.Equal(t, "tool-musl.tar.gz", got.Name, "findReleaseAsset() = %q, want musl candidate")
 }
 
 func TestFindReleaseAssetFallsBack(t *testing.T) {
@@ -30,12 +27,8 @@ func TestFindReleaseAssetFallsBack(t *testing.T) {
 	}
 
 	got, ok := findReleaseAsset(assets, []string{"tool-musl.tar.gz", "tool-gnu.tar.gz"})
-	if !ok {
-		t.Fatal("findReleaseAsset() did not use the fallback asset")
-	}
-	if got.Name != "tool-gnu.tar.gz" {
-		t.Fatalf("findReleaseAsset() = %q, want GNU fallback", got.Name)
-	}
+	require.True(t, ok, "findReleaseAsset() did not use the fallback asset")
+	require.Equal(t, "tool-gnu.tar.gz", got.Name, "findReleaseAsset() = %q, want GNU fallback")
 }
 
 func TestSelectCompatibleAssetFallsBackToOlderRelease(t *testing.T) {
@@ -67,12 +60,13 @@ func TestSelectCompatibleAssetFallsBackToOlderRelease(t *testing.T) {
 		PlatformDarwin,
 		ArchAMD64,
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if asset.Name != "fd-v10.3.0-x86_64-apple-darwin.tar.gz" {
-		t.Fatalf("selectCompatibleAsset() = %q, want v10.3.0 Intel macOS asset", asset.Name)
-	}
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"fd-v10.3.0-x86_64-apple-darwin.tar.gz",
+		asset.Name,
+		"selectCompatibleAsset() = %q, want v10.3.0 Intel macOS asset",
+	)
 }
 
 func TestSelectCompatibleAssetNoMatch(t *testing.T) {
@@ -87,13 +81,9 @@ func TestSelectCompatibleAssetNoMatch(t *testing.T) {
 		PlatformDarwin,
 		ArchAMD64,
 	)
-	if err == nil {
-		t.Fatal("selectCompatibleAsset() unexpectedly found an asset")
-	}
+	require.Error(t, err, "selectCompatibleAsset() unexpectedly found an asset")
 	for _, want := range []string{"fd has no compatible release asset", "darwin/amd64", "v10.4.2, v10.4.1"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("selectCompatibleAsset() error = %q, want substring %q", err, want)
-		}
+		require.Contains(t, err.Error(), want, "selectCompatibleAsset() error = %q, want substring %q", err, want)
 	}
 }
 
@@ -113,7 +103,6 @@ func TestSelectCompatibleAssetRequiresDownloadURL(t *testing.T) {
 		PlatformLinux,
 		ArchAMD64,
 	)
-	if err == nil || !strings.Contains(err.Error(), "has no download URL") {
-		t.Fatalf("selectCompatibleAsset() error = %v, want missing URL error", err)
-	}
+	require.Error(t, err, "selectCompatibleAsset() error = %v, want missing URL error")
+	require.Contains(t, err.Error(), "has no download URL")
 }

--- a/internal/toolmanager/tool_test.go
+++ b/internal/toolmanager/tool_test.go
@@ -1,8 +1,9 @@
 package toolmanager
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestAssetNameCandidates(t *testing.T) {
@@ -61,9 +62,7 @@ func TestAssetNameCandidates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := Tools[tt.tool].AssetNames.getAssetNames(tt.version, tt.platform, tt.arch)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("getAssetNames() = %q, want %q", got, tt.want)
-			}
+			require.Equal(t, tt.want, got, "getAssetNames()")
 		})
 	}
 }

--- a/internal/tools/agenttool/agent_result_test.go
+++ b/internal/tools/agenttool/agent_result_test.go
@@ -3,6 +3,9 @@ package agenttool_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/tools"
 )
 
@@ -14,23 +17,18 @@ func TestParseAgentResultSummary(t *testing.T) {
   "summary": "## Findings\n\n- ok\n"
 }`
 	r := tools.ParseAgentResult(out)
-	if !r.OK || r.JobID != "job_1" || r.Status != "completed" {
-		t.Fatalf("%+v", r)
-	}
-	if got := r.RenderableSummary(); got != "## Findings\n\n- ok" {
-		t.Fatalf("summary %q", got)
-	}
+	require.True(t, r.OK)
+	require.Equal(t, "job_1", r.JobID)
+	require.Equal(t, "completed", r.Status)
+	require.Equal(t, "## Findings\n\n- ok", r.RenderableSummary())
 }
 
 func TestParseAgentResultRunningNoSummary(t *testing.T) {
 	r := tools.ParseAgentResult(`{"job_id":"j","status":"running"}`)
-	if !r.OK || r.RenderableSummary() != "" {
-		t.Fatalf("%+v", r)
-	}
+	require.True(t, r.OK)
+	require.Empty(t, r.RenderableSummary())
 }
 
 func TestParseAgentResultRejectsPlain(t *testing.T) {
-	if tools.ParseAgentResult("hello").OK {
-		t.Fatal("expected reject")
-	}
+	assert.False(t, tools.ParseAgentResult("hello").OK, "expected reject")
 }

--- a/internal/tools/agenttool/agent_s4_test.go
+++ b/internal/tools/agenttool/agent_s4_test.go
@@ -119,7 +119,7 @@ func TestS4Cancel(t *testing.T) {
 	select {
 	case <-started:
 	case <-time.After(2 * time.Second):
-		t.Fatal("job did not start")
+		require.Fail(t, "job did not start")
 	}
 
 	cancelRaw, _ := json.Marshal(map[string]any{"job_id": spawned.JobID})

--- a/internal/tools/bashtool/bash_output_test.go
+++ b/internal/tools/bashtool/bash_output_test.go
@@ -4,14 +4,14 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBashOutputFormattingPreservesShortOutput(t *testing.T) {
 	in := "a\nb\nc\n"
 	got := formatBashOutput(in, false)
-	if got != in {
-		t.Fatalf("short output changed: %q", got)
-	}
+	require.Equal(t, in, got, "short output changed")
 }
 
 func TestBashOutputFormattingWritesTemp(t *testing.T) {
@@ -21,23 +21,15 @@ func TestBashOutputFormattingWritesTemp(t *testing.T) {
 	}
 	full := b.String()
 	got := formatBashOutput(full, false)
-	if !strings.Contains(got, "Full output:") {
-		t.Fatalf("missing full-output notice: %q", got)
-	}
-	if !strings.Contains(got, "Showing lines") {
-		t.Fatalf("missing range notice: %q", got)
-	}
+	require.Contains(t, got, "Full output:", "missing full-output notice")
+	require.Contains(t, got, "Showing lines", "missing range notice")
 	// Extract path and confirm file exists with full content.
 	_, rest, _ := strings.Cut(got, "Full output: ")
 	path := strings.TrimSpace(strings.Split(rest, "]")[0])
 	t.Cleanup(func() { _ = os.Remove(path) })
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != full {
-		t.Fatalf("temp file content mismatch: got %d bytes want %d", len(data), len(full))
-	}
+	require.NoError(t, err)
+	require.Equal(t, full, string(data), "temp file content mismatch")
 }
 
 func TestFormatCollectedBashOutputLabelsRetainedFile(t *testing.T) {
@@ -48,46 +40,28 @@ func TestFormatCollectedBashOutputLabelsRetainedFile(t *testing.T) {
 	retained := b.String()
 
 	got := formatBashOutput(retained, true)
-	if !strings.Contains(got, "Retained output:") {
-		t.Fatalf("missing retained-output notice: %q", got)
-	}
-	if strings.Contains(got, "Full output:") {
-		t.Fatalf("collection-truncated output mislabeled as full: %q", got)
-	}
-	if !strings.Contains(got, "Showing lines 21-1020 of 1020") {
-		t.Fatalf("collection notice changed real line range: %q", got)
-	}
-	if !strings.HasSuffix(got, collectTruncationNote) {
-		t.Fatalf("missing collection truncation note: %q", got)
-	}
+	require.Contains(t, got, "Retained output:", "missing retained-output notice")
+	require.NotContains(t, got, "Full output:", "collection-truncated output mislabeled as full")
+	require.Contains(t, got, "Showing lines 21-1020 of 1020", "collection notice changed real line range")
+	require.True(t, strings.HasSuffix(got, collectTruncationNote), "missing collection truncation note")
 	_, rest, _ := strings.Cut(got, "Retained output: ")
 	path := strings.TrimSpace(strings.Split(rest, "]")[0])
-	if path == "" {
-		t.Fatal("missing retained output path")
-	}
+	require.NotEmpty(t, path, "missing retained output path")
 	t.Cleanup(func() { _ = os.Remove(path) })
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != retained {
-		t.Fatalf("retained file contains display metadata: got %d bytes want %d", len(data), len(retained))
-	}
+	require.NoError(t, err)
+	require.Equal(t, retained, string(data), "retained file contains display metadata")
 }
 
 func TestCollectionNoticeDoesNotConsumeDisplayBudget(t *testing.T) {
 	output := strings.Repeat("x", BashMaxOutputBytes)
 	got := formatBashOutput(output, true)
-	if got != output+collectTruncationNote {
-		t.Fatalf(
-			"collection notice altered output at display limit: got %d bytes want %d",
-			len(got),
-			len(output)+len(collectTruncationNote),
-		)
-	}
-	if strings.Contains(got, "Retained output:") || strings.Contains(got, "Showing lines") {
-		t.Fatalf("collection notice caused an unnecessary temp dump: %q", got[len(output):])
-	}
+	require.Equal(t, output+collectTruncationNote, got, "collection notice altered output at display limit")
+	require.False(
+		t,
+		strings.Contains(got, "Retained output:") || strings.Contains(got, "Showing lines"),
+		"collection notice caused an unnecessary temp dump",
+	)
 }
 
 func TestTruncateBashTailPreservesTailSemantics(t *testing.T) {
@@ -136,16 +110,16 @@ func TestTruncateBashTailPreservesTailSemantics(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			display, path := truncateBashTail(tc.output, tc.maxLines, tc.maxBytes, "Full output")
-			if path == "" {
-				t.Fatal("missing temp output path")
-			}
+			require.NotEmpty(t, path, "missing temp output path")
 			t.Cleanup(func() { _ = os.Remove(path) })
-			if !strings.HasPrefix(display, tc.wantTail+"\n\n[") {
-				t.Fatalf("display tail=%q, want prefix %q", display, tc.wantTail)
-			}
-			if !strings.Contains(display, tc.wantRange) {
-				t.Fatalf("display=%q, want range %q", display, tc.wantRange)
-			}
+			require.True(
+				t,
+				strings.HasPrefix(display, tc.wantTail+"\n\n["),
+				"display tail=%q, want prefix %q",
+				display,
+				tc.wantTail,
+			)
+			require.Contains(t, display, tc.wantRange, "display=%q, want range %q", display, tc.wantRange)
 		})
 	}
 }

--- a/internal/tools/bashtool/collect_test.go
+++ b/internal/tools/bashtool/collect_test.go
@@ -4,65 +4,54 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCappedBufferKeepsNewestTail(t *testing.T) {
 	cb := newCappedBuffer(32)
 	full := strings.Repeat("0123456789", 100)
 	for range 100 {
-		if _, err := cb.Write([]byte("0123456789")); err != nil {
-			t.Fatal(err)
-		}
+		_, err := cb.Write([]byte("0123456789"))
+		require.NoError(t, err)
 	}
-	got := cb.String()
-	if want := full[len(full)-32:]; got != want {
-		t.Fatalf("want the newest 32 bytes %q, got %q", want, got)
-	}
-	if !cb.Truncated() {
-		t.Fatal("want truncated")
-	}
+	require.Equal(t, full[len(full)-32:], cb.String(), "want the newest 32 bytes")
+	require.True(t, cb.Truncated(), "want truncated")
 }
 
 func TestBashOutputTailKeepsNewestLinesAndBytes(t *testing.T) {
 	tail := NewBashOutputTail(3, 64)
-	if _, err := tail.WriteString("one\ntwo\nthree\nfour\n"); err != nil {
-		t.Fatal(err)
-	}
+	_, err := tail.WriteString("one\ntwo\nthree\nfour\n")
+	require.NoError(t, err)
 	got, truncated := tail.Snapshot()
-	if want := "two\nthree\nfour\n"; got != want || !truncated {
-		t.Fatalf("got %q truncated=%v, want %q and truncation", got, truncated, want)
-	}
+	require.Equal(t, "two\nthree\nfour\n", got)
+	require.True(t, truncated)
 
 	tail = NewBashOutputTail(100, 10)
-	if _, err := tail.WriteString("0123456789ABC"); err != nil {
-		t.Fatal(err)
-	}
+	_, err = tail.WriteString("0123456789ABC")
+	require.NoError(t, err)
 	got, truncated = tail.Snapshot()
-	if got != "3456789ABC" || !truncated {
-		t.Fatalf("got %q truncated=%v, want newest 10 bytes", got, truncated)
-	}
+	require.Equal(t, "3456789ABC", got)
+	require.True(t, truncated, "want newest 10 bytes")
 }
 
 func TestCappedBufferNoTruncationUnderLimit(t *testing.T) {
 	cb := newCappedBuffer(64)
 	data := "hello world"
-	if _, err := cb.Write([]byte(data)); err != nil {
-		t.Fatal(err)
-	}
-	if cb.String() != data || cb.Truncated() {
-		t.Fatalf("got %q truncated=%v", cb.String(), cb.Truncated())
-	}
+	_, err := cb.Write([]byte(data))
+	require.NoError(t, err)
+	require.Equal(t, data, cb.String())
+	require.False(t, cb.Truncated())
 }
 
 func TestCappedBufferExactLimit(t *testing.T) {
 	cb := newCappedBuffer(10)
 	data := "0123456789"
-	if _, err := cb.Write([]byte(data)); err != nil {
-		t.Fatal(err)
-	}
-	if cb.String() != data || cb.Truncated() {
-		t.Fatalf("got %q truncated=%v", cb.String(), cb.Truncated())
-	}
+	_, err := cb.Write([]byte(data))
+	require.NoError(t, err)
+	require.Equal(t, data, cb.String())
+	require.False(t, cb.Truncated())
 }
 
 func TestCappedBufferConcurrentWrites(t *testing.T) {
@@ -80,7 +69,6 @@ func TestCappedBufferConcurrentWrites(t *testing.T) {
 		}(g)
 	}
 	wg.Wait()
-	if len(cb.String()) != 1024 || !cb.Truncated() {
-		t.Fatalf("len=%d truncated=%v", len(cb.String()), cb.Truncated())
-	}
+	assert.Len(t, cb.String(), 1024)
+	assert.True(t, cb.Truncated())
 }

--- a/internal/tools/bashtool/shell_exec_test.go
+++ b/internal/tools/bashtool/shell_exec_test.go
@@ -6,32 +6,23 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestExecShellEcho(t *testing.T) {
 	res, err := ExecShell(t.Context(), "echo hello", ShellExecOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.Canceled || res.ExitCode != 0 {
-		t.Fatalf("result: %+v", res)
-	}
-	if !strings.Contains(res.Output, "hello") {
-		t.Fatalf("output=%q", res.Output)
-	}
+	require.NoError(t, err)
+	require.False(t, res.Canceled || res.ExitCode != 0, "result: %+v", res)
+	require.Contains(t, res.Output, "hello")
 }
 
 func TestExecShellCapturesBothStreams(t *testing.T) {
 	res, err := ExecShell(t.Context(), "printf stdout; printf stderr >&2", ShellExecOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.ExitCode != 0 || res.Canceled {
-		t.Fatalf("result: %+v", res)
-	}
-	if !strings.Contains(res.Output, "stdout") || !strings.Contains(res.Output, "stderr") {
-		t.Fatalf("combined output=%q", res.Output)
-	}
+	require.NoError(t, err)
+	require.False(t, res.ExitCode != 0 || res.Canceled, "result: %+v", res)
+	require.Contains(t, res.Output, "stdout")
+	require.Contains(t, res.Output, "stderr")
 }
 
 func TestShellOutputWriterStreamsAfterCollectionCap(t *testing.T) {
@@ -40,18 +31,13 @@ func TestShellOutputWriterStreamsAfterCollectionCap(t *testing.T) {
 		cb:      newCappedBuffer(4),
 		onChunk: func(chunk string) { streamed.WriteString(chunk) },
 	}
-	if _, err := output.Write([]byte("1234")); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := output.Write([]byte("5678")); err != nil {
-		t.Fatal(err)
-	}
-	if got := streamed.String(); got != "12345678" {
-		t.Fatalf("streamed output=%q, want all chunks", got)
-	}
-	if got := output.cb.String(); got != "5678" || !output.cb.Truncated() {
-		t.Fatalf("collected output=%q truncated=%v, want bounded tail", got, output.cb.Truncated())
-	}
+	_, err := output.Write([]byte("1234"))
+	require.NoError(t, err)
+	_, err = output.Write([]byte("5678"))
+	require.NoError(t, err)
+	require.Equal(t, "12345678", streamed.String(), "streamed output should contain all chunks")
+	require.Equal(t, "5678", output.cb.String(), "collected output should be bounded tail")
+	require.True(t, output.cb.Truncated(), "expected truncation")
 }
 
 func TestExecShellCapturesOutputBeforeProcessExit(t *testing.T) {
@@ -60,15 +46,10 @@ func TestExecShellCapturesOutputBeforeProcessExit(t *testing.T) {
 
 	for range 8 {
 		res, err := ExecShell(t.Context(), command, ShellExecOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if res.ExitCode != 0 || res.Canceled {
-			t.Fatalf("result: %+v", res)
-		}
-		if len(res.Output) != outputSize || strings.Trim(res.Output, "x") != "" {
-			t.Fatalf("captured %d bytes, want %d x bytes", len(res.Output), outputSize)
-		}
+		require.NoError(t, err)
+		require.False(t, res.ExitCode != 0 || res.Canceled, "result: %+v", res)
+		require.Len(t, res.Output, outputSize)
+		require.Empty(t, strings.Trim(res.Output, "x"), "expected all x bytes")
 	}
 }
 
@@ -77,23 +58,14 @@ func TestExecShellKeepsOutputTail(t *testing.T) {
 	// must not be dropped (writer-mode copying drains to EOF before Run returns).
 	command := "seq 1 100000" // ~590KB, under the collection cap
 	res, err := ExecShell(t.Context(), command, ShellExecOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cleanupBashOutputFile(t, res.Output)
-	if res.ExitCode != 0 || res.Canceled {
-		t.Fatalf("result: %+v", res)
-	}
+	require.False(t, res.ExitCode != 0 || res.Canceled, "result: %+v", res)
 	// The display notice's own line range proves line 100000 was collected.
-	if !strings.Contains(res.Output, "Showing lines 99001-100000 of 100000") {
-		t.Fatalf("output tail lost, ends with %q", tailLines(res.Output))
-	}
-	if !strings.Contains(res.Output, "Full output:") || strings.Contains(res.Output, "Retained output:") {
-		t.Fatalf("under-cap output mislabeled, ends with %q", tailLines(res.Output))
-	}
-	if strings.Contains(res.Output, "[output truncated:") {
-		t.Fatalf("unexpected collection truncation, ends with %q", tailLines(res.Output))
-	}
+	require.Contains(t, res.Output, "Showing lines 99001-100000 of 100000", "output tail lost")
+	require.Contains(t, res.Output, "Full output:")
+	require.NotContains(t, res.Output, "Retained output:", "under-cap output mislabeled")
+	require.NotContains(t, res.Output, "[output truncated:", "unexpected collection truncation")
 }
 
 func TestExecShellBoundsCollection(t *testing.T) {
@@ -101,19 +73,12 @@ func TestExecShellBoundsCollection(t *testing.T) {
 	// BashMaxCollectBytes are kept and the collection truncation is reported.
 	command := "yes x | head -c 20971520" // 20MB
 	res, err := ExecShell(t.Context(), command, ShellExecOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cleanupBashOutputFile(t, res.Output)
-	if res.ExitCode != 0 || res.Canceled {
-		t.Fatalf("result: %+v", res)
-	}
-	if !strings.Contains(res.Output, "[output truncated: only the last 8 MB was kept]") {
-		t.Fatalf("want collection truncation notice, ends with %q", tailLines(res.Output))
-	}
-	if !strings.Contains(res.Output, "Retained output:") || strings.Contains(res.Output, "Full output:") {
-		t.Fatalf("collection-truncated output mislabeled, ends with %q", tailLines(res.Output))
-	}
+	require.False(t, res.ExitCode != 0 || res.Canceled, "result: %+v", res)
+	require.Contains(t, res.Output, "[output truncated: only the last 8 MB was kept]")
+	require.Contains(t, res.Output, "Retained output:")
+	require.NotContains(t, res.Output, "Full output:", "collection-truncated output mislabeled")
 }
 
 func cleanupBashOutputFile(t *testing.T, output string) {
@@ -132,14 +97,6 @@ func cleanupBashOutputFile(t *testing.T, output string) {
 	}
 }
 
-func tailLines(s string) string {
-	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
-	if len(lines) > 3 {
-		lines = lines[len(lines)-3:]
-	}
-	return strings.Join(lines, "\n")
-}
-
 func TestExecShellCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
@@ -147,20 +104,12 @@ func TestExecShellCancel(t *testing.T) {
 		cancel()
 	}()
 	res, err := ExecShell(ctx, "sleep 5", ShellExecOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !res.Canceled {
-		t.Fatalf("want canceled, got %+v", res)
-	}
+	require.NoError(t, err)
+	require.True(t, res.Canceled, "want canceled, got %+v", res)
 }
 
 func TestExecShellExitCode(t *testing.T) {
 	res, err := ExecShell(t.Context(), "exit 7", ShellExecOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.ExitCode != 7 {
-		t.Fatalf("exit=%d", res.ExitCode)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 7, res.ExitCode)
 }

--- a/internal/tools/bashtool/shellconfig_test.go
+++ b/internal/tools/bashtool/shellconfig_test.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/tools/tooldef"
 )
 
@@ -15,9 +18,7 @@ func TestIsLegacyWslBashPath(t *testing.T) {
 		`c:\windows\system32\bash.exe`,
 		`C:/Windows/Sysnative/bash.exe`,
 	} {
-		if !isLegacyWslBashPath(p) {
-			t.Errorf("want WSL shim for %q", p)
-		}
+		assert.True(t, isLegacyWslBashPath(p), "want WSL shim for %q", p)
 	}
 	for _, p := range []string{
 		`C:\Program Files\Git\bin\bash.exe`,
@@ -25,33 +26,28 @@ func TestIsLegacyWslBashPath(t *testing.T) {
 		`/bin/bash`,
 		`C:\Windows\System32\wsl.exe`,
 	} {
-		if isLegacyWslBashPath(p) {
-			t.Errorf("not a WSL shim for %q", p)
-		}
+		assert.False(t, isLegacyWslBashPath(p), "not a WSL shim for %q", p)
 	}
 }
 
 func TestConfigForShell(t *testing.T) {
 	cfg := configForShell(`C:\Program Files\Git\bin\bash.exe`)
-	if cfg.stdinMode || len(cfg.args) != 1 || cfg.args[0] != "-c" {
-		t.Fatalf("git bash config: %+v", cfg)
-	}
+	require.False(t, cfg.stdinMode, "git bash should not use stdin mode")
+	require.Len(t, cfg.args, 1)
+	require.Equal(t, "-c", cfg.args[0])
+
 	cfg = configForShell(`C:\Windows\System32\bash.exe`)
-	if !cfg.stdinMode || len(cfg.args) != 1 || cfg.args[0] != "-s" {
-		t.Fatalf("WSL shim must use stdin transport: %+v", cfg)
-	}
+	require.True(t, cfg.stdinMode, "WSL shim must use stdin transport")
+	require.Len(t, cfg.args, 1)
+	require.Equal(t, "-s", cfg.args[0])
 }
 
 func TestResolveShellConfig(t *testing.T) {
 	cfg, err := resolveShellConfig()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.shell == "" {
-		t.Fatal("empty shell")
-	}
-	if runtime.GOOS == "windows" && !cfg.stdinMode && (len(cfg.args) != 1 || cfg.args[0] != "-c") {
-		t.Fatalf("windows config: %+v", cfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg.shell, "empty shell")
+	if runtime.GOOS == "windows" {
+		require.False(t, !cfg.stdinMode && (len(cfg.args) != 1 || cfg.args[0] != "-c"), "windows config: %+v", cfg)
 	}
 }
 
@@ -59,56 +55,37 @@ func TestPrependPathEntry(t *testing.T) {
 	sep := string(os.PathListSeparator)
 	got := prependPathEntry([]string{"PATH=/usr/bin" + sep + "/bin"}, "/x/bin")
 	want := "PATH=/x/bin" + sep + "/usr/bin" + sep + "/bin"
-	if got[0] != want {
-		t.Fatalf("got %q, want %q", got[0], want)
-	}
+	require.Equal(t, want, got[0])
 
 	// Already present → unchanged.
 	existing := "PATH=/usr/bin" + sep + "/x/bin"
 	got = prependPathEntry([]string{existing}, "/x/bin")
-	if len(got) != 1 || got[0] != existing {
-		t.Fatalf("expected unchanged, got %v", got)
-	}
+	require.Len(t, got, 1)
+	require.Equal(t, existing, got[0])
 
 	// Windows-style key casing is matched case-insensitively.
 	got = prependPathEntry([]string{"Path=C:\\Windows"}, `C:\Phi\bin`)
-	if !strings.HasPrefix(got[0], "Path=") || !strings.Contains(got[0], `C:\Phi\bin`) {
-		t.Fatalf("got %q", got[0])
-	}
+	require.True(t, strings.HasPrefix(got[0], "Path="))
+	require.Contains(t, got[0], `C:\Phi\bin`)
 
 	// No PATH entry → appended.
 	got = prependPathEntry([]string{"HOME=/home/x"}, "/x/bin")
-	if len(got) != 2 || got[1] != "PATH=/x/bin" {
-		t.Fatalf("got %v", got)
-	}
+	require.Len(t, got, 2)
+	require.Equal(t, "PATH=/x/bin", got[1])
 }
 
 func TestBuildShellCommand(t *testing.T) {
 	cmd, err := buildShellCommand(t.Context(), "echo hi")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cmd.SysProcAttr == nil {
-		t.Fatal("expected process-group syscall attr")
-	}
-	if cmd.Cancel == nil {
-		t.Fatal("expected tree-kill cancel")
-	}
-	if cmd.WaitDelay != shellWaitDelay {
-		t.Fatalf("WaitDelay=%v, want %v", cmd.WaitDelay, shellWaitDelay)
-	}
-	if len(cmd.Env) == 0 {
-		t.Fatal("expected enriched env")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, cmd.SysProcAttr, "expected process-group syscall attr")
+	require.NotNil(t, cmd.Cancel, "expected tree-kill cancel")
+	require.Equal(t, shellWaitDelay, cmd.WaitDelay)
+	require.NotEmpty(t, cmd.Env, "expected enriched env")
 }
 
 func TestBuildShellCommandUsesContextCwd(t *testing.T) {
 	dir := t.TempDir()
 	cmd, err := buildShellCommand(tooldef.WithCwd(t.Context(), dir), "echo hi")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cmd.Dir != dir {
-		t.Fatalf("Dir=%q, want %q", cmd.Dir, dir)
-	}
+	require.NoError(t, err)
+	require.Equal(t, dir, cmd.Dir)
 }

--- a/internal/tools/lstool/ls_test.go
+++ b/internal/tools/lstool/ls_test.go
@@ -6,153 +6,98 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLs_RelativePath(t *testing.T) {
 	root := t.TempDir()
 	sub := filepath.Join(root, "pkg")
-	if err := os.Mkdir(sub, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(sub, "main.go"), []byte("package pkg"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "main.go"), []byte("package pkg"), 0o644))
 
 	t.Chdir(root)
 
 	raw, err := json.Marshal(lsInput{Path: "pkg"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	out, err := runLs(t.Context(), raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.Content, "main.go") {
-		t.Fatalf("expected output to contain main.go, got: %s", out.Content)
-	}
-	if !strings.HasPrefix(out.Content, "pkg/") {
-		t.Fatalf("expected cwd-relative tree root pkg/, got: %s", out.Content)
-	}
-	if out.Detail != "pkg" {
-		t.Fatalf("expected detail pkg, got %q", out.Detail)
-	}
+	require.NoError(t, err)
+	require.Contains(t, out.Content, "main.go")
+	require.True(
+		t,
+		strings.HasPrefix(out.Content, "pkg/"),
+		"expected cwd-relative tree root pkg/, got: %s",
+		out.Content,
+	)
+	require.Equal(t, "pkg", out.Detail)
 }
 
 func TestLs_Errors(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "a.txt")
-	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
 
 	raw, err := json.Marshal(lsInput{Path: file})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	_, err = runLs(t.Context(), raw)
-	if err == nil {
-		t.Fatal("expected error for file path, got nil")
-	}
-	if !strings.Contains(strings.ToLower(err.Error()), "not a directory") {
-		t.Fatalf("expected 'not a directory' error, got: %v", err)
-	}
+	require.Error(t, err, "expected error for file path")
+	require.Contains(t, strings.ToLower(err.Error()), "not a directory")
 }
 
 func TestLs_MaxDepthStopsExpansion(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "lvl1", "lvl2", "lvl3"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "lvl1", "lvl2", "lvl3", "deep.txt"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "lvl1", "lvl2", "lvl3"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "lvl1", "lvl2", "lvl3", "deep.txt"), []byte("x"), 0o644))
 
 	raw, err := json.Marshal(lsInput{
 		Path:     root,
 		MaxDepth: 3,
 		Limit:    100,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	out, err := runLs(t.Context(), raw)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	result := out.Content
 
-	if !strings.Contains(result, "lvl1"+string(os.PathSeparator)) {
-		t.Fatalf("expected output to contain lvl1/")
-	}
-	if !strings.Contains(result, "lvl2"+string(os.PathSeparator)) {
-		t.Fatalf("expected output to contain lvl2/")
-	}
-	if !strings.Contains(result, "lvl3"+string(os.PathSeparator)) {
-		t.Fatalf("expected output to contain lvl3/")
-	}
-	if strings.Contains(result, "deep.txt") {
-		t.Fatalf("expected output NOT to contain deep.txt at maxDepth=3")
-	}
+	require.Contains(t, result, "lvl1"+string(os.PathSeparator))
+	require.Contains(t, result, "lvl2"+string(os.PathSeparator))
+	require.Contains(t, result, "lvl3"+string(os.PathSeparator))
+	require.NotContains(t, result, "deep.txt", "expected output NOT to contain deep.txt at maxDepth=3")
 }
 
 func TestLs_LimitTriggersTruncationMessage(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "b.txt"), []byte("b"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "b.txt"), []byte("b"), 0o644))
 
 	raw, err := json.Marshal(lsInput{
 		Path:  root,
 		Limit: 1,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	out, err := runLs(t.Context(), raw)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	result := out.Content
 
-	if !strings.Contains(result, "Tree truncated after 1 files") {
-		t.Fatalf("expected truncation message, got: %s", result)
-	}
-	if !strings.Contains(result, "limit=<n>") {
-		t.Fatalf("expected limit=<n> hint, got: %s", result)
-	}
+	require.Contains(t, result, "Tree truncated after 1 files")
+	require.Contains(t, result, "limit=<n>")
 }
 
 func TestLs_DefaultOptionsApplied(t *testing.T) {
 	limit, depth := normalizeOptions(0, 0)
-	if limit != defaultMaxFiles {
-		t.Fatalf("expected limit=%d, got %d", defaultMaxFiles, limit)
-	}
-	if depth != defaultMaxDepth {
-		t.Fatalf("expected depth=%d, got %d", defaultMaxDepth, depth)
-	}
+	require.Equal(t, defaultMaxFiles, limit)
+	require.Equal(t, defaultMaxDepth, depth)
 }
 
 func TestLs_PlainStringPath(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "x.txt"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(root, "x.txt"), []byte("x"), 0o644))
 
 	// Pass path as a plain JSON string, not an object.
 	raw, err := json.Marshal(root)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	out, err := runLs(t.Context(), raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out.Content, "x.txt") {
-		t.Fatalf("expected output to contain x.txt, got: %s", out.Content)
-	}
+	require.NoError(t, err)
+	require.Contains(t, out.Content, "x.txt")
 }

--- a/internal/tools/mcptool/mcp_test.go
+++ b/internal/tools/mcptool/mcp_test.go
@@ -1,8 +1,10 @@
 package mcptool_test
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/mcp"
 	"github.com/pulseaiclub/phi/internal/tools/mcptool"
@@ -14,24 +16,18 @@ func TestMCPToolsRegister(t *testing.T) {
 		"echo": {Command: []string{"true"}},
 	})
 	tools := mcptool.Tools(pool)
-	if len(tools) != 3 {
-		t.Fatalf("tools = %d", len(tools))
-	}
+	require.Len(t, tools, 3)
 	byName := map[string]bool{}
 	for _, tool := range tools {
 		byName[tool.Definition.Name] = true
 	}
 	for _, name := range []string{"mcp_list", "mcp_inspect", "mcp_call"} {
-		if !byName[name] {
-			t.Fatalf("missing %s", name)
-		}
+		assert.True(t, byName[name], "missing %s", name)
 	}
 }
 
 func TestMCPToolsNilPool(t *testing.T) {
-	if mcptool.Tools(nil) != nil {
-		t.Fatal("expected nil")
-	}
+	require.Nil(t, mcptool.Tools(nil))
 }
 
 func TestMCPListRequiresServer(t *testing.T) {
@@ -40,13 +36,11 @@ func TestMCPListRequiresServer(t *testing.T) {
 	})
 	list := findTool(t, mcptool.Tools(pool), "mcp_list")
 	req := list.Definition.Params.Required
-	if len(req) != 1 || req[0] != "server" {
-		t.Fatalf("Required = %v, want [server]", req)
-	}
+	require.Len(t, req, 1)
+	require.Equal(t, "server", req[0])
 	_, err := list.Run(t.Context(), []byte(`{}`))
-	if err == nil || !strings.Contains(err.Error(), "server is required") {
-		t.Fatalf("err = %v, want server is required", err)
-	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "server is required")
 }
 
 func findTool(t *testing.T, tools []tooldef.Tool, name string) tooldef.Tool {
@@ -56,6 +50,6 @@ func findTool(t *testing.T, tools []tooldef.Tool, name string) tooldef.Tool {
 			return tool
 		}
 	}
-	t.Fatalf("missing %s", name)
+	require.Failf(t, "tool not found", "missing %s", name)
 	return tooldef.Tool{}
 }

--- a/internal/tui/commands/session_cmds_test.go
+++ b/internal/tui/commands/session_cmds_test.go
@@ -45,7 +45,7 @@ func TestSessionCommands_ShowEmptyToasts(t *testing.T) {
 		Bus:        bus,
 		SessionDir: func() string { return t.TempDir() },
 		OpenPicker: func([]session.SessionMeta, string) {
-			t.Fatal("picker should not open")
+			require.Fail(t, "picker should not open")
 		},
 	}
 	s.Show()

--- a/internal/tui/composer/mention_search_test.go
+++ b/internal/tui/composer/mention_search_test.go
@@ -31,7 +31,7 @@ func TestScheduleMentionSearchCancelsPrevious(t *testing.T) {
 	select {
 	case <-firstDone:
 	case <-time.After(time.Second):
-		t.Fatal("scheduling a new search must cancel the previous one")
+		require.Fail(t, "scheduling a new search must cancel the previous one")
 	}
 }
 
@@ -104,7 +104,7 @@ func TestHideCompletersCancelsSearch(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("closing the picker must cancel the search in flight")
+		require.Fail(t, "closing the picker must cancel the search in flight")
 	}
 }
 

--- a/internal/tui/controller/bus_test.go
+++ b/internal/tui/controller/bus_test.go
@@ -3,6 +3,8 @@ package controller_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/job"
 	"github.com/pulseaiclub/phi/internal/session"
 	"github.com/pulseaiclub/phi/internal/tui/controller"
@@ -14,17 +16,11 @@ func TestBusOnWakeOnceUntilDrain(t *testing.T) {
 	b.Publish(controller.JobProgressMsg{Progress: job.Progress{JobID: "j", ToolUseID: "t1", Status: "in-progress"}})
 	b.Publish(controller.JobProgressMsg{Progress: job.Progress{JobID: "j", ToolUseID: "t1", Status: "done"}})
 	b.Publish(controller.JobProgressMsg{Progress: job.Progress{JobID: "j", ToolUseID: "t2", Status: "done"}})
-	if wakes != 1 {
-		t.Fatalf("wakes=%d want 1 before Drain", wakes)
-	}
+	require.Equal(t, 1, wakes, "wakes before Drain")
 	batch := b.Drain()
-	if len(batch) != 2 {
-		t.Fatalf("len=%d want 2", len(batch))
-	}
+	require.Len(t, batch, 2)
 	b.Publish(controller.JobProgressMsg{Progress: job.Progress{JobID: "j", ToolUseID: "t3", Status: "done"}})
-	if wakes != 2 {
-		t.Fatalf("wakes=%d want 2 after re-arm", wakes)
-	}
+	require.Equal(t, 2, wakes, "wakes after re-arm")
 }
 
 func TestBusCoalesceNonAdjacentAssistant(t *testing.T) {
@@ -37,18 +33,12 @@ func TestBusCoalesceNonAdjacentAssistant(t *testing.T) {
 	b.Publish(controller.SessionEventMsg{Event: session.AssistantMessageUpdate{Message: session.Message{
 		ID: "a1", Text: "two", State: session.StateStreaming,
 	}}})
-	if wakes != 1 {
-		t.Fatalf("wakes=%d want 1", wakes)
-	}
+	require.Equal(t, 1, wakes)
 	batch := b.Drain()
-	if len(batch) != 2 {
-		t.Fatalf("len=%d want 2 (assistant coalesced across progress)", len(batch))
-	}
+	require.Len(t, batch, 2, "assistant coalesced across progress")
 	te := batch[0].(controller.SessionEventMsg)
 	upd := te.Event.(session.AssistantMessageUpdate)
-	if upd.Message.Text != "two" {
-		t.Fatalf("text=%q want two", upd.Message.Text)
-	}
+	require.Equal(t, "two", upd.Message.Text)
 }
 
 func TestBusCoalesceJobProgressAcrossSession(t *testing.T) {
@@ -59,11 +49,7 @@ func TestBusCoalesceJobProgressAcrossSession(t *testing.T) {
 	}}})
 	b.Publish(controller.JobProgressMsg{Progress: job.Progress{JobID: "j", ToolUseID: "t1", Status: "done"}})
 	batch := b.Drain()
-	if len(batch) != 2 {
-		t.Fatalf("len=%d want 2", len(batch))
-	}
+	require.Len(t, batch, 2)
 	jp := batch[0].(controller.JobProgressMsg)
-	if jp.Progress.Status != "done" {
-		t.Fatalf("status=%q", jp.Progress.Status)
-	}
+	require.Equal(t, "done", jp.Progress.Status)
 }

--- a/internal/tui/controller/controller_ext_test.go
+++ b/internal/tui/controller/controller_ext_test.go
@@ -60,5 +60,5 @@ func assertStatusReset(t *testing.T, bus *Bus) {
 			return
 		}
 	}
-	t.Fatal("expected an extension status reset (ExtSessionEffectsMsg{StatusSet:true, Status:\"\"})")
+	require.Fail(t, "expected an extension status reset (ExtSessionEffectsMsg{StatusSet:true, Status:\"\"})")
 }

--- a/internal/tui/controller/controller_progress_test.go
+++ b/internal/tui/controller/controller_progress_test.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/job"
 )
 
@@ -15,16 +17,10 @@ func TestShouldPublishJobProgressDedup(t *testing.T) {
 		Status:    "in-progress",
 		Detail:    "a.go",
 	}
-	if !c.shouldPublishJobProgress(p) {
-		t.Fatal("first should publish")
-	}
-	if c.shouldPublishJobProgress(p) {
-		t.Fatal("duplicate should drop")
-	}
+	require.True(t, c.shouldPublishJobProgress(p), "first should publish")
+	require.False(t, c.shouldPublishJobProgress(p), "duplicate should drop")
 	p.Status = "done"
-	if !c.shouldPublishJobProgress(p) {
-		t.Fatal("status change should publish")
-	}
+	require.True(t, c.shouldPublishJobProgress(p), "status change should publish")
 	p2 := job.Progress{
 		JobID:     "j",
 		ToolUseID: "t2",
@@ -32,7 +28,5 @@ func TestShouldPublishJobProgressDedup(t *testing.T) {
 		Status:    "done",
 		Detail:    "ls",
 	}
-	if !c.shouldPublishJobProgress(p2) {
-		t.Fatal("new child should publish")
-	}
+	require.True(t, c.shouldPublishJobProgress(p2), "new child should publish")
 }

--- a/internal/tui/footer/tokens_test.go
+++ b/internal/tui/footer/tokens_test.go
@@ -19,24 +19,16 @@ func TestFormatTokens(t *testing.T) {
 		1500000: "1.5M",
 	}
 	for n, want := range cases {
-		if got := formatTokens(n); got != want {
-			t.Fatalf("formatTokens(%d)=%q want %q", n, got, want)
-		}
+		require.Equal(t, want, formatTokens(n))
 	}
 }
 
 func TestFormatContextLabel(t *testing.T) {
 	u := session.TokenUsage{PromptTokens: 5120, TotalTokens: 6000}
 	got := formatContextLabel(u, 128000)
-	if got != "4%/128k" {
-		t.Fatalf("got %q", got)
-	}
-	if formatContextLabel(session.TokenUsage{}, 128000) != "" {
-		t.Fatal("empty usage should hide label")
-	}
-	if formatContextLabel(u, 0) != "" {
-		t.Fatal("zero window should hide label")
-	}
+	require.Equal(t, "4%/128k", got)
+	require.Empty(t, formatContextLabel(session.TokenUsage{}, 128000), "empty usage should hide label")
+	require.Empty(t, formatContextLabel(u, 0), "zero window should hide label")
 }
 
 func TestFormatUsageStats(t *testing.T) {
@@ -45,36 +37,37 @@ func TestFormatUsageStats(t *testing.T) {
 		CompletionTokens: 800,
 		TotalTokens:      2000,
 	})
-	if got != "↑1.2k ↓800 Σ2.0k" {
-		t.Fatalf("got %q", got)
-	}
+	require.Equal(t, "↑1.2k ↓800 Σ2.0k", got)
 	got = formatUsageStats(session.TokenUsage{
 		PromptTokens:     1200,
 		CompletionTokens: 800,
 		CachedTokens:     900,
 		TotalTokens:      2000,
 	})
-	if got != "↑1.2k ↓800 C900 Σ2.0k" {
-		t.Fatalf("got %q", got)
-	}
+	require.Equal(t, "↑1.2k ↓800 C900 Σ2.0k", got)
 }
 
 func TestJoinBorderParts(t *testing.T) {
-	if got := joinBorderParts(
+	got := joinBorderParts(
 		"↑1.2k ↓800 Σ2.0k",
 		"context: 4% of 128k",
-	); got != "↑1.2k ↓800 Σ2.0k context: 4% of 128k" {
-		t.Fatalf("got %q", got)
-	}
-	if got := joinBorderParts("", "context: 4% of 128k"); got != "context: 4% of 128k" {
-		t.Fatalf("got %q", got)
-	}
-	if got := joinBorderParts("↑1.2k", ""); got != "↑1.2k" {
-		t.Fatalf("got %q", got)
-	}
-	if got := joinBorderParts("", ""); got != "" {
-		t.Fatalf("got %q", got)
-	}
+	)
+	require.Equal(t, "↑1.2k ↓800 Σ2.0k context: 4% of 128k", got)
+}
+
+func TestJoinBorderPartsSecondEmpty(t *testing.T) {
+	got := joinBorderParts("", "context: 4% of 128k")
+	require.Equal(t, "context: 4% of 128k", got)
+}
+
+func TestJoinBorderPartsSecondBlank(t *testing.T) {
+	got := joinBorderParts("↑1.2k", "")
+	require.Equal(t, "↑1.2k", got)
+}
+
+func TestJoinBorderPartsBothEmpty(t *testing.T) {
+	got := joinBorderParts("", "")
+	require.Empty(t, got)
 }
 
 func TestTokenStatusLabelAmbient(t *testing.T) {

--- a/internal/tui/overlays/overlays_test.go
+++ b/internal/tui/overlays/overlays_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pulseaiclub/xui"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/permission"
@@ -24,26 +25,16 @@ func TestResolvePermissionSendsReply(t *testing.T) {
 		Reason:    "needs approval",
 		PermReply: reply,
 	})
-	if o.perm == nil {
-		t.Fatal("expected permAsk")
-	}
-	if o.perm.header != "Run this command?" {
-		t.Fatalf("header=%q", o.perm.header)
-	}
-	if activity.Current != controller.ActivityAwaitingApproval {
-		t.Fatalf("activity=%v", activity.Current)
-	}
+	require.NotNil(t, o.perm, "expected permAsk")
+	require.Equal(t, "Run this command?", o.perm.header)
+	require.Equal(t, controller.ActivityAwaitingApproval, activity.Current)
 	o.resolvePermission(controller.AskReply{Approved: true})
-	if o.perm != nil {
-		t.Fatal("expected cleared")
-	}
+	require.Nil(t, o.perm, "expected cleared")
 	select {
 	case r := <-reply:
-		if !r.Approved {
-			t.Fatal("want approved")
-		}
+		require.True(t, r.Approved, "want approved")
 	default:
-		t.Fatal("expected reply")
+		require.Fail(t, "expected reply")
 	}
 }
 
@@ -56,15 +47,12 @@ func TestPermissionDenyWithFeedback(t *testing.T) {
 		PermReply: reply,
 	})
 	o.acceptPermissionOption(askOptDenyFeedback)
-	if o.perm == nil || !o.perm.feedbackMode {
-		t.Fatal("expected feedback mode")
-	}
+	require.True(t, o.perm != nil && o.perm.feedbackMode, "expected feedback mode")
 	o.perm.feedback = "use docs instead"
 	o.resolvePermission(controller.AskReply{Feedback: o.perm.feedback})
 	r := <-reply
-	if r.Approved || r.Feedback != "use docs instead" {
-		t.Fatalf("got %+v", r)
-	}
+	require.False(t, r.Approved)
+	require.Equal(t, "use docs instead", r.Feedback)
 }
 
 func TestPermissionDismissClearsOverlay(t *testing.T) {
@@ -76,12 +64,10 @@ func TestPermissionDismissClearsOverlay(t *testing.T) {
 		PermReply: reply,
 	})
 	o.Apply(controller.OverlayMsg{Kind: controller.OverlayPermissionDismiss})
-	if o.perm != nil {
-		t.Fatal("overlay should clear without consuming reply")
-	}
+	require.Nil(t, o.perm, "overlay should clear without consuming reply")
 	select {
 	case <-reply:
-		t.Fatal("dismiss must not send on reply")
+		require.Fail(t, "dismiss must not send on reply")
 	default:
 	}
 }
@@ -99,16 +85,14 @@ func TestDrawPermissionAskReplacesComposerSlot(t *testing.T) {
 		Max:    components.Size{Width: 60, Height: 12},
 		Method: 0,
 	}, 60, 12)
-	if surf.Size.Width != 60 || surf.Size.Height != 12 {
-		t.Fatalf("size=%v", surf.Size)
-	}
+	require.Equal(t, 60, surf.Size.Width)
+	require.Equal(t, 12, surf.Size.Height)
 }
 
 func TestFormatAskHeader(t *testing.T) {
 	h, d := formatAskHeader(permission.Request{Action: permission.ActionWrite, Paths: []string{"/tmp/a"}})
-	if h != "Allow creating file:" || d != "/tmp/a" {
-		t.Fatalf("%q %q", h, d)
-	}
+	require.Equal(t, "Allow creating file:", h)
+	require.Equal(t, "/tmp/a", d)
 }
 
 func TestContinueAskResolveContinue(t *testing.T) {
@@ -120,26 +104,16 @@ func TestContinueAskResolveContinue(t *testing.T) {
 		MaxRounds: 64,
 		ContReply: reply,
 	})
-	if o.cont == nil {
-		t.Fatal("expected continueAsk")
-	}
-	if o.cont.maxRounds != 64 {
-		t.Fatalf("maxRounds=%d", o.cont.maxRounds)
-	}
-	if activity.Current != controller.ActivityAwaitingApproval {
-		t.Fatalf("activity=%v", activity.Current)
-	}
+	require.NotNil(t, o.cont, "expected continueAsk")
+	require.Equal(t, 64, o.cont.maxRounds)
+	require.Equal(t, controller.ActivityAwaitingApproval, activity.Current)
 	o.resolveContinue(controller.ContinueReply{Continue: true})
-	if o.cont != nil {
-		t.Fatal("expected continueAsk cleared")
-	}
+	require.Nil(t, o.cont, "expected continueAsk cleared")
 	select {
 	case r := <-reply:
-		if !r.Continue {
-			t.Fatal("expected Continue=true")
-		}
+		require.True(t, r.Continue, "expected Continue=true")
 	default:
-		t.Fatal("expected reply")
+		require.Fail(t, "expected reply")
 	}
 }
 
@@ -155,11 +129,9 @@ func TestContinueAskEscapeStops(t *testing.T) {
 	_ = o.handleContinueKey(ctx, xui.KeyEvent{Press: true, Code: xui.KeyEscape})
 	select {
 	case r := <-reply:
-		if r.Continue {
-			t.Fatal("escape should stop")
-		}
+		require.False(t, r.Continue, "escape should stop")
 	default:
-		t.Fatal("expected reply on escape")
+		require.Fail(t, "expected reply on escape")
 	}
 }
 
@@ -172,12 +144,10 @@ func TestContinueDismissClearsOverlay(t *testing.T) {
 		ContReply: reply,
 	})
 	o.Apply(controller.OverlayMsg{Kind: controller.OverlayContinueDismiss})
-	if o.cont != nil {
-		t.Fatal("overlay should clear without consuming reply")
-	}
+	require.Nil(t, o.cont, "overlay should clear without consuming reply")
 	select {
 	case <-reply:
-		t.Fatal("dismiss must not send on reply")
+		require.Fail(t, "dismiss must not send on reply")
 	default:
 	}
 }

--- a/internal/tui/submit/bash_test.go
+++ b/internal/tui/submit/bash_test.go
@@ -3,6 +3,9 @@ package submit
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBashLiveOutputPublishesTrailingUpdate(t *testing.T) {
@@ -13,18 +16,14 @@ func TestBashLiveOutputPublishesTrailingUpdate(t *testing.T) {
 	t.Cleanup(live.Close)
 
 	live.Append("first")
-	if got := <-updates; got != "first" {
-		t.Fatalf("first update=%q", got)
-	}
+	require.Equal(t, "first", <-updates)
 	live.Append("-second")
 
 	select {
 	case got := <-updates:
-		if got != "first-second" {
-			t.Fatalf("trailing update=%q", got)
-		}
+		require.Equal(t, "first-second", got)
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for trailing update")
+		require.Fail(t, "timed out waiting for trailing update")
 	}
 }
 
@@ -41,7 +40,6 @@ func TestBashLiveOutputCloseCancelsTrailingUpdate(t *testing.T) {
 
 	live.mu.Lock()
 	defer live.mu.Unlock()
-	if !live.stopped || live.timer != nil {
-		t.Fatalf("closed live output: stopped=%v timer=%v", live.stopped, live.timer)
-	}
+	require.True(t, live.stopped, "expected stopped=true")
+	assert.Nil(t, live.timer, "expected timer=nil")
 }

--- a/internal/tui/transcript/mapper_agent_test.go
+++ b/internal/tui/transcript/mapper_agent_test.go
@@ -1,8 +1,10 @@
 package transcript_test
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/block"
@@ -57,30 +59,19 @@ func TestMapperAgentBlockSummaryAndChildren(t *testing.T) {
 	}
 
 	entries, ids, dirty := m.Sync(nil, nil, snap)
-	if len(entries) != 1 || len(ids) != 1 {
-		t.Fatalf("entries=%d ids=%d", len(entries), len(ids))
-	}
-	if len(dirty) != 1 || dirty[0] != 0 {
-		t.Fatalf("dirty=%v want [0]", dirty)
-	}
+	require.Len(t, entries, 1)
+	require.Len(t, ids, 1)
+	require.Equal(t, []int{0}, dirty)
 	ab, ok := entries[0].(*block.AgentBlock)
-	if !ok {
-		t.Fatalf("got %T", entries[0])
-	}
-	if ab.Summary == "" || !strings.Contains(ab.Summary, "Findings") {
-		t.Fatalf("summary %q", ab.Summary)
-	}
-	if len(ab.Children) != 1 || ab.Children[0].Name != "read" {
-		t.Fatalf("children %+v", ab.Children)
-	}
-	if ab.Status != status.ToolDone {
-		t.Fatalf("status %v", ab.Status)
-	}
+	require.True(t, ok, "expected *block.AgentBlock, got %T", entries[0])
+	assert.NotEmpty(t, ab.Summary)
+	assert.Contains(t, ab.Summary, "Findings")
+	require.Len(t, ab.Children, 1)
+	require.Equal(t, "read", ab.Children[0].Name)
+	require.Equal(t, status.ToolDone, ab.Status)
 	surf := ab.Draw(components.DrawContext{Max: components.Size{Width: 80, Height: 40}})
 	txt := components.SurfaceText(surf)
-	if strings.Contains(txt, `"job_id"`) {
-		t.Fatalf("raw json leaked: %q", txt)
-	}
+	assert.NotContains(t, txt, `"job_id"`, "raw json leaked")
 }
 
 func TestMapperAgentWaitSummaryOnly(t *testing.T) {
@@ -125,12 +116,8 @@ func TestMapperAgentWaitSummaryOnly(t *testing.T) {
 
 	entries, _, _ := m.Sync(nil, nil, snap)
 	ab, ok := entries[0].(*block.AgentBlock)
-	if !ok {
-		t.Fatalf("got %T", entries[0])
-	}
-	if len(ab.Children) != 0 {
-		t.Fatalf("wait must not show spawn children: %+v", ab.Children)
-	}
+	require.True(t, ok, "expected *block.AgentBlock, got %T", entries[0])
+	require.Empty(t, ab.Children, "wait must not show spawn children")
 
 	// Done wait: markdown summary only.
 	snap.Tools["call_wait"] = session.ToolRun{
@@ -145,20 +132,10 @@ func TestMapperAgentWaitSummaryOnly(t *testing.T) {
 }`,
 	}
 	entries, _, dirty := m.Sync(entries, []string{"call_wait"}, snap)
-	if len(dirty) != 1 || dirty[0] != 0 {
-		t.Fatalf("dirty=%v want [0] after summary change", dirty)
-	}
+	require.Equal(t, []int{0}, dirty, "dirty after summary change")
 	ab, ok = entries[0].(*block.AgentBlock)
-	if !ok {
-		t.Fatalf("got %T", entries[0])
-	}
-	if len(ab.Children) != 0 {
-		t.Fatalf("wait children still set: %+v", ab.Children)
-	}
-	if !strings.Contains(ab.Summary, "Done") {
-		t.Fatalf("summary %q", ab.Summary)
-	}
-	if !ab.Expanded {
-		t.Fatal("expected expand when summary present")
-	}
+	require.True(t, ok, "expected *block.AgentBlock, got %T", entries[0])
+	require.Empty(t, ab.Children, "wait children still set")
+	assert.Contains(t, ab.Summary, "Done")
+	require.True(t, ab.Expanded, "expected expand when summary present")
 }

--- a/internal/tui/transcript/mapper_sync_test.go
+++ b/internal/tui/transcript/mapper_sync_test.go
@@ -34,26 +34,19 @@ func TestMapperSyncDirtyOnlyChangedRows(t *testing.T) {
 		},
 	}
 	entries, ids, dirty := m.Sync(nil, nil, snap)
-	if len(dirty) != 2 {
-		t.Fatalf("initial dirty=%v", dirty)
-	}
+	require.Len(t, dirty, 2, "initial dirty")
 
 	// Stream more assistant text — only assistant row should be dirty.
 	snap.Messages[1].Content[0].Text = "hi there"
 	entries, ids, dirty = m.Sync(entries, ids, snap)
-	if len(dirty) != 1 || dirty[0] != 1 {
-		t.Fatalf("stream dirty=%v want [1]", dirty)
-	}
+	require.Equal(t, []int{1}, dirty, "stream dirty")
 	ab, ok := entries[1].(*block.AssistantBlock)
-	if !ok || ab.Text != "hi there" {
-		t.Fatalf("assistant %+v", entries[1])
-	}
+	require.True(t, ok)
+	require.Equal(t, "hi there", ab.Text)
 
 	// No-op sync — nothing dirty.
 	entries, ids, dirty = m.Sync(entries, ids, snap)
-	if len(dirty) != 0 {
-		t.Fatalf("noop dirty=%v", dirty)
-	}
+	require.Empty(t, dirty, "noop dirty")
 
 	// Append a new user message — only the new index dirty.
 	snap.Messages = append(snap.Messages, session.Message{
@@ -63,9 +56,7 @@ func TestMapperSyncDirtyOnlyChangedRows(t *testing.T) {
 		Text:  "more",
 	})
 	_, _, dirty = m.Sync(entries, ids, snap)
-	if len(dirty) != 1 || dirty[0] != 2 {
-		t.Fatalf("append dirty=%v want [2]", dirty)
-	}
+	require.Equal(t, []int{2}, dirty, "append dirty")
 }
 
 func TestApplyProgressReportsChange(t *testing.T) {
@@ -79,16 +70,10 @@ func TestApplyProgressReportsChange(t *testing.T) {
 		Status:          "in-progress",
 		Detail:          "a.go",
 	}
-	if !s.ApplyProgress(p) {
-		t.Fatal("first apply should change")
-	}
-	if s.ApplyProgress(p) {
-		t.Fatal("identical apply should not change")
-	}
+	require.True(t, s.ApplyProgress(p), "first apply should change")
+	require.False(t, s.ApplyProgress(p), "identical apply should not change")
 	p.Status = "done"
-	if !s.ApplyProgress(p) {
-		t.Fatal("status change should dirty")
-	}
+	require.True(t, s.ApplyProgress(p), "status change should dirty")
 }
 
 func TestMapperToolExpandedFromRun(t *testing.T) {

--- a/internal/tui/transcript/pane_test.go
+++ b/internal/tui/transcript/pane_test.go
@@ -3,6 +3,8 @@ package transcript
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components"
 	"github.com/pulseaiclub/phi/internal/components/status"
 	"github.com/pulseaiclub/phi/internal/session"
@@ -16,12 +18,8 @@ func TestTranscriptPane_ApplySessionAndSync(t *testing.T) {
 	pane.ApplySession(session.UserAppend{Text: "hello"})
 	pane.Sync()
 
-	if pane.IsEmpty() {
-		t.Fatal("expected transcript entries after user append")
-	}
-	if len(pane.Snapshot().Messages) != 1 {
-		t.Fatalf("snap messages = %d, want 1", len(pane.Snapshot().Messages))
-	}
+	require.False(t, pane.IsEmpty(), "expected transcript entries after user append")
+	require.Len(t, pane.Snapshot().Messages, 1)
 }
 
 func TestTranscriptPane_IsStreaming(t *testing.T) {
@@ -29,25 +27,19 @@ func TestTranscriptPane_IsStreaming(t *testing.T) {
 	spin := status.NewSpinner(th.ToolName)
 	pane := NewTranscriptPane(th, spin, "Phi test")
 
-	if pane.IsStreaming() {
-		t.Fatal("empty pane should not stream")
-	}
+	require.False(t, pane.IsStreaming(), "empty pane should not stream")
 
 	pane.ApplySession(session.AssistantMessageUpdate{Message: session.Message{
 		ID:    "a1",
 		State: session.StateStreaming,
 	}})
-	if !pane.IsStreaming() {
-		t.Fatal("expected streaming after assistant StateStreaming")
-	}
+	require.True(t, pane.IsStreaming(), "expected streaming after assistant StateStreaming")
 
 	pane.ApplySession(session.AssistantMessageUpdate{Message: session.Message{
 		ID:    "a1",
 		State: session.StateComplete,
 	}})
-	if pane.IsStreaming() {
-		t.Fatal("expected idle after StreamEnd")
-	}
+	require.False(t, pane.IsStreaming(), "expected idle after StreamEnd")
 }
 
 func TestTranscriptPane_LoadReplayClearsWidgets(t *testing.T) {
@@ -57,13 +49,9 @@ func TestTranscriptPane_LoadReplayClearsWidgets(t *testing.T) {
 
 	pane.ApplySession(session.UserAppend{Text: "x"})
 	pane.Sync()
-	if pane.IsEmpty() {
-		t.Fatal("setup: expected entries")
-	}
+	require.False(t, pane.IsEmpty(), "setup: expected entries")
 
 	pane.LoadReplay(session.Snapshot{})
 	pane.Sync()
-	if !pane.IsEmpty() {
-		t.Fatal("LoadReplay should clear visible entries until snap has items")
-	}
+	require.True(t, pane.IsEmpty(), "LoadReplay should clear visible entries until snap has items")
 }

--- a/internal/tui/transcript/subagent_store_test.go
+++ b/internal/tui/transcript/subagent_store_test.go
@@ -3,6 +3,8 @@ package transcript_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/components/status"
 	"github.com/pulseaiclub/phi/internal/job"
 	"github.com/pulseaiclub/phi/internal/tools"
@@ -38,22 +40,15 @@ func TestSubagentStoreProgressAndResult(t *testing.T) {
 	})
 
 	kids := s.Children("parent1")
-	if len(kids) != 2 {
-		t.Fatalf("len=%d", len(kids))
-	}
-	if kids[0].Status != status.ToolDone || kids[0].Name != "read" {
-		t.Fatalf("%+v", kids[0])
-	}
+	require.Len(t, kids, 2)
+	require.Equal(t, status.ToolDone, kids[0].Status)
+	require.Equal(t, "read", kids[0].Name)
 	byJob := s.ChildrenByJob("job1")
-	if len(byJob) != 2 {
-		t.Fatalf("byJob len=%d", len(byJob))
-	}
+	require.Len(t, byJob, 2)
 
 	s.ApplyResult("parent1", tools.ParseAgentResult(`{
 		"job_id":"job1","status":"completed","summary":"## Ok"
 	}`))
 	// Summary is stored; Children unchanged.
-	if len(s.Children("parent1")) != 2 {
-		t.Fatal("children cleared")
-	}
+	require.Len(t, s.Children("parent1"), 2, "children should not be cleared")
 }

--- a/internal/util/githubrelease/release_test.go
+++ b/internal/util/githubrelease/release_test.go
@@ -3,6 +3,8 @@ package githubrelease
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTagVersion(t *testing.T) {
@@ -16,9 +18,7 @@ func TestTagVersion(t *testing.T) {
 		{tag: "1.2.3", want: "1.2.3"},
 	}
 	for _, tt := range tests {
-		if got := TagVersion(tt.tag); got != tt.want {
-			t.Fatalf("TagVersion(%q) = %q, want %q", tt.tag, got, tt.want)
-		}
+		require.Equal(t, tt.want, TagVersion(tt.tag), "TagVersion(%q)", tt.tag)
 	}
 }
 
@@ -26,9 +26,7 @@ func TestDownloadBaseURL(t *testing.T) {
 	t.Parallel()
 	in := "https://github.com/pulseaiclub/phi/releases/tag/v0.1.0"
 	want := "https://github.com/pulseaiclub/phi/releases/download/v0.1.0"
-	if got := DownloadBaseURL(in); got != want {
-		t.Fatalf("DownloadBaseURL() = %q, want %q", got, want)
-	}
+	require.Equal(t, want, DownloadBaseURL(in))
 }
 
 func TestDecodeReleaseIncludesAssets(t *testing.T) {
@@ -43,22 +41,12 @@ func TestDecodeReleaseIncludesAssets(t *testing.T) {
 	}`
 
 	release, err := decodeRelease(strings.NewReader(response))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if release.TagName != "15.2.0" {
-		t.Fatalf("TagName = %q, want 15.2.0", release.TagName)
-	}
-	if len(release.Assets) != 1 {
-		t.Fatalf("len(Assets) = %d, want 1", len(release.Assets))
-	}
+	require.NoError(t, err)
+	require.Equal(t, "15.2.0", release.TagName, "TagName")
+	require.Len(t, release.Assets, 1, "len(Assets)")
 	asset := release.Assets[0]
-	if asset.Name != "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz" {
-		t.Fatalf("asset Name = %q", asset.Name)
-	}
-	if asset.BrowserDownloadURL == "" {
-		t.Fatal("asset BrowserDownloadURL is empty")
-	}
+	require.Equal(t, "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz", asset.Name, "asset Name")
+	require.NotEmpty(t, asset.BrowserDownloadURL, "asset BrowserDownloadURL is empty")
 }
 
 func TestStableReleasesFiltersDraftsAndPrereleases(t *testing.T) {
@@ -70,20 +58,17 @@ func TestStableReleasesFiltersDraftsAndPrereleases(t *testing.T) {
 	]`
 
 	releases, err := decodeReleases(strings.NewReader(response))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	stable := stableReleases(releases)
-	if len(stable) != 1 || stable[0].TagName != "v1.0.0" {
-		t.Fatalf("stableReleases() = %#v, want only v1.0.0", stable)
-	}
+	require.Len(t, stable, 1)
+	require.Equal(t, "v1.0.0", stable[0].TagName)
 }
 
 func TestFetchRecentRejectsInvalidLimit(t *testing.T) {
 	t.Parallel()
 	for _, limit := range []int{0, maxReleasesPerPage + 1} {
 		if _, err := FetchRecent(t.Context(), "owner/repo", limit); err == nil {
-			t.Fatalf("FetchRecent(limit=%d) unexpectedly succeeded", limit)
+			require.Failf(t, "unexpected success", "FetchRecent(limit=%d) unexpectedly succeeded", limit)
 		}
 	}
 }

--- a/internal/util/retry_test.go
+++ b/internal/util/retry_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"errors"
 	"io"
 	"math"
 	"net/http"
@@ -11,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseRetryAfter(t *testing.T) {
@@ -40,9 +41,8 @@ func TestParseRetryAfter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, valid := parseRetryAfter(tt.value, now)
-			if got != tt.want || valid != tt.valid {
-				t.Fatalf("parseRetryAfter(%q) = (%s, %t), want (%s, %t)", tt.value, got, valid, tt.want, tt.valid)
-			}
+			require.Equal(t, tt.want, got, "parseRetryAfter(%q) duration", tt.value)
+			require.Equal(t, tt.valid, valid, "parseRetryAfter(%q) valid", tt.value)
 		})
 	}
 }
@@ -66,9 +66,14 @@ func TestRetryDelayFallbackAndHeaderPrecedence(t *testing.T) {
 			if tt.header != "" {
 				resp = &http.Response{Header: http.Header{"Retry-After": []string{tt.header}}}
 			}
-			if got := retryDelay(resp, tt.attempt); got != tt.wantDelay {
-				t.Fatalf("retryDelay(attempt=%d, header=%q) = %s, want %s", tt.attempt, tt.header, got, tt.wantDelay)
-			}
+			require.Equal(
+				t,
+				tt.wantDelay,
+				retryDelay(resp, tt.attempt),
+				"retryDelay(attempt=%d, header=%q)",
+				tt.attempt,
+				tt.header,
+			)
 		})
 	}
 }
@@ -173,35 +178,30 @@ func TestDoWithRetryRetryAfterBehavior(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), tt.timeout)
 			defer cancel()
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, http.NoBody)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			resp, err := DoWithRetry(server.Client(), req)
 			if tt.wantErr {
-				if err == nil || !errors.Is(err, context.DeadlineExceeded) {
-					t.Fatalf("DoWithRetry error = %v, want context deadline exceeded", err)
-				}
+				require.Error(t, err, "DoWithRetry should return error")
+				require.ErrorIs(
+					t,
+					err,
+					context.DeadlineExceeded,
+					"DoWithRetry error = %v, want context deadline exceeded",
+					err,
+				)
 				if resp != nil {
 					resp.Body.Close()
-					t.Fatal("DoWithRetry returned a response with an error")
+					require.Fail(t, "DoWithRetry returned a response with an error")
 				}
 			} else {
-				if err != nil {
-					t.Fatalf("DoWithRetry returned error: %v", err)
-				}
-				if resp == nil {
-					t.Fatal("DoWithRetry returned nil response")
-				}
-				if resp.StatusCode != tt.wantStatus {
-					t.Fatalf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
-				}
+				require.NoError(t, err, "DoWithRetry returned error")
+				require.NotNil(t, resp, "DoWithRetry returned nil response")
+				require.Equal(t, tt.wantStatus, resp.StatusCode, "status mismatch")
 				_ = resp.Body.Close()
 			}
 
-			if got := requests.Load(); got != tt.wantRequests {
-				t.Fatalf("requests = %d, want %d", got, tt.wantRequests)
-			}
+			require.Equal(t, tt.wantRequests, requests.Load(), "requests mismatch")
 		})
 	}
 }

--- a/internal/util/update/check_test.go
+++ b/internal/util/update/check_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/util/update"
 )
 
@@ -22,23 +24,18 @@ func TestCheckUsesCacheWhenAvailable(t *testing.T) {
 		"latest":     "v0.2.0",
 		"url":        "https://example.com/releases/tag/v0.2.0",
 	})
-	if err := os.WriteFile(cache, payload, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(cache, payload, 0o600))
 
 	info := update.Check(t.Context(), update.CheckOptions{
 		Current:  "v0.1.0",
 		CacheDir: dir,
 	})
-	if !info.Available || info.Latest != "v0.2.0" {
-		t.Fatalf("expected cached update, got %+v", info)
-	}
+	require.True(t, info.Available, "expected cached update, got %+v", info)
+	require.Equal(t, "v0.2.0", info.Latest)
 }
 
 func TestSkipCheckEnv(t *testing.T) {
 	t.Setenv("PHI_SKIP_VERSION_CHECK", "1")
 	info := update.Check(t.Context(), update.CheckOptions{Current: "v0.1.0"})
-	if info.Available {
-		t.Fatalf("expected skip, got %+v", info)
-	}
+	require.False(t, info.Available, "expected skip, got %+v", info)
 }

--- a/internal/util/update/version_test.go
+++ b/internal/util/update/version_test.go
@@ -3,6 +3,8 @@ package update_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pulseaiclub/phi/internal/util/update"
 )
 
@@ -19,16 +21,14 @@ func TestVersionLess(t *testing.T) {
 	}
 	for _, tc := range cases {
 		if got := update.VersionLess(tc.a, tc.b); got != tc.want {
-			t.Fatalf("VersionLess(%q, %q)=%v want %v", tc.a, tc.b, got, tc.want)
+			require.Equal(t, tc.want, got, "VersionLess(%q, %q)", tc.a, tc.b)
 		}
 	}
 }
 
 func TestIsDevBuild(t *testing.T) {
-	if !update.IsDevBuild("dev") || !update.IsDevBuild("") || !update.IsDevBuild("v0.0.0") {
-		t.Fatal("expected dev builds")
-	}
-	if update.IsDevBuild("v0.1.0") {
-		t.Fatal("v0.1.0 should not be dev")
-	}
+	require.True(t, update.IsDevBuild("dev"), "expected dev build: dev")
+	require.True(t, update.IsDevBuild(""), "expected dev build: empty")
+	require.True(t, update.IsDevBuild("v0.0.0"), "expected dev build: v0.0.0")
+	require.False(t, update.IsDevBuild("v0.1.0"), "v0.1.0 should not be dev")
 }


### PR DESCRIPTION
Convert ~555 t.Fatalf/t.Fatal/t.Errorf calls across 63 test files to testify assert/require. Preserve fail-fast semantics: require.* for Fatal, assert.* for Errorf. Remove unused helper functions and clean up stale imports left behind by the conversion.