### PR TITLE
remove `/resume` slash command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+- `/resume` slash command — use `/sessions` picker or `phi run --session <id>` instead.
+
 ### Fixed
 
 ### Security

--- a/internal/tui/commands/builtins.go
+++ b/internal/tui/commands/builtins.go
@@ -31,22 +31,6 @@ func registerBuiltinCommands(r *CommandRegistry) {
 		},
 	})
 	r.Register(Command{
-		Name:        "resume",
-		Description: "Resume a session in this directory — /resume <id>",
-		Slash:       true,
-		NeedsArgs:   true,
-		Insert:      "/resume ",
-		Run: func(ctx CommandContext) error {
-			if len(ctx.Args) < 1 {
-				return nil
-			}
-			if ctx.ResumeSession != nil {
-				ctx.ResumeSession(ctx.Args[0])
-			}
-			return nil
-		},
-	})
-	r.Register(Command{
 		Name:        "clear",
 		Description: "Start a new empty session",
 		Slash:       true,

--- a/internal/tui/commands/commands_test.go
+++ b/internal/tui/commands/commands_test.go
@@ -158,12 +158,7 @@ func TestSkillsCommand_Empty(t *testing.T) {
 func TestFilterSlashCommands(t *testing.T) {
 	r := NewBuiltinRegistry()
 	all := r.FilterSlash("")
-	require.Len(t, all, 4)
-
-	resu := r.FilterSlash("resu")
-	require.Len(t, resu, 1)
-	assert.Equal(t, "resume", resu[0].Path)
-	assert.Contains(t, resu[0].Description, "Resume")
+	require.Len(t, all, 3)
 
 	clr := r.FilterSlash("cle")
 	require.Len(t, clr, 1)
@@ -172,7 +167,6 @@ func TestFilterSlashCommands(t *testing.T) {
 	none := r.FilterSlash("zzz")
 	assert.Empty(t, none)
 
-	assert.Equal(t, "/resume ", r.LookupInsert("resume"))
 	assert.Equal(t, "/sessions", r.LookupInsert("sessions"))
 	assert.Equal(t, "/clear", r.LookupInsert("clear"))
 	assert.Equal(t, "/diff ", r.LookupInsert("diff"))
@@ -181,26 +175,16 @@ func TestFilterSlashCommands(t *testing.T) {
 func TestCommandRegistry_DispatchSlash(t *testing.T) {
 	r := NewBuiltinRegistry()
 	var sessions, cleared int
-	var resumeID string
 	bus := controller.NewBus(nil)
 
 	ctx := CommandContext{
-		ShowSessions:  func() { sessions++ },
-		ResumeSession: func(id string) { resumeID = id },
-		ClearSession:  func() { cleared++ },
-		Bus:           bus,
+		ShowSessions: func() { sessions++ },
+		ClearSession: func() { cleared++ },
+		Bus:          bus,
 	}
 
 	assert.True(t, r.DispatchSlash("/sessions", ctx))
 	assert.Equal(t, 1, sessions)
-
-	assert.True(t, r.DispatchSlash("/resume abc", ctx))
-	assert.Equal(t, "abc", resumeID)
-
-	insert, ok := r.IncompleteSlash("/resume")
-	assert.True(t, ok)
-	assert.Equal(t, "/resume ", insert)
-	assert.Empty(t, drainToast(t, bus))
 
 	assert.True(t, r.DispatchSlash("/clear", ctx))
 	assert.Equal(t, 1, cleared)

--- a/internal/tui/commands/registry.go
+++ b/internal/tui/commands/registry.go
@@ -21,9 +21,8 @@ type CommandContext struct {
 	Bus         *controller.Bus
 	PushSubmenu func(title string, cmds []palette.PaletteCommand)
 
-	ShowSessions  func()
-	ResumeSession func(id string)
-	ClearSession  func() // may toast internally if busy
+	ShowSessions func()
+	ClearSession func() // may toast internally if busy
 
 	SetModel         func(name string)
 	ApplyTheme       func(name string)

--- a/internal/tui/commands/session_cmds.go
+++ b/internal/tui/commands/session_cmds.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pulseaiclub/phi/internal/tui/transcript"
 )
 
-// SessionCommands owns /sessions, /resume, and /clear UI side effects.
+// SessionCommands owns /sessions and /clear UI side effects.
 type SessionCommands struct {
 	Ctrl       *controller.EngineController
 	Transcript *transcript.TranscriptPane
@@ -95,11 +95,11 @@ func (s *SessionCommands) Accept(id string) {
 		s.showToast("Cannot resume while a reply or command is running", toast.ToastWarning, 3*time.Second)
 		return
 	}
-	s.Resume(id)
+	s.resume(id)
 }
 
-// Resume loads a prior session by id into the UI.
-func (s *SessionCommands) Resume(id string) {
+// resume loads a prior session by id into the UI.
+func (s *SessionCommands) resume(id string) {
 	if s == nil {
 		return
 	}

--- a/internal/tui/editor/bridge.go
+++ b/internal/tui/editor/bridge.go
@@ -58,8 +58,7 @@ func (b *commandBridge) context() commands.CommandContext {
 		PushSubmenu: func(title string, cmds []palette.PaletteCommand) {
 			b.composer.PushPalette(title, cmds)
 		},
-		ShowSessions:  b.sessions.Show,
-		ResumeSession: b.sessions.Resume,
+		ShowSessions: b.sessions.Show,
 		ClearSession: func() {
 			if b.submitter != nil && b.submitter.StreamActive() {
 				b.toast("Cannot clear while a reply or command is running", toast.ToastWarning, 3*time.Second)

--- a/internal/tui/submit/submitter_test.go
+++ b/internal/tui/submit/submitter_test.go
@@ -99,9 +99,16 @@ func TestSubmitter_Submit_needsArgsRefillsComposer(t *testing.T) {
 	spin := status.NewSpinner(th.ToolName)
 	tp := transcript.NewTranscriptPane(th, spin, "Phi test")
 	comp := &stubComposer{}
-	sub := newTestSubmitter(t, tp, nil, comp, commands.NewBuiltinRegistry())
-	sub.Submit("/resume")
-	assert.Equal(t, "/resume ", comp.input)
+	reg := commands.NewCommandRegistry()
+	reg.Register(commands.Command{
+		Name:      "plan",
+		Slash:     true,
+		NeedsArgs: true,
+		Run:       func(commands.CommandContext) error { return nil },
+	})
+	sub := newTestSubmitter(t, tp, nil, comp, reg)
+	sub.Submit("/plan")
+	assert.Equal(t, "/plan ", comp.input)
 	assert.Empty(t, tp.Snapshot().Messages)
 }
 


### PR DESCRIPTION
sessions picker (`/sessions`) and CLI flags (`--session` / `--continue-last`) already cover all resume scenarios. the direct-id command was redundant and lacked the stream-active guard that Accept() has.