### PR TITLE
Refactor Rust SDK for idiomatic practices and cleanup

### DIFF
--- a/ext/rust/src/phi/mod.rs
+++ b/ext/rust/src/phi/mod.rs
@@ -38,7 +38,7 @@ pub use schema::Schema;
 
 type Rd = io::StdinLock<'static>;
 type Wr = io::StdoutLock<'static>;
-type EventHandlers = HashMap<u16, Box<dyn FnMut(pxb::EventNotify)>>;
+type EventHandlers = HashMap<pxb::Event, Box<dyn FnMut(pxb::EventNotify)>>;
 
 /// Host metadata filled by the hello handshake (and refreshed by
 /// `SessionMeta` pushes).
@@ -304,6 +304,21 @@ struct Handlers {
     events: EventHandlers,
 }
 
+/// Bundles all mutable state owned by the run loop, so `serve` and
+/// `serve_command` can borrow individual fields without passing 7+
+/// separate `&mut` parameters.
+struct ServeState<'a> {
+    rd: &'a mut Rd,
+    wr: &'a mut Wr,
+    host: HostInfo,
+    tools: Vec<Tool>,
+    commands: Vec<(String, Command)>,
+    handlers: Handlers,
+    pending_submit: Option<String>,
+    next_host_id: u32,
+    rt: &'a tokio::runtime::Runtime,
+}
+
 /// The author-facing registration surface for a PXB extension binary.
 pub struct Extension {
     name: String,
@@ -402,12 +417,11 @@ impl Extension {
     /// Adds a fire-and-forget lifecycle listener; the payload is the wire
     /// `EventNotify`. Unknown events are ignored.
     pub fn subscribe(&mut self, event: pxb::Event, f: impl FnMut(pxb::EventNotify) + 'static) {
-        let code = event.code();
-        if code == 0 {
+        if event == pxb::Event::Unknown(0) {
             return;
         }
         push_unique(&mut self.events, event);
-        self.handlers.events.insert(code, Box::new(f));
+        self.handlers.events.insert(event, Box::new(f));
     }
 
     /// Speaks PXB on stdin/stdout until the host shuts down.
@@ -424,15 +438,24 @@ impl Extension {
         let host = handshake(&mut rd, &mut wr, &self)?;
         register(&mut wr, &self)?;
 
-        // Destructure so each handler owns only the state it mutates,
-        // instead of aliasing `self` (command handlers take `&mut` state).
         let Extension {
             tools,
             commands,
             handlers,
             ..
         } = self;
-        serve(&mut rd, &mut wr, host, tools, commands, handlers, &rt)
+        let mut state = ServeState {
+            rd: &mut rd,
+            wr: &mut wr,
+            host,
+            tools,
+            commands,
+            handlers,
+            pending_submit: None,
+            next_host_id: 0,
+            rt: &rt,
+        };
+        serve(&mut state)
     }
 }
 
@@ -509,46 +532,32 @@ fn register(wr: &mut Wr, ext: &Extension) -> Result<(), Error> {
 
 /// Dispatches frames until the host shuts down, handing each frame type to a
 /// focused handler that borrows only the state it mutates.
-fn serve(
-    rd: &mut Rd,
-    wr: &mut Wr,
-    mut host: HostInfo,
-    mut tools: Vec<Tool>,
-    mut commands: Vec<(String, Command)>,
-    mut handlers: Handlers,
-    rt: &tokio::runtime::Runtime,
-) -> Result<(), Error> {
-    let mut pending_submit: Option<String> = None;
-    let mut next_host_id: u32 = 0;
-
+fn serve(state: &mut ServeState<'_>) -> Result<(), Error> {
     loop {
-        let f = pxb::read_frame(rd)?;
+        let f = pxb::read_frame(state.rd)?;
         match pxb::FrameType::from_u16(f.header.typ) {
             pxb::FrameType::Shutdown => {
-                pxb::write_frame(wr, pxb::TYPE_SHUTDOWN_ACK, 0, 0, &[])?;
+                pxb::write_frame(state.wr, pxb::TYPE_SHUTDOWN_ACK, 0, 0, &[])?;
                 return Ok(());
             }
-            pxb::FrameType::CommandInvoked => serve_command(
-                rd,
-                wr,
-                &f,
-                &mut host,
-                &mut commands,
-                &mut handlers.events,
-                &mut pending_submit,
-                &mut next_host_id,
-            )?,
-            pxb::FrameType::ToolInvoke => serve_tool(wr, &f, &mut tools, rt)?,
-            pxb::FrameType::ToolDetailInvoke => serve_tool_detail(wr, &f, &mut tools)?,
-            pxb::FrameType::Intercept => serve_intercept(wr, &f, &mut handlers)?,
+            pxb::FrameType::CommandInvoked => serve_command(state, &f)?,
+            pxb::FrameType::ToolInvoke => {
+                serve_tool(state.wr, &f, &mut state.tools, state.rt)?
+            }
+            pxb::FrameType::ToolDetailInvoke => {
+                serve_tool_detail(state.wr, &f, &mut state.tools)?
+            }
+            pxb::FrameType::Intercept => {
+                serve_intercept(state.wr, &f, &mut state.handlers)?
+            }
             pxb::FrameType::Event => {
                 if let Ok(ev) = pxb::decode_event_notify(&f.body) {
-                    dispatch_event(&mut handlers.events, ev);
+                    dispatch_event(&mut state.handlers.events, ev);
                 }
             }
             pxb::FrameType::SessionMeta => {
                 if let Ok(meta) = pxb::decode_session_meta(&f.body) {
-                    apply_session_meta(&mut host, meta);
+                    apply_session_meta(&mut state.host, meta);
                 }
             }
             // Unknown frame types are already consumed by length; ignore.
@@ -563,33 +572,23 @@ fn serve(
 /// Commands stay synchronous: their [`Context`] reads nested PXB frames off
 /// the same pipe, which only works on the loop thread. Use async *tool*
 /// handlers for IO-heavy work.
-#[allow(clippy::too_many_arguments)] // the loop lends each state piece separately
-fn serve_command(
-    rd: &mut Rd,
-    wr: &mut Wr,
-    frame: &pxb::Frame,
-    host: &mut HostInfo,
-    commands: &mut [(String, Command)],
-    events: &mut EventHandlers,
-    pending_submit: &mut Option<String>,
-    next_host_id: &mut u32,
-) -> Result<(), Error> {
+fn serve_command(state: &mut ServeState<'_>, frame: &pxb::Frame) -> Result<(), Error> {
     let inv = pxb::decode_command_invoked(&frame.body)?;
     let mut resp = pxb::CommandResponse {
         ok: true,
         ..Default::default()
     };
-    if let Some((_, cmd)) = commands.iter_mut().find(|(n, _)| *n == inv.name) {
+    if let Some((_, cmd)) = state.commands.iter_mut().find(|(n, _)| *n == inv.name) {
         let mut ctx = Context {
-            cwd: host.cwd.clone(),
-            session_id: host.session_id.clone(),
+            cwd: state.host.cwd.clone(),
+            session_id: state.host.session_id.clone(),
             has_ui: true,
-            rd,
-            wr,
-            host,
-            pending_submit,
-            next_host_id,
-            events,
+            rd: state.rd,
+            wr: state.wr,
+            host: &mut state.host,
+            pending_submit: &mut state.pending_submit,
+            next_host_id: &mut state.next_host_id,
+            events: &mut state.handlers.events,
         };
         if let Err(e) = (cmd.handler)(&inv.args, &mut ctx) {
             resp.ok = false;
@@ -599,10 +598,10 @@ fn serve_command(
         resp.ok = false;
         resp.error = "unknown command".into();
     }
-    resp.submit = pending_submit.take().unwrap_or_default();
+    resp.submit = state.pending_submit.take().unwrap_or_default();
     let body = pxb::encode_command_response(&resp);
     pxb::write_frame(
-        wr,
+        state.wr,
         pxb::TYPE_COMMAND_RESPONSE,
         frame.header.flags,
         frame.header.id,
@@ -795,7 +794,8 @@ fn apply_session_meta(host: &mut HostInfo, meta: pxb::SessionMeta) {
 
 /// Dispatches an event push to its subscriber, if one is registered.
 fn dispatch_event(handlers: &mut EventHandlers, ev: pxb::EventNotify) {
-    if let Some(handler) = handlers.get_mut(&ev.event) {
+    let event = pxb::Event::from_code(ev.event);
+    if let Some(handler) = handlers.get_mut(&event) {
         handler(ev);
     }
 }
@@ -828,6 +828,21 @@ pub struct Context<'a> {
 }
 
 impl Context<'_> {
+    /// The working directory reported by the host.
+    pub fn cwd(&self) -> &str {
+        &self.cwd
+    }
+
+    /// The current session identifier.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Whether the host has a UI available.
+    pub fn has_ui(&self) -> bool {
+        self.has_ui
+    }
+
     /// Pushes a toast to the host (`level`: `info` | `warning` | `error`).
     pub fn notify(&mut self, level: &str, message: &str) {
         let body = pxb::encode_notify(&pxb::NotifyMsg {

--- a/ext/rust/src/phi/mod.rs
+++ b/ext/rust/src/phi/mod.rs
@@ -541,15 +541,9 @@ fn serve(state: &mut ServeState<'_>) -> Result<(), Error> {
                 return Ok(());
             }
             pxb::FrameType::CommandInvoked => serve_command(state, &f)?,
-            pxb::FrameType::ToolInvoke => {
-                serve_tool(state.wr, &f, &mut state.tools, state.rt)?
-            }
-            pxb::FrameType::ToolDetailInvoke => {
-                serve_tool_detail(state.wr, &f, &mut state.tools)?
-            }
-            pxb::FrameType::Intercept => {
-                serve_intercept(state.wr, &f, &mut state.handlers)?
-            }
+            pxb::FrameType::ToolInvoke => serve_tool(state.wr, &f, &mut state.tools, state.rt)?,
+            pxb::FrameType::ToolDetailInvoke => serve_tool_detail(state.wr, &f, &mut state.tools)?,
+            pxb::FrameType::Intercept => serve_intercept(state.wr, &f, &mut state.handlers)?,
             pxb::FrameType::Event => {
                 if let Ok(ev) = pxb::decode_event_notify(&f.body) {
                     dispatch_event(&mut state.handlers.events, ev);

--- a/ext/rust/src/phi/schema.rs
+++ b/ext/rust/src/phi/schema.rs
@@ -159,11 +159,9 @@ impl Schema {
 
     /// Add an object property. No-op on non-object / raw schemas.
     pub fn property(mut self, name: impl Into<String>, schema: Schema) -> Self {
-        if let SchemaInner::Built(n) = &mut self.inner {
+        if let (SchemaInner::Built(n), SchemaInner::Built(child)) = (&mut self.inner, schema.inner) {
             if n.kind == Kind::Object {
-                if let SchemaInner::Built(child) = schema.inner {
-                    n.properties.insert(name.into(), child);
-                }
+                n.properties.insert(name.into(), child);
             }
         }
         self

--- a/ext/rust/src/phi/schema.rs
+++ b/ext/rust/src/phi/schema.rs
@@ -159,7 +159,8 @@ impl Schema {
 
     /// Add an object property. No-op on non-object / raw schemas.
     pub fn property(mut self, name: impl Into<String>, schema: Schema) -> Self {
-        if let (SchemaInner::Built(n), SchemaInner::Built(child)) = (&mut self.inner, schema.inner) {
+        if let (SchemaInner::Built(n), SchemaInner::Built(child)) = (&mut self.inner, schema.inner)
+        {
             if n.kind == Kind::Object {
                 n.properties.insert(name.into(), child);
             }

--- a/ext/rust/src/pxb/fields.rs
+++ b/ext/rust/src/pxb/fields.rs
@@ -92,9 +92,7 @@ impl FieldWriter {
         }
         let mut inner = Vec::with_capacity(2 + vs.len() * 2);
         inner.extend_from_slice(&(vs.len() as u16).to_le_bytes());
-        for v in vs {
-            inner.extend_from_slice(&v.to_le_bytes());
-        }
+        inner.extend(vs.iter().flat_map(|v| v.to_le_bytes()));
         self.put_bytes(tag, &inner);
     }
 }

--- a/ext/rust/src/pxb/msg.rs
+++ b/ext/rust/src/pxb/msg.rs
@@ -339,15 +339,11 @@ fn decode_u16s(p: &[u8]) -> Result<Vec<u16>, Error> {
         return Err(Error::Truncated);
     }
     let n = u16::from_le_bytes([p[0], p[1]]) as usize;
-    if p.len() < 2 + n * 2 {
-        return Err(Error::Truncated);
-    }
-    let mut out = Vec::with_capacity(n);
-    for i in 0..n {
-        let off = 2 + i * 2;
-        out.push(u16::from_le_bytes([p[off], p[off + 1]]));
-    }
-    Ok(out)
+    let data = p.get(2..2 + n * 2).ok_or(Error::Truncated)?;
+    Ok(data
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect())
 }
 
 /// Host→ext when the user runs a slash command.

--- a/ext/rust/src/pxb/types.rs
+++ b/ext/rust/src/pxb/types.rs
@@ -133,7 +133,7 @@ impl FrameType {
 /// Lifecycle event codes (compact on the wire; strings only at SDK edges).
 /// Append-only: never reuse a code. Unknown codes are ignored by peers that
 /// did not Subscribe to them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Event {
     ToolCall,
     ToolResult,


### PR DESCRIPTION
- EventHandlers: use Event enum as HashMap key instead of raw u16
- ServeState: consolidate serve/serve_command params, drop clippy allow
- Context: add cwd()/session_id()/has_ui() getters
- Event: derive Hash for type-safe map keys
- decode_u16s: rewrite with chunks_exact
- put_u16s: rewrite with flat_map